### PR TITLE
Refactored sidebar to use accordions

### DIFF
--- a/js/repl/AccordionTab.js
+++ b/js/repl/AccordionTab.js
@@ -1,0 +1,98 @@
+// @flow
+
+import { css } from "glamor";
+import React, { Component } from "react";
+import Svg from "./Svg";
+import { colors, media } from "./styles";
+
+type Props = {
+  children: React$Element<any>,
+  className: ?any,
+  defaultExpanded?: boolean,
+  label: string,
+};
+
+type State = {
+  expanded: boolean,
+};
+
+export default class AccordionTab extends Component {
+  props: Props;
+  state: State = {
+    expanded: !!this.props.defaultExpanded,
+  };
+
+  render() {
+    const { expanded } = this.state;
+
+    return (
+      <div className={`${styles.AccordionTab} ${this.props.className || ""}`}>
+        <div className={styles.HeaderRow} onClick={this._onClick}>
+          <div className={styles.Label}>
+            {this.props.label}
+          </div>
+          <Svg
+            className={`${styles.Arrow} ${expanded
+              ? styles.ArrowExpanded
+              : ""}`}
+            path="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+          />
+        </div>
+        {expanded &&
+          <div className={styles.Content}>
+            {this.props.children}
+          </div>}
+      </div>
+    );
+  }
+
+  _onClick = () => {
+    this.setState(state => ({
+      expanded: !state.expanded,
+    }));
+  };
+}
+
+const styles = {
+  AccordionTab: css({
+    flex: "1 0 2.5rem",
+    cursor: "default",
+    borderBottom: `1px solid ${colors.inverseBackgroundDark}`,
+
+    [media.medium]: {
+      borderRight: `1px solid ${colors.inverseBackgroundDark}`,
+    },
+  }),
+  HeaderRow: css({
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    padding: "1rem 1.5rem",
+    transition: "background-color 250ms ease-in-out, color 250ms ease-in-out",
+    color: colors.inverseForegroundLight,
+    cursor: "pointer",
+
+    "&:hover": {
+      backgroundColor: colors.inverseBackgroundLight,
+      color: colors.inverseForeground,
+    },
+  }),
+  Label: css({
+    flex: "1",
+    fontSize: "1.5rem",
+    fontWeight: "bold",
+  }),
+  Arrow: css({
+    height: "2rem",
+    width: "2rem",
+    transition: "transform 250ms ease-in-out",
+  }),
+  ArrowExpanded: css({
+    transform: "rotateZ(-90deg)",
+  }),
+  Content: css({
+    display: "flex",
+    flexDirection: "column",
+    padding: "1rem 1.5rem",
+  }),
+};

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -7,6 +7,7 @@ import {
   pluginConfigs,
   presetPluginConfigs,
 } from "./PluginConfig";
+import AccordionTab from "./AccordionTab";
 import PresetLoadingAnimation from "./PresetLoadingAnimation";
 import Svg from "./Svg";
 import { colors, media } from "./styles";
