### PR TITLE
Load runtime polyfill into scoped-eval iframe

### DIFF
--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -261,7 +261,7 @@ export default class Repl extends React.Component {
           // Re-render (even if no error) to update the label loading-state.
           this.setState({ evalErrorMessage });
         },
-        scopedEval.getIframe().contentDocument
+        scopedEval.getIframe()
       );
     }
 

--- a/js/repl/WorkerApi.js
+++ b/js/repl/WorkerApi.js
@@ -41,7 +41,7 @@ export default class WorkerApi {
           // But eval requires the UI thread so code can access globals like window.
           if (config.evaluate) {
             try {
-              scopedEval(compiled, sourceMap);
+              scopedEval.execute(compiled, sourceMap);
             } catch (error) {
               evalErrorMessage = error.message;
             }

--- a/js/repl/loadPlugin.js
+++ b/js/repl/loadPlugin.js
@@ -8,7 +8,7 @@ import type { LoadScriptCallback, PluginState } from "./types";
 export default function loadPlugin(
   state: PluginState,
   callback: LoadScriptCallback,
-  targetDocument: Document = document
+  target: ?HTMLIFrameElement
 ) {
   if (state.isLoading) {
     return;
@@ -33,6 +33,6 @@ export default function loadPlugin(
 
       callback(success);
     },
-    targetDocument
+    target
   );
 }

--- a/js/repl/loadPlugin.js
+++ b/js/repl/loadPlugin.js
@@ -7,7 +7,8 @@ import type { LoadScriptCallback, PluginState } from "./types";
 
 export default function loadPlugin(
   state: PluginState,
-  callback: LoadScriptCallback
+  callback: LoadScriptCallback,
+  targetDocument: Document = document
 ) {
   if (state.isLoading) {
     return;
@@ -19,16 +20,19 @@ export default function loadPlugin(
   const base = config.baseUrl || "https://bundle.run";
   const url = `${base}/${config.package}@${config.version || ""}`;
 
-  loadScript(url, success => {
-    if (success) {
-      state.isLoaded = true;
-      state.isLoading = false;
-      state.plugin = window[camelCase(state.config.package)];
-    } else {
-      state.didError = true;
-      state.isLoading = false;
-    }
+  loadScript(
+    url,
+    success => {
+      if (success) {
+        state.isLoaded = true;
+        state.isLoading = false;
+      } else {
+        state.didError = true;
+        state.isLoading = false;
+      }
 
-    callback(success);
-  });
+      callback(success);
+    },
+    targetDocument
+  );
 }

--- a/js/repl/loadScript.js
+++ b/js/repl/loadScript.js
@@ -5,7 +5,31 @@ import type { LoadScriptCallback } from "./types";
 export default function loadScript(
   url: string,
   callback: LoadScriptCallback,
-  targetDocument: Document = document
+  target: ?HTMLIFrameElement
+) {
+  if (target != null) {
+    const targetDocument = target.contentDocument;
+
+    // If we're loading this script into an iframe, wait for it to load,
+    // Otherwise the script tag we insert will be removed on-load.
+    if (targetDocument.readyState !== "complete") {
+      target.addEventListener("load", () => {
+        // Use the newly-loaded document.
+        // $FlowFixMe We know target isn't null at this point
+        loadScriptIntoDocument(url, callback, target.contentDocument);
+      });
+    } else {
+      loadScriptIntoDocument(url, callback, targetDocument);
+    }
+  } else {
+    loadScriptIntoDocument(url, callback, document);
+  }
+}
+
+function loadScriptIntoDocument(
+  url: string,
+  callback: LoadScriptCallback,
+  targetDocument: Document
 ) {
   const script = targetDocument.createElement("script");
   script.async = true;

--- a/js/repl/loadScript.js
+++ b/js/repl/loadScript.js
@@ -5,21 +5,20 @@ import type { LoadScriptCallback } from "./types";
 export default function loadScript(
   url: string,
   callback: LoadScriptCallback,
-  target: ?HTMLIFrameElement
+  maybeTarget: ?HTMLIFrameElement
 ) {
-  if (target != null) {
-    const targetDocument = target.contentDocument;
+  if (maybeTarget != null) {
+    const target = maybeTarget;
 
     // If we're loading this script into an iframe, wait for it to load,
     // Otherwise the script tag we insert will be removed on-load.
-    if (targetDocument.readyState !== "complete") {
+    if (target.contentDocument.readyState !== "complete") {
       target.addEventListener("load", () => {
         // Use the newly-loaded document.
-        // $FlowFixMe We know target isn't null at this point
         loadScriptIntoDocument(url, callback, target.contentDocument);
       });
     } else {
-      loadScriptIntoDocument(url, callback, targetDocument);
+      loadScriptIntoDocument(url, callback, target.contentDocument);
     }
   } else {
     loadScriptIntoDocument(url, callback, document);

--- a/js/repl/loadScript.js
+++ b/js/repl/loadScript.js
@@ -2,8 +2,12 @@
 
 import type { LoadScriptCallback } from "./types";
 
-export default function loadScript(url: string, callback: LoadScriptCallback) {
-  const script = document.createElement("script");
+export default function loadScript(
+  url: string,
+  callback: LoadScriptCallback,
+  targetDocument: Document = document
+) {
+  const script = targetDocument.createElement("script");
   script.async = true;
   script.src = url;
   script.onerror = () => {
@@ -14,5 +18,5 @@ export default function loadScript(url: string, callback: LoadScriptCallback) {
   };
 
   // $FlowFixMe
-  document.head.appendChild(script);
+  targetDocument.head.appendChild(script);
 }

--- a/js/repl/scopedEval.js
+++ b/js/repl/scopedEval.js
@@ -2,7 +2,7 @@
 
 let iframe = null;
 
-export default function scopedEval(code: string, sourceMap: ?string) {
+function getIframe() {
   if (iframe === null) {
     iframe = document.createElement("iframe");
     iframe.style.display = "none";
@@ -11,6 +11,10 @@ export default function scopedEval(code: string, sourceMap: ?string) {
     document.body.append(iframe);
   }
 
+  return iframe;
+}
+
+function scopedEval(code: string, sourceMap: ?string) {
   // Append source map footer so errors map to pre-compiled code.
   if (sourceMap) {
     code = `${code}\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${btoa(
@@ -19,5 +23,10 @@ export default function scopedEval(code: string, sourceMap: ?string) {
   }
 
   // Eval code within an iframe so that it can't eg unmount the REPL.
-  iframe.contentWindow.eval(code);
+  getIframe().contentWindow.eval(code);
 }
+
+export default {
+  execute: scopedEval,
+  getIframe,
+};

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -39,7 +39,6 @@ export type BabelState = LazyLoadedState & {
 export type PluginState = LazyLoadedState & {
   config: PluginConfig,
   isEnabled: boolean,
-  plugin: any,
 };
 
 export type PluginStateMap = { [name: string]: PluginState };


### PR DESCRIPTION
This is done so that helper methods like regeneratorRuntime are accessible as globals on the iframe's `contentWindow`.

While adding this feature, I discovered that Firefox behaves differently than Chrome and Safari when a new iframe is appended- it (asynchronously) loads "about:blank" and clobbers any (synchronously) appended script tags. So we also check the `iframe.contentDocument.readyState` before appending.

This has been tested on the following:

Browser | OS
:---|:---
Chrome | OSX
Firefox | OSX
Safari | OSX
Brave | Android
Safari | iOS

Resolves #1350