### PR TITLE
Debounce compilation and plug-in changes

### DIFF
--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -117,15 +117,6 @@ export default class Repl extends React.Component {
 
     // Load any plug-ins enabled by query params.
     this._checkForUnloadedPlugins();
-
-    // Debounce certain expensive actions.
-    // This also avoids prematurely warning the user about invalid syntax,
-    // eg when in the middle of typing a variable name.
-    this._compileToState = debounce(this._compileToState, DEBOUNCE_DELAY);
-    this._presetsUpdatedSetStateCallback = debounce(
-      this._presetsUpdatedSetStateCallback,
-      DEBOUNCE_DELAY
-    );
   }
 
   render() {
@@ -304,9 +295,12 @@ export default class Repl extends React.Component {
     };
   };
 
-  _compileToState = (code: string) => {
+  // Debounce compilation since it's expensive.
+  // This also avoids prematurely warning the user about invalid syntax,
+  // eg when in the middle of typing a variable name.
+  _compileToState = debounce((code: string) => {
     this.setState(state => this._compile(code, state), this._persistState);
-  };
+  }, DEBOUNCE_DELAY);
 
   _onEnvPresetSettingChange = (name: string, value: any) => {
     this.setState(

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -8,6 +8,7 @@ type Return = {
   compiled: ?string,
   compileError: ?Error,
   evalError: ?Error,
+  sourceMap: ?string,
 };
 
 const DEFAULT_PRETTIER_CONFIG = {
@@ -76,7 +77,6 @@ export default function compile(code: string, config: CompileConfig): Return {
   }
 
   return {
-    code,
     compiled,
     compileError,
     evalError,

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "codemirror": "5.28.0",
     "glamor": "2.20.39",
     "lodash.camelcase": "^4.3.0",
+    "lodash.debounce": "^4.0.8",
     "lz-string": "^1.4.4",
     "react": "16.0.0-beta.3",
     "react-dom": "16.0.0-beta.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2827,6 +2827,10 @@ lodash.chunk@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"


### PR DESCRIPTION
Since we used controlled inputs, `state` changes for their values must remain synchronous. The actual compilation can be debounced though. I think this PR seems to do the tricky? 😅  I initially expected it to be more complicated than this.

Resolves #1316

Note that I'm moving discussion of moving compilation to a worker to #1342. I think it's worth separating from debounce.