### PR TITLE
Ignore js/repl/node_modules in Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ exclude:
   - Makefile
   - Rakefile
   - package.json
+  - js/repl/node_modules
 
 include:
   - _redirects


### PR DESCRIPTION
If you build the new REPL, the Jekyll build hangs as it tries to build all ~20,000 files in its node_modules directory.

This was the reason @bvaughn was having difficulty with Jekyll. It took a while to track down - I only figured it out after watching exactly what the Ruby process was doing and noticing that it was reading a large number of Markdown files from `node_modules`:
![](http://ss.dan.cx/2017/08/Process_Monitor_-_Sysinternals_www.sysinternals.c_14-21.24.29.png)

I'm working on adding the new REPL to the site and integrating it into the Jekyll build, but in the meantime this will unblock anyone that wants to try the new REPL locally *and* still be able to build the site. 😛 