### PR TITLE
Scrollbar overlap console output

### DIFF
--- a/_sass/pages/_repl.scss
+++ b/_sass/pages/_repl.scss
@@ -86,7 +86,7 @@
 .babel-repl-reporter {
   position: absolute;
   z-index: 4;
-  bottom: 0;
+  bottom: -15px;
   min-height: 30px;
   max-height: 50%;
   overflow: auto;


### PR DESCRIPTION
When compiled code length does not fit into the screen it adds a scrollbar, which can overlap console output. Visit [Babel repl](https://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=env%2Ces2015%2Ces2015-loose%2Ces2016%2Ces2017%2Creact%2Cstage-0%2Cstage-1%2Cstage-2%2Cstage-3&targets=Node-1&browsers=&builtIns=false&debug=false&code_lz=JYWwDg9gTgLgBAURAIwKZTgMyhEcDkqK6-A3EA&experimental=true&playground=false&loose=true&spec=false) for more info.