### PR TITLE
WIP: Better document breaking changes for the AST

### DIFF
--- a/_posts/2017-03-01-upgrade-to-babel-7-for-tool-authors.md
+++ b/_posts/2017-03-01-upgrade-to-babel-7-for-tool-authors.md
@@ -35,6 +35,61 @@ Calls to `babel.transform` or any other transform function may return `null` if 
 
 The `opts.basename` option exposed on `state.file.opts` has been removed. If you need it, best to build it from `opts.filename` yourself [babel/babel#5467](https://github.com/babel/babel/pull/5467).
 
+## Babylon
+
+> Removed the `*` plugin option [#301](https://github.com/babel/babylon/pull/301) ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+This was first added in v6.14.1 (Nov 17, 2016) so it's unlikely anyone was using this.
+
+This catch-all option was removed; instead you should specifically decide which plugins you want to activate.
+
+We thought it would be a good idea for tools so they wouldn't have to constantly update their config but it also means we can't easily make a breaking change.
+
+Before:
+
+```js
+babylon.parse(code, {
+  plugins: [ "*" ]
+})
+```
+
+You can get the old behavior using:
+
+```js
+babylon.parse(code, {
+  plugins: [
+    "asyncGenerators",
+    "classProperties",
+    "decorators",
+    "doExpressions",
+    "dynamicImport",
+    "exportExtensions",
+    "flow",
+    "functionBind",
+    "functionSent",
+    "jsx",
+    "objectRestSpread",
+  ]
+})
+```
+
+See Babylon's [plugin options](https://babeljs.io/docs/core-packages/babylon/#api-plugins).
+
+> Removed `classConstructorCall` plugin [#291](https://github.com/babel/babylon/pull/291) ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+## `babel-traverse`
+
+`getFunctionParent` will no longer return `Program`, please use `getProgramParent` instead [#5923](https://github.com/babel/babel/pull/5923). ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+It doesn't make sense that a function named `getFunctionParent` also returns the Program, so that was removed.
+
+To get the equivalent behavior, you'll need to make a change like
+
+```diff
+- path.scope.getFunctionParent()
++ path.scope.getFunctionParent() || path.scope.getProgramParent()
+```
+
 ## AST changes
 
 > ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
@@ -219,58 +274,3 @@ The two AST-Nodes `RestProperty` and `SpreadProperty` have been removed in favor
 ```
 
 See our [upgrade PR for Babel](https://github.com/babel/babel/pull/5317) and the [Babylon AST spec](https://github.com/babel/babylon/blob/7.0/ast/spec.md) for more information.
-
-## Babylon
-
-> TODO Removed the `*` plugin option [babel/babylon#301](https://github.com/babel/babylon/pull/301) ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
-
-This was first added in v6.14.1 (Nov 17, 2016) so it's unlikely anyone was using this.
-
-This catch-all option was removed; instead you should specifically decide which plugins you want to activate.
-
-We thought it would be a good idea for tools so they wouldn't have to constantly update their config but it also means we can't easily make a breaking change.
-
-Before:
-
-```js
-babylon.parse(code, {
-  plugins: [ "*" ]
-})
-```
-
-You can get the old behavior using:
-
-```js
-babylon.parse(code, {
-  plugins: [
-    "asyncGenerators",
-    "classProperties",
-    "decorators",
-    "doExpressions",
-    "dynamicImport",
-    "exportExtensions",
-    "flow",
-    "functionBind",
-    "functionSent",
-    "jsx",
-    "objectRestSpread",
-  ]
-})
-```
-
-See Babylon's [plugin options](https://babeljs.io/docs/core-packages/babylon/#api-plugins).
-
-> TODO: Removed `classConstructorCall` plugin [#291](https://github.com/babel/babylon/pull/291) ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
-
-## `babel-traverse`
-
-`getFunctionParent` will no longer return `Program`, please use `getProgramParent` instead [babel/babel#5923](https://github.com/babel/babel/pull/5923). ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
-
-It doesn't make sense that a function named `getFunctionParent` also returns the Program, so that was removed.
-
-To get the equivalent behavior, you'll need to make a change like
-
-```diff
-- path.scope.getFunctionParent()
-+ path.scope.getFunctionParent() || path.scope.getProgramParent()
-```

--- a/_posts/2017-03-01-upgrade-to-babel-7-for-tool-authors.md
+++ b/_posts/2017-03-01-upgrade-to-babel-7-for-tool-authors.md
@@ -39,6 +39,25 @@ The `opts.basename` option exposed on `state.file.opts` has been removed. If you
 
 > ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
 
+### Tokens removed
+
+In previous versions `tokens` were always attached to the AST on the top-level. In the latests version of babylon we removed this behavior and made it disabled by default to improve the performance of the parser. All usages in babel itself have been remove and `babel-generator` is not using the tokens anymore for pretty printing.
+
+If your babel-plugin uses `tokens` at the moment, evaluate if it is still necessary and try to remove the usage if possible. If your plugin really depends on getting tokens you can reactivate it but please only consider this if there is no other way as this will hurt users performance.
+
+To activate you need to set the `tokens` option of babylon to true. You can do this directly from your plugin.
+
+```js
+export default function() {
+  return {
+    manipulateOptions(opts, parserOpts) {
+      parserOpts.tokens = true;
+    },
+    ...
+  };
+}
+```
+
 ### Renamed
 
 The following nodes have been renamed:
@@ -242,9 +261,6 @@ babylon.parse(code, {
 See Babylon's [plugin options](https://babeljs.io/docs/core-packages/babylon/#api-plugins).
 
 > TODO: Removed `classConstructorCall` plugin [#291](https://github.com/babel/babylon/pull/291) ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
-
-> TODO: Tokens are not added to the AST by default anymore
-
 
 ## `babel-traverse`
 

--- a/_posts/2017-03-01-upgrade-to-babel-7-for-tool-authors.md
+++ b/_posts/2017-03-01-upgrade-to-babel-7-for-tool-authors.md
@@ -17,12 +17,16 @@ Refer users to this document for those that create tools that depend on Babel (s
 
 ## All Babel packages
 
-> Support for Node.js 0.10 and 0.12 has been dropped ![high](https://img.shields.io/badge/level%20of%20awesomeness%3F-high-red.svg)
+### NodeJS support
+![high](https://img.shields.io/badge/level%20of%20awesomeness%3F-high-red.svg)
 
-> Dropped use of `add-module-exports` plugin on Babel packages ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+Support for Node.js 0.10 and 0.12 has been dropped as both of this versions are out of maintenance.
 
+### Export changes
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+Dropped use of `add-module-exports` plugin on Babel packages.
 This had to be used earlier to prevent a breaking change with our exports.
-
 If you import a Babel package in a library you may need to use `.default` when using `require` rather than `import`.
 
 ## `babel-core`
@@ -91,8 +95,6 @@ To get the equivalent behavior, you'll need to make a change like
 ```
 
 ## AST changes
-
-> ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
 
 ### Tokens removed
 


### PR DESCRIPTION
This enhances the blog post for tool authors to better show what changed and how a possible fix might look like.

I changed the Overall heading from `Babylon` to `AST changes` as otherwise it might sound like you are only affected when you are using babylon, but actually every babel-plugin is affected.