### PR TITLE
Fix sidebar flickering when scroll reaches page bottom

### DIFF
--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -74,9 +74,6 @@
         var sidebarMargin = parseInt($sidebar.children(0).css('margin-top'), 10);
 
         return offsetTop - navbarOuterHeight - sidebarMargin;
-      }),
-      bottom: _.memoize(function() {
-        return $('.footer').outerHeight(true);
       })
     }
   });


### PR DESCRIPTION
**Steps to reproduce:**
1. Open any Docs page. Example: https://babeljs.io/docs/plugins/
2. Scroll to page bottom.

**Expected result:**
Sidebar doesn't flickering.

**Actual result:**
Sidebar flickering.



**Before fix:**
![babel-oi-sidebar-before-320](https://user-images.githubusercontent.com/10023109/29632225-005a3ef0-884b-11e7-85a6-448946f2feb6.gif)



**After fix:**
![babel-oi-sidebar-after-320](https://user-images.githubusercontent.com/10023109/29632377-820f3a4a-884b-11e7-9e4a-5213f4a548cb.gif)