@@ -81,8 +82,11 @@ class ExpandedContainer extends Component {
     return (
       <div className={styles.expandedContainer}>
         <div className={styles.sectionsWrapper}>
-          <div className={styles.section}>
-            <div className={styles.sectionHeader}>Settings</div>
+          <AccordionTab
+            className={styles.section}
+            label="Settings"
+            defaultExpanded={true}
+          >
             <PluginToggle
               config={runtimePolyfillConfig}
               label="Evaluate"
@@ -106,9 +110,8 @@ class ExpandedContainer extends Component {
                 state={pluginState[config.package]}
               />
             )}
-          </div>
-          <div className={styles.section}>
-            <div className={styles.sectionHeader}>Presets</div>
+          </AccordionTab>
+          <AccordionTab className={styles.section} label="Presets">
             {presetPluginConfigs.map(config =>
               <PluginToggle
                 config={config}
@@ -117,22 +120,24 @@ class ExpandedContainer extends Component {
                 state={presetState[config.package]}
               />
             )}
-          </div>
-          <div className={`${styles.section} ${styles.sectionEnv}`}>
-            <label
-              className={`${styles.sectionHeader} ${styles.sectionEnvHeader}`}
-            >
-              {envPresetState.isLoading
-                ? <PresetLoadingAnimation />
-                : "Env Preset"}
-
+          </AccordionTab>
+          <AccordionTab
+            className={`${styles.section} ${styles.sectionEnv}`}
+            label="Env Preset"
+          >
+            <label className={styles.settingsLabel}>
               <input
                 checked={envConfig.isEnvPresetEnabled}
-                className={styles.envPresetCheckbox}
+                className={styles.inputCheckboxLeft}
                 type="checkbox"
                 onChange={this._onEnvPresetEnabledChange}
               />
+
+              {envPresetState.isLoading
+                ? <PresetLoadingAnimation />
+                : "Enabled"}
             </label>
+
             <div className={styles.envPresetColumn}>
               <label
                 className={`${styles.envPresetColumnLabel} ${styles.highlight}`}
@@ -219,7 +224,7 @@ class ExpandedContainer extends Component {
               />
               Debug
             </label>
-          </div>
+          </AccordionTab>
         </div>
         <div className={styles.versionAndClassicRow}>
           <a className={styles.classicReplLink} href="/repl-old/">
@@ -404,7 +409,7 @@ const styles = {
       maxWidth: "25rem",
 
       [`& .${nestedCloseButton}`]: {
-        right: "-1.5rem",
+        right: "-2rem",
       },
     },
 
@@ -416,6 +421,7 @@ const styles = {
   }),
   closeButton: css({
     position: "absolute",
+    zIndex: 2,
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
@@ -448,6 +454,7 @@ const styles = {
     },
   }),
   sectionsWrapper: css({
+    flex: "1 1 auto",
     display: "flex",
     flexDirection: "row",
     flexWrap: "wrap",
@@ -464,13 +471,13 @@ const styles = {
     },
   }),
   section: css({
+    position: "relative",
+    zIndex: 7,
     display: "flex",
     flexDirection: "column",
     overflow: "auto",
     flex: "0 0 auto",
     maxHeight: "100%",
-    padding: "1.5rem",
-    zIndex: 7,
 
     [media.mediumAndDown]: {
       flex: "1 0 100px",
@@ -479,7 +486,6 @@ const styles = {
     },
   }),
   sectionEnv: css({
-    borderBottom: "none",
     borderRight: "none",
 
     [media.mediumAndDown]: {
@@ -494,18 +500,6 @@ const styles = {
     fontSize: "1rem",
     fontWeight: "bold",
     color: colors.inverseForeground,
-  }),
-  sectionHeader: css({
-    flex: "0 0 2.5rem",
-    fontSize: "1.5rem",
-    fontWeight: "bold",
-    color: colors.inverseForegroundLight,
-  }),
-  sectionEnvHeader: css({
-    display: "flex",
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
   }),
   settingsLabel: css({
     flex: "0 0 2.5rem",
@@ -544,7 +538,7 @@ const styles = {
   }),
   envPresetCheckbox: css({
     flex: "0 0 auto",
-    margin: "0 0 0 0.75rem !important", // TODO (bvaughn) Override input[type="checkbox"] style in main.css
+    margin: "0 0.75rem !important", // TODO (bvaughn) Override input[type="checkbox"] style in main.css
   }),
   envPresetLabel: css({
     flex: 1,

--- a/js/repl/styles.js
+++ b/js/repl/styles.js
@@ -11,6 +11,7 @@ const colors = {
   // Inspired by: Nuclide's "One Dark" theme
   inverseBackground: "#21252b",
   inverseBackgroundDark: "#181a1f",
+  inverseBackgroundLight: "#292d36",
   inverseForeground: "#ffffff",
   inverseForegroundLight: "#9da5b4",
 
@@ -22,6 +23,7 @@ const colors = {
 
 const media = {
   small: "@media(max-width: 600px)",
+  medium: "@media(min-width: 601px), (max-width: 1000px)",
   mediumAndDown: "@media(max-width: 1000px)",
   large: "@media(min-width: 1001px)",
 };


### PR DESCRIPTION
Resolves #1347 

**TODO**:
* Lift accordion expanded state up so that collapsing/expanding the sidebar doesn't reset which accordions are expanded.
* Don't let `textarea` in "Env" section cause the nav size to change when opened.

# Screenshot: Resizing
![sidebar-accordion-resized](https://user-images.githubusercontent.com/29597/29804377-11cde656-8c37-11e7-9845-1b48e919702d.gif)

# Screenshot: Large
![sidebar-accordion-large](https://user-images.githubusercontent.com/29597/29804374-11baacda-8c37-11e7-9183-88f601584e2b.gif)

# Screenshot: Medium
![sidebar-accordion-medium](https://user-images.githubusercontent.com/29597/29804375-11bb2ab6-8c37-11e7-850a-0c0127ce8e47.gif)

# Screenshot: Small
![sidebar-accordion-small](https://user-images.githubusercontent.com/29597/29804376-11cd9a34-8c37-11e7-9f92-0820098e2f13.gif)


