### PR TITLE
Fix affix sidebar flickering

### DIFF
--- a/_sass/components/_sidebar.scss
+++ b/_sass/components/_sidebar.scss
@@ -81,7 +81,6 @@
     &.affix {
       position: fixed; /* Undo the static from mobile first approach */
       top: 70px;
-      bottom: 0;
       overflow: auto;
     }
 

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -75,9 +75,19 @@
 
         return offsetTop - navbarOuterHeight - sidebarMargin;
       }),
-      bottom: _.memoize(function() {
-        return $('.footer').outerHeight(true);
-      })
+      bottom: _.throttle(function() {
+        return $('.footer').outerHeight(true) + $('#discourse-comments').outerHeight(true);
+      }, 1000)
+    }
+  });
+
+  $sidebar.on('affixed.bs.affix', function() {
+    var sidebarClientRect = $sidebar[0].getBoundingClientRect();
+
+    if (window.innerHeight - sidebarClientRect.top < sidebarClientRect.height) {
+      $sidebar.css({
+        maxHeight: window.innerHeight - $sidebar[0].getBoundingClientRect().top
+      });
     }
   });
 


### PR DESCRIPTION
When fixing an overflow issue on the sidebar with this PR https://github.com/babel/website/pull/1274

A flickering issue was introduced that was pointed out in this comment by @xtuc (his last one on the thread):
https://github.com/babel/website/pull/1274#issuecomment-315534841

The issue can be fix by using a max-height instead of a bottom with value zero.

How it looks on production (https://babeljs.io/docs/core-packages/):
https://screencast-o-matic.com/watch/cbjor0ldMM

How it would look like with the fix:
https://screencast-o-matic.com/watch/cbjorTldM8