### PR TITLE
Removed transform-regenerator plugin from hard-coded transform options

### DIFF
--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -73,7 +73,6 @@ export default function compile(code: string, config: CompileConfig): Return {
       babelrc: false,
       filename: "repl",
       presets: config.presets,
-      plugins: ["transform-regenerator"],
       sourceMap: config.sourceMap,
     });
 


### PR DESCRIPTION
Resolves #1369 

I believe this change resolves the differences in behavior between classic and legacy Repl with regard to async functions.