### PR TITLE
Load minified Babel in REPL when using release builds

### DIFF
--- a/js/repl/loadBabel.js
+++ b/js/repl/loadBabel.js
@@ -73,5 +73,5 @@ export default async function loadBabel(
     version = DEFAULT_BABEL_VERSION;
   }
 
-  return doLoad(`https://unpkg.com/babel-standalone@${version}/babel.js`);
+  return doLoad(`https://unpkg.com/babel-standalone@${version}/babel.min.js`);
 }


### PR DESCRIPTION
REPL should load `babel.min.js` rather than `babel.js`. This is what the old REPL did: https://github.com/babel/website/blob/master/repl-old.html#L9