### PR TITLE
REPL attaches source maps to eval()

### DIFF
--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -46,10 +46,10 @@ type State = {
   evalError: ?Error,
   isSidebarExpanded: boolean,
   lineWrap: boolean,
-  map: ?string,
   plugins: PluginStateMap,
   presets: PluginStateMap,
   runtimePolyfillState: PluginState,
+  sourceMap: ?string
 };
 
 export default class Repl extends React.Component {
@@ -98,13 +98,13 @@ export default class Repl extends React.Component {
       evalError: null,
       isSidebarExpanded: persistedState.showSidebar,
       lineWrap: persistedState.lineWrap,
-      map: null,
       plugins: configArrayToStateMap(pluginConfigs, defaultPlugins),
       presets: configArrayToStateMap(presetPluginConfigs, defaultPresets),
       runtimePolyfillState: configToState(
         runtimePolyfillConfig,
         persistedState.evaluate
       ),
+      sourceMap: null
     };
 
     this.state = {
@@ -122,15 +122,6 @@ export default class Repl extends React.Component {
     const options = {
       lineWrapping: state.lineWrap,
     };
-
-    let compiled = null;
-    if (state.code) {
-      compiled = state.compiled;
-      if (state.map) {
-        // $FlowFixMe
-        compiled += `\n\n// ${state.map}`;
-      }
-    }
 
     return (
       <div className={styles.repl}>
@@ -162,7 +153,7 @@ export default class Repl extends React.Component {
           />
           <CodeMirrorPanel
             className={styles.codeMirrorPanel}
-            code={compiled}
+            code={state.compiled}
             error={state.evalError}
             info={state.debugEnvPreset ? state.envPresetDebugInfo : null}
             options={options}
@@ -221,7 +212,7 @@ export default class Repl extends React.Component {
         // Just evaluate the most recently compiled code.
         try {
           // eslint-disable-next-line
-          scopedEval(this.state.compiled);
+          scopedEval(this.state.compiled, this.state.sourceMap);
         } catch (error) {
           evalError = error;
         }

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -46,6 +46,7 @@ type State = {
   evalError: ?Error,
   isSidebarExpanded: boolean,
   lineWrap: boolean,
+  map: ?string,
   plugins: PluginStateMap,
   presets: PluginStateMap,
   runtimePolyfillState: PluginState,
@@ -97,6 +98,7 @@ export default class Repl extends React.Component {
       evalError: null,
       isSidebarExpanded: persistedState.showSidebar,
       lineWrap: persistedState.lineWrap,
+      map: null,
       plugins: configArrayToStateMap(pluginConfigs, defaultPlugins),
       presets: configArrayToStateMap(presetPluginConfigs, defaultPresets),
       runtimePolyfillState: configToState(
@@ -120,6 +122,15 @@ export default class Repl extends React.Component {
     const options = {
       lineWrapping: state.lineWrap,
     };
+
+    let compiled = null;
+    if (state.code) {
+      compiled = state.compiled;
+      if (state.map) {
+        // $FlowFixMe
+        compiled += `\n\n// ${state.map}`;
+      }
+    }
 
     return (
       <div className={styles.repl}>
@@ -151,10 +162,11 @@ export default class Repl extends React.Component {
           />
           <CodeMirrorPanel
             className={styles.codeMirrorPanel}
-            code={state.compiled}
+            code={compiled}
             error={state.evalError}
             info={state.debugEnvPreset ? state.envPresetDebugInfo : null}
             options={options}
+            placeholder="Compiled output will be shown here"
           />
         </div>
       </div>

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -236,7 +236,7 @@ export default class Repl extends React.Component {
   }
 
   _compile = (code: string, state: State) => {
-    const { envConfig } = state;
+    const { envConfig, runtimePolyfillState } = state;
 
     const presetsArray = this._presetsToArray(state);
 
@@ -280,16 +280,13 @@ export default class Repl extends React.Component {
       presetsArray.push(["env", options]);
     }
 
-    // Only generate source maps if "Evaluate" is enabled.
-    const generateSourceMaps = state.runtimePolyfillState.isEnabled;
-
     return {
-      ...compile(code, generateSourceMaps, {
+      ...compile(code, {
         evaluate:
-          state.runtimePolyfillState.isEnabled &&
-          state.runtimePolyfillState.isLoaded,
+          runtimePolyfillState.isEnabled && runtimePolyfillState.isLoaded,
         presets: presetsArray,
         prettify: state.plugins.prettier.isEnabled,
+        sourceMap: runtimePolyfillState.isEnabled,
       }),
       envPresetDebugInfo,
     };

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -49,7 +49,7 @@ type State = {
   plugins: PluginStateMap,
   presets: PluginStateMap,
   runtimePolyfillState: PluginState,
-  sourceMap: ?string
+  sourceMap: ?string,
 };
 
 export default class Repl extends React.Component {
@@ -104,7 +104,7 @@ export default class Repl extends React.Component {
         runtimePolyfillConfig,
         persistedState.evaluate
       ),
-      sourceMap: null
+      sourceMap: null,
     };
 
     this.state = {
@@ -280,8 +280,11 @@ export default class Repl extends React.Component {
       presetsArray.push(["env", options]);
     }
 
+    // Only generate source maps if "Evaluate" is enabled.
+    const generateSourceMaps = state.runtimePolyfillState.isEnabled;
+
     return {
-      ...compile(code, {
+      ...compile(code, generateSourceMaps, {
         evaluate:
           state.runtimePolyfillState.isEnabled &&
           state.runtimePolyfillState.isLoaded,

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -1,25 +1,25 @@
 // @flow
 
-import scopedEval from './scopedEval';
+import scopedEval from "./scopedEval";
 
-import type { CompileConfig } from './types';
+import type { CompileConfig } from "./types";
 
 type Return = {
   compiled: ?string,
   compileError: ?Error,
-  evalError: ?Error
+  evalError: ?Error,
 };
 
 const DEFAULT_PRETTIER_CONFIG = {
   bracketSpacing: true,
   jsxBracketSameLine: false,
-  parser: 'babylon',
+  parser: "babylon",
   printWidth: 80,
   semi: true,
   singleQuote: false,
   tabWidth: 2,
-  trailingComma: 'none',
-  useTabs: false
+  trailingComma: "none",
+  useTabs: false,
 };
 
 export default function compile(code: string, config: CompileConfig): Return {
@@ -31,9 +31,9 @@ export default function compile(code: string, config: CompileConfig): Return {
   try {
     const transformed = window.Babel.transform(code, {
       babelrc: false,
-      filename: 'repl',
+      filename: "repl",
       presets: config.presets,
-      plugins: ['transform-regenerator'],
+      plugins: ["transform-regenerator"],
       sourceMap: true
     });
 
@@ -62,7 +62,7 @@ export default function compile(code: string, config: CompileConfig): Return {
     if (config.evaluate) {
       try {
         // eslint-disable-next-line
-        scopedEval(code, compiled, sourceMap);
+        scopedEval(compiled, sourceMap);
       } catch (error) {
         evalError = error;
       }

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -22,7 +22,11 @@ const DEFAULT_PRETTIER_CONFIG = {
   useTabs: false,
 };
 
-export default function compile(code: string, config: CompileConfig): Return {
+export default function compile(
+  code: string,
+  generateSourceMaps: boolean,
+  config: CompileConfig
+): Return {
   let compiled = null;
   let compileError = null;
   let evalError = null;
@@ -34,15 +38,17 @@ export default function compile(code: string, config: CompileConfig): Return {
       filename: "repl",
       presets: config.presets,
       plugins: ["transform-regenerator"],
-      sourceMap: true
+      sourceMap: generateSourceMaps,
     });
 
     compiled = transformed.code;
 
-    try {
-      sourceMap = JSON.stringify(transformed.map);
-    } catch (error) {
-      console.error(`Source Map generation failed: ${error}`);
+    if (generateSourceMaps) {
+      try {
+        sourceMap = JSON.stringify(transformed.map);
+      } catch (error) {
+        console.error(`Source Map generation failed: ${error}`);
+      }
     }
 
     if (config.prettify && window.prettier !== undefined) {
@@ -78,6 +84,6 @@ export default function compile(code: string, config: CompileConfig): Return {
     compiled,
     compileError,
     evalError,
-    sourceMap
+    sourceMap,
   };
 }

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -22,11 +22,7 @@ const DEFAULT_PRETTIER_CONFIG = {
   useTabs: false,
 };
 
-export default function compile(
-  code: string,
-  generateSourceMaps: boolean,
-  config: CompileConfig
-): Return {
+export default function compile(code: string, config: CompileConfig): Return {
   let compiled = null;
   let compileError = null;
   let evalError = null;
@@ -38,12 +34,12 @@ export default function compile(
       filename: "repl",
       presets: config.presets,
       plugins: ["transform-regenerator"],
-      sourceMap: generateSourceMaps,
+      sourceMap: config.sourceMap,
     });
 
     compiled = transformed.code;
 
-    if (generateSourceMaps) {
+    if (config.sourceMap) {
       try {
         sourceMap = JSON.stringify(transformed.map);
       } catch (error) {

--- a/js/repl/scopedEval.js
+++ b/js/repl/scopedEval.js
@@ -1,20 +1,20 @@
 // @flow
 
-// Some libraries are loaded directly from CDN to improve page speed.
-// It's best to mask them so that evaled code doesn't accidentally interact with the page.
-// eg ReactDOM.render() shouldn't be able to unmount the REPL app.
-// Other globals are just potentially problematic to eval,
-// eg document.body.innerHTML = '' shouldn't be able to replace the Babel website.
-const globals = [
-  "React",
-  "ReactDOM",
-  "LZString",
-  "CodeMirror",
-  "document",
-  "window",
-];
+let iframe = null;
 
-export default function scopedEval(code: string) {
-  // $FlowFixMe
-  new Function(...globals, code)();
+export default function scopedEval(code: string, sourceMap: string) {
+  if (iframe === null) {
+    iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+
+    document.body.append(iframe);
+  }
+
+  // Append source map footer so errors map to pre-compiled code.
+  if (sourceMap) {
+    code = `${code}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${btoa(sourceMap)}`;
+  }
+
+  // Eval code within an iframe so that it can't eg unmount the REPL.
+  iframe.contentWindow.eval(code);
 }

--- a/js/repl/scopedEval.js
+++ b/js/repl/scopedEval.js
@@ -14,7 +14,7 @@ export default function scopedEval(code: string, sourceMap: ?string) {
   // Append source map footer so errors map to pre-compiled code.
   if (sourceMap) {
     code = `${code}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${btoa(
-      sourceMap
+      unescape(encodeURIComponent(sourceMap))
     )}`;
   }
 

--- a/js/repl/scopedEval.js
+++ b/js/repl/scopedEval.js
@@ -2,17 +2,20 @@
 
 let iframe = null;
 
-export default function scopedEval(code: string, sourceMap: string) {
+export default function scopedEval(code: string, sourceMap: ?string) {
   if (iframe === null) {
     iframe = document.createElement("iframe");
     iframe.style.display = "none";
 
+    // $FlowFixMe
     document.body.append(iframe);
   }
 
   // Append source map footer so errors map to pre-compiled code.
   if (sourceMap) {
-    code = `${code}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${btoa(sourceMap)}`;
+    code = `${code}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${btoa(
+      sourceMap
+    )}`;
   }
 
   // Eval code within an iframe so that it can't eg unmount the REPL.

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -38,6 +38,7 @@ export type CompileConfig = {
   evaluate: boolean,
   presets: BabelPresets,
   prettify: boolean,
+  sourceMap: boolean,
 };
 
 export type PersistedState = {


### PR DESCRIPTION
This PR adds a couple of improvements to the new REPL:
* `eval` is now done within an `iframe` rather than a context-less `new Function` so that compiled code can access `window` without potentially clobbering the REPL itself.
* Inline source maps are passed to `eval` so errors will map to pre-compiled code. This works fine on Safari and Firefox but I can't get it working on Chrome. I'm aware of some issues with this (see [459499](https://bugs.chromium.org/p/chromium/issues/detail?id=459499#c22) and some potential workarounds (see [`EvalSourceMapDevToolModuleTemplatePlugin.js`](https://github.com/webpack/webpack/blob/3f79150d6ab2ad7a614b94e55c9314adf581b07a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js#L65) but I'm not having much luck.

Potential downsides:
* The inline source maps do not work for Chrome. (This is also the case for eg the Preact REPL so maybe we're stuck with it for now. I've reached out to Jason about it on Twitter though.)
* Firefox 55 seems to cache the source maps so that they don't stay in-sync with the evaled code (see devtools-html/devtools-core/issues/606) but Firefox Nightly updates correctly (as does Safari).

Resolves #65