### PR TITLE
Mask global variables before eval-ing REPL code

### DIFF
--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -8,6 +8,7 @@ import StorageService from './StorageService';
 import UriUtils from './UriUtils';
 import compile from './compile';
 import loadPlugin from './loadPlugin';
+import scopedEval from './scopedEval';
 import {
   envPresetConfig,
   pluginConfigs,
@@ -204,7 +205,7 @@ export default class Repl extends React.Component {
         // Just evaluate the most recently compiled code.
         try {
           // eslint-disable-next-line
-          eval(this.state.compiled);
+          scopedEval(this.state.compiled);
         } catch (error) {
           evalError = error;
         }

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -1,5 +1,7 @@
 // @flow
 
+import scopedEval from './scopedEval';
+
 import type { CompileConfig } from './types';
 
 type Return = {
@@ -52,7 +54,7 @@ export default function compile(code: string, config: CompileConfig): Return {
     if (config.evaluate) {
       try {
         // eslint-disable-next-line
-        eval(compiled);
+        scopedEval(compiled);
       } catch (error) {
         evalError = error;
       }

--- a/js/repl/scopedEval.js
+++ b/js/repl/scopedEval.js
@@ -1,0 +1,19 @@
+// @flow
+
+// Some libraries are loaded directly from CDN to improve page speed.
+// It's best to mask them so that evaled code doesn't accidentally interact with the page.
+// eg ReactDOM.render() shouldn't be able to unmount the REPL app.
+// Other globals are just potentially problematic to eval,
+// eg document.body.innerHTML = '' shouldn't be able to replace the Babel website.
+const globals = [
+  'React',
+  'ReactDOM',
+  'LZString',
+  'CodeMirror',
+  'document',
+  'window',
+];
+
+export default function scopedEval(code: string) {
+  new Function(...globals, code)();
+}


### PR DESCRIPTION
Maybe we should consider evaling code within a web worker to be safer, but this PR is at least a step in a better direction. We now mask globals to prevent evaled code from accidentally interacting with the Babel website or the REPL.

After this change the following code snippets will no longer mess up the REPL:
```js
document.body.innerHTML = ''
```

```jsx
ReactDOM.render(
  <div/>,
  document.getElementById('root')
);
```

Potentially resolves #1329