### PR TITLE
Allow loading babel-standalone from CircleCI to enable easy testing of PRs

### DIFF
--- a/7.html
+++ b/7.html
@@ -6,7 +6,6 @@ custom_js_with_timestamps:
 - pretty-format.js
 - 7.js
 third_party_js:
-- https://unpkg.com/babel-standalone@7.0.0-alpha.15/babel.js
 - https://unpkg.com/babel-polyfill@7.0.0-alpha.15/dist/polyfill.min.js
 - https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js
 - https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/base64-string.min.js
@@ -38,7 +37,7 @@ third_party_js:
 
     <div class="pull-right">
       <div class="form-group">
-        <strong>Babel <span id="babel-repl-version"></span></strong>
+        <strong>Babel <span id="babel-repl-version">is loading...</span></strong>
       </div>
     </div>
   </form>

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,9 @@ exclude:
   - Rakefile
   - package.json
 
+include:
+  - _redirects
+
 # Build settings
 highlighter: rouge
 markdown: kramdown

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,8 @@
+---
+layout: null
+---
+
+# REPL builds, to preview pull requests
+/repl/build/:build /7/ 200
+# Previous versions of the REPL
+/repl/version/:version /7/ 200

--- a/scripts/7.js
+++ b/scripts/7.js
@@ -1,4 +1,4 @@
-(function(babel, $, _, ace, LZString, window) {
+(function($, _, ace, LZString, window) {
   'use strict';
   var UPDATE_DELAY = 500;
 
@@ -12,6 +12,9 @@
     'stage-2',
     'stage-3'
   ];
+
+  // TODO HAX: Change "Daniel15" to "babel" once https://github.com/babel/babel/pull/6029 lands
+  var buildArtifactURL = 'https://circleci.com/api/v1.1/project/github/Daniel15/babel/{build}/artifacts';
 
   /* Throw meaningful errors for getters of commonjs. */
   var enableCommonJSError = true;
@@ -293,6 +296,7 @@
     var state = this.storage.get('b7ReplState') || {};
     _.assign(state, UriUtils.parseQuery());
     this.options = _.assign(new Options(), state);
+    loadBabel(this.options);
 
     this.input = new Editor('.babel-repl-input .ace_editor').editor;
     this.input.setValue(UriUtils.decode(state.code || ''));
@@ -307,8 +311,6 @@
     this.$consoleReporter = $('.babel-repl-console-output');
     this.$toolBar = $('.babel-repl-toolbar');
     this.$textareaWrapper = $('.dropdown-menu-container');
-
-    document.getElementById('babel-repl-version').innerHTML = babel.version;
   }
 
   REPL.prototype.clearOutput = function () {
@@ -337,10 +339,16 @@
     var code = this.getSource();
     this.clearOutput();
 
+    if (!hasBabelLoaded()) {
+      this.setOutput('// Babel is loading, please wait...');
+      return;
+    }
+
     var presets = options.presets.split(',');
 
     try {
-      transformed = babel.transform(code, {
+      document.getElementById('babel-repl-version').innerHTML = Babel.version;
+      transformed = Babel.transform(code, {
         presets: presets.filter(Boolean),
         filename: 'repl',
         babelrc: false,
@@ -495,7 +503,76 @@
     };
   }
 
+  var loadingScripts = {};
+  /**
+   * Checks if a script (such as Babel-standalone or Babili-standalone) has been
+   * loaded. If not, kicks off a load (if it hasn't already started) and returns
+   * false. Returns true if the script is ready to use.
+   */
+  function lazyLoadScript(name, checkFn, url) {
+    if (checkFn()) {
+      return true;
+    }
+    if (loadingScripts[name]) {
+      return false;
+    }
+
+    if (url) {
+      // Babili-standalone is exported as a UMD script, and thus hits the CommonJS
+      // error ("is not supported in the browser..."), temporarily disable it
+      // while loading.
+      enableCommonJSError = false;
+
+      var script = document.createElement('script');
+      script.async = true;
+      script.src = url;
+      script.onload = function() {
+        enableCommonJSError = true;
+        onSourceChange();
+      };
+      document.head.appendChild(script);
+      loadingScripts[name] = true;
+    }
+    return false;
+  }
+
+  function hasBabelLoaded() {
+    return lazyLoadScript('Babel', () => !!window.Babel);
+  }
+
+  function loadBabel(options) {
+    function doLoad(url) {
+      lazyLoadScript('Babel', () => !!window.Babel, url);
+    }
+
+    if (options.circleci_build) {
+      // Loading a build from CircleCI (eg. for a pull request). We need to
+      // first call CircleCI's API to get the URL to the artifact.
+      var xhr = new XMLHttpRequest();
+      xhr.open('get', buildArtifactURL.replace('{build}', options.circleci_build), true);
+      xhr.onload = function() {
+        var response = JSON.parse(xhr.responseText);
+        if (response.message) {
+          alert('Could not load Babel build #' + options.circleci_build + ': ' + response.message);
+          return;
+        }
+        var artifacts = response.filter(x => /babel-standalone\/babel.js$/.test(x.path));
+        if (!artifacts) {
+          alert('Could not find valid babel-standalone artifact in build #' + options.circleci_build);
+          return;
+        }
+        doLoad(artifacts[0].url);
+      };
+      xhr.onerror = function() {
+        alert('Could not load Babel build #' + options.circleci_build + ' :(');
+      }
+      xhr.send();
+    } else {
+      doLoad('https://unpkg.com/babel-standalone@next/babel.js');
+    }
+  }
+
   initResizable('.babel-repl-resize');
   onPresetChange();
   onToolbarChange();
-}(Babel, $, _, ace, LZString, window));
+}($, _, ace, LZString, window));


### PR DESCRIPTION
This PR adds a new "circleci_build" parameter to the Babel v7 REPL page. When provided, this is treated as a CircleCI build number and `babel-standalone` is loaded from the CircleCI build artifacts rather than from unpkg. The idea is that we can have a bot that runs as a CircleCI webhook and automatically comments on all Babel PRs with a link to the REPL to allow easy testing of changes.

The new parameter is passed like this:
```
/repl/?circleci_build=123
```

The `lazyLoadScript` function added in this PR is a generalised version of the `hasBabiliLoaded` function in the current `repl.js`.

Depends on https://github.com/babel/babel/pull/6029 ("Move babel-standalone into main Babel repo"). We can't test this with real Babel PRs until the other PR lands. 

cc @hzoo 
