### PR TITLE
generate package in presetPluginConfigs (fixes #1365)

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -78,10 +78,6 @@ const presetPluginConfigs: Array<PluginConfig> = [
   },
 ];
 
-presetPluginConfigs.forEach(config => {
-  config.package = `babel-preset-${config.label}`;
-});
-
 export {
   envPresetConfig,
   envPresetDefaults,

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -42,50 +42,45 @@ const pluginConfigs: Array<PluginConfig> = [
 const presetPluginConfigs: Array<PluginConfig> = [
   {
     label: "es2015",
-    package: "babel-preset-es2015",
     isPreLoaded: true,
   },
   {
     label: "es2015-loose",
-    package: "babel-preset-es2015-loose",
     isPreLoaded: true,
   },
   {
     label: "es2016",
-    package: "babel-preset-es2016",
     isPreLoaded: true,
   },
   {
     label: "es2017",
-    package: "babel-preset-es2017",
     isPreLoaded: true,
   },
   {
     label: "react",
-    package: "babel-preset-react",
     isPreLoaded: true,
   },
   {
     label: "stage-0",
-    package: "babel-preset-stage-0",
     isPreLoaded: true,
   },
   {
     label: "stage-1",
-    package: "babel-preset-stage-1",
     isPreLoaded: true,
   },
   {
     label: "stage-2",
-    package: "babel-preset-stage-2",
     isPreLoaded: true,
   },
   {
     label: "stage-3",
-    package: "babel-preset-stage-3",
     isPreLoaded: true,
   },
 ];
+
+presetPluginConfigs.forEach(config => {
+  config.package = `babel-preset-${config.label}`;
+});
 
 export {
   envPresetConfig,

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -378,7 +378,6 @@ const PluginToggle = ({
   </label>
 );
 
-
 // Defined separately from styles due to nesting.
 const nestedCloseButton = css({});
 

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -132,9 +132,9 @@ class ExpandedContainer extends Component {
             {presetPluginConfigs.map(config => (
               <PluginToggle
                 config={config}
-                key={config.package}
+                key={config.label}
                 onSettingChange={onSettingChange}
-                state={presetState[config.package]}
+                state={presetState[config.label]}
               />
             ))}
           </AccordionTab>
@@ -365,18 +365,19 @@ const PluginToggle = ({
   state,
   onSettingChange,
 }: PluginToggleProps) => (
-  <label key={config.package} className={styles.settingsLabel}>
+  <label key={config.label} className={styles.settingsLabel}>
     <input
       checked={state.isEnabled && !state.didError}
       className={styles.inputCheckboxLeft}
       disabled={state.isLoading || state.didError}
       onChange={(event: SyntheticInputEvent) =>
-        onSettingChange(config.package, event.target.checked)}
+        onSettingChange(config.label, event.target.checked)}
       type="checkbox"
     />
     {state.isLoading ? <PresetLoadingAnimation /> : label || config.label}
   </label>
-);
+  );
+
 
 // Defined separately from styles due to nesting.
 const nestedCloseButton = css({});

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -376,7 +376,7 @@ const PluginToggle = ({
     />
     {state.isLoading ? <PresetLoadingAnimation /> : label || config.label}
   </label>
-  );
+);
 
 
 // Defined separately from styles due to nesting.

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -75,9 +75,9 @@ export const configArrayToStateMap = (
   defaults: DefaultPlugins = {}
 ): PluginStateMap =>
   pluginConfigs.reduce((reduced, config) => {
-    reduced[config.package] = configToState(
+    reduced[config.package || config.label] = configToState(
       config,
-      defaults[config.package] === true
+      defaults[config.package || config.label] === true
     );
     return reduced;
   }, {});

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -17,7 +17,7 @@ export type PluginConfig = {
   baseUrl?: string,
   isPreLoaded?: boolean,
   label: string,
-  package: string,
+  package?: string,
   version?: string,
 };
 


### PR DESCRIPTION
The issue presented in #1365 asks to delete the package key from `presetPluginConfigs`

@Daniel15 
I'm not sure if that was the exact task to be done or if there is something more here. Checking `js/repl/ReplOptions.js`, it looks like the presetPluginConfig needs the package key in order for http://babeljs.io/repl/# page to handle its state.

Currently I just deleted the hardcoded package key and generated after the object is created, so that the `package` key is still used in `ReplOptions.js`

Happy to help on the issue in any way I can :)