### PR TITLE
Show compile error in console

### DIFF
--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -73,6 +73,8 @@ export default function compile(code: string, config: CompileConfig): Return {
       }
     }
   } catch (error) {
+    console.error(error);
+
     compiled = null;
     compileErrorMessage = error.message;
     envPresetDebugInfo = null;


### PR DESCRIPTION
While looking at https://github.com/babel/website/issues/1405, only the error message is displayed.

[Demo here (look console)](https://deploy-preview-1406--babel.netlify.com/repl/#?babili=true&browsers=&build=&builtIns=false&code_lz=IxA&debug=false&circleciRepo=&evaluate=false&lineWrap=true&presets=es2015%2Creact%2Cstage-2%2Cbabili&targets=&version=7.0.0-alpha.20)