### PR TITLE
Fix lint warns - remark doesnt seem to find definitions properly if t…

### DIFF
--- a/_posts/2017-08-16-gsoc-karl-1.md
+++ b/_posts/2017-08-16-gsoc-karl-1.md
@@ -126,6 +126,10 @@ Holding my computer together with judicious applications of <kbd>Alt</kbd> + <kb
 Even through all that, I still couldn’t see any reason why it was deciding to remove this “necessary” (so I thought) code that was being removed with my original fix.
 
 ### The actual problem?
+
+  [bug]: https://github.com/babel/babel/issues/5656#issuecomment-300139737
+  [pr]: https://github.com/babel/babel/pull/5721
+
 See the error shown above? That entire code in green wasn’t meant to be there, even though it was “expected”.
 
 Basically: the test was broken. _Great._ :/
@@ -145,9 +149,6 @@ So, all in all, a few lessons here:
 1. Make sure your tests are right in the first place—don't be complacent!
 2. Yes, the debugger is actually useful in seeing what goes on.
 3. Sometimes things take time to work out—if you’re getting nowhere, take a break or work on something else.
-
-  [bug]: https://github.com/babel/babel/issues/5656#issuecomment-300139737
-  [pr]: https://github.com/babel/babel/pull/5721
 
 ## 3. Team meetings!
 


### PR DESCRIPTION
…hey are referenced before geting defined

This was causing [those warnings](https://travis-ci.org/babel/website/builds/265903838#L597)