### PR TITLE
Changed NODE_ENV to BABEL_ENV in .babelrc.md

### DIFF
--- a/docs/usage/babelrc.md
+++ b/docs/usage/babelrc.md
@@ -65,7 +65,7 @@ BABEL_ENV=production YOUR_COMMAND_HERE
 Or as a separate command:
 
 ```sh
-export NODE_ENV=production
+export BABEL_ENV=production
 ```
 
 ```sh


### PR DESCRIPTION
The `BABEL_ENV` env variable was mistakenly written as `NODE_ENV` in the babelrc.md doc file.