### PR TITLE
Fixed "Try" links to REPL

### DIFF
--- a/js/repl/UriUtils.js
+++ b/js/repl/UriUtils.js
@@ -61,6 +61,7 @@ const parseQuery = () => {
       "browsers",
       "build",
       "builtIns",
+      "code",
       "debug",
       "circleciRepo",
       "evaluate",


### PR DESCRIPTION
The underlying issue was that "Try" links don't use lz compression. I wrote the REPL expecting that the `code` search param would always be compressed as `code_lz`. I've updated the REPL now to accept `code` too- and to defer to `code_lz` when it's present.

Resolves #1349