### PR TITLE
Make area non-user-selectable

### DIFF
--- a/js/repl/AccordionTab.js
+++ b/js/repl/AccordionTab.js
@@ -45,6 +45,7 @@ const styles = {
     flex: "1 0 2.5rem",
     cursor: "default",
     borderBottom: `1px solid ${colors.inverseBackgroundDark}`,
+    userSelect: "none",
 
     [media.medium]: {
       borderRight: `1px solid ${colors.inverseBackgroundDark}`,


### PR DESCRIPTION
Double clicking the chevron cause text to be selected. I figured there's no good reason for this to be selectable anyway.

![screen shot 2017-10-05 at 6 43 44 pm](https://user-images.githubusercontent.com/6177621/31229316-e50330a6-a9fd-11e7-8638-25c852b0c224.png)
