### PR TITLE
"Try it out" menubar item should be selected when on REPL 2

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -34,4 +34,4 @@
 - title: Blog
   url: /blog/
 - title: FAQ
-  url: /faq
+  url: /faq/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,36 +1,51 @@
 - title: Learn ES2015
   url: /learn-es2015/
+  match: /learn-es2015/
 - title: Docs
   url: /docs
+  match: /docs
   subnav:
     - items:
         - title: Setup
           url: /docs/setup/
+          match: /docs/setup/
         - title: Editors
           url: /docs/editors
+          match: /docs/editors
         - title: Caveats
           url: /docs/usage/caveats/
+          match: /docs/usage/caveats/
     - name: Packages
       items:
         - title: babel-core
           url: /docs/core-packages/
+          match: /docs/core-packages/
         - title: babel-polyfill
           url: /docs/usage/polyfill/
+          match: /docs/usage/polyfill/
         - title: Plugins
           url: /docs/plugins/
+          match: /docs/plugins/
     - name: Usage
       items:
         - title: .babelrc
           url: /docs/usage/babelrc/
+          match: /docs/usage/babelrc/
         - title: babel-cli
           url: /docs/usage/cli/
+          match: /docs/usage/cli/
         - title: babel-register
           url: /docs/usage/babel-register/
+          match: /docs/usage/babel-register/
         - title: API
           url: /docs/usage/api/
+          match: /docs/usage/api/
 - title: Try it out
   url: /repl/
+  match: ["/repl/", "/repl2/", "/php/"]
 - title: Blog
   url: /blog/
+  match: /blog/
 - title: FAQ
   url: /faq
+  match: /faq

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,51 +1,37 @@
 - title: Learn ES2015
   url: /learn-es2015/
-  match: /learn-es2015/
 - title: Docs
   url: /docs
-  match: /docs
   subnav:
     - items:
         - title: Setup
           url: /docs/setup/
-          match: /docs/setup/
         - title: Editors
           url: /docs/editors
-          match: /docs/editors
         - title: Caveats
           url: /docs/usage/caveats/
-          match: /docs/usage/caveats/
     - name: Packages
       items:
         - title: babel-core
           url: /docs/core-packages/
-          match: /docs/core-packages/
         - title: babel-polyfill
           url: /docs/usage/polyfill/
-          match: /docs/usage/polyfill/
         - title: Plugins
           url: /docs/plugins/
-          match: /docs/plugins/
     - name: Usage
       items:
         - title: .babelrc
           url: /docs/usage/babelrc/
-          match: /docs/usage/babelrc/
         - title: babel-cli
           url: /docs/usage/cli/
-          match: /docs/usage/cli/
         - title: babel-register
           url: /docs/usage/babel-register/
-          match: /docs/usage/babel-register/
         - title: API
           url: /docs/usage/api/
-          match: /docs/usage/api/
 - title: Try it out
   url: /repl/
   match: ["/repl/", "/repl2/", "/php/"]
 - title: Blog
   url: /blog/
-  match: /blog/
 - title: FAQ
   url: /faq
-  match: /faq

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,7 @@
       <ul class="nav navbar-nav">
         {% for item in site.data.navigation %}
           {% if item.subnav %}
-            <li class="dropdown {% if page.url contains item.url %}active{% endif %}">
+            <li class="dropdown {% if page.url contains item.match %}active{% endif %}">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ item.title }} <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 {% for group in item.subnav %}
@@ -31,7 +31,7 @@
 
                   {% for item in group.items %}
 
-                    <li {% if page.url contains item.url %}class="active"{% endif %}>
+                    <li {% if item.match contains page.url %}class="active"{% endif %}>
                       <a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
                     </li>
                   {% endfor %}
@@ -40,7 +40,7 @@
               </ul>
             </li>
           {% else %}
-            <li {% if page.url contains item.url %}class="active"{% endif %}>
+            <li {% if item.match contains page.url %}class="active"{% endif %}>
               <a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
             </li>
           {% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,7 @@
       <ul class="nav navbar-nav">
         {% for item in site.data.navigation %}
           {% if item.subnav %}
-            <li class="dropdown {% if page.url contains item.match %}active{% endif %}">
+            <li class="dropdown {% if page.url contains item.url %}active{% endif %}">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ item.title }} <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 {% for group in item.subnav %}
@@ -31,7 +31,7 @@
 
                   {% for item in group.items %}
 
-                    <li {% if item.match contains page.url %}class="active"{% endif %}>
+                    <li {% if page.url contains item.url %}class="active"{% endif %}>
                       <a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
                     </li>
                   {% endfor %}
@@ -40,7 +40,14 @@
               </ul>
             </li>
           {% else %}
-            <li {% if item.match contains page.url %}class="active"{% endif %}>
+            {% assign match = item.match %}
+            {% if match == nil %}
+              {% assign match = item.url %}
+            {% endif %}
+            {% if page.url == "/" %}
+              {% assign match = nil %}
+            {% endif %}
+            <li {% if match contains page.url %}class="active"{% endif %}>
               <a href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a>
             </li>
           {% endif %}


### PR DESCRIPTION
Fixes issue here: https://github.com/babel/website/issues/1324

An interesting thing I learned about Liquid's `contains` operator is that it can match based on an array. The PR here adds a `match` field to each navigation item. This does seem to duplicate information (which is unexciting), but since the "try it out" menu item is intended to be overloaded I think it's a reasonable solution.