### PR TITLE
Add AST panel to repl

### DIFF
--- a/js/repl/CodeMirror.js
+++ b/js/repl/CodeMirror.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { css } from "emotion";
 import { injectGlobal } from "emotion";
 import CodeMirror from "codemirror";
 import React from "react";
@@ -39,22 +40,27 @@ export default class ReactCodeMirror extends React.Component {
   };
 
   _codeMirror: any;
-  _textAreaRef: HTMLTextAreaElement;
+  _container: HTMLDivElement;
+
+  shouldComponentUpdate() {
+    return false;
+  }
 
   componentDidMount() {
-    this._codeMirror = CodeMirror.fromTextArea(this._textAreaRef, {
+    this._codeMirror = CodeMirror(this._container, {
+      value: this.props.value || "",
+      placeholder: this.props.placeholder,
+      autofocus: this.props.autoFocus,
       ...DEFAULT_CODE_MIRROR_OPTIONS,
       ...this.props.options,
     });
     this._codeMirror.on("change", this._onChange);
-    this._codeMirror.setValue(this.props.value || "");
   }
 
   componentWillUnmount() {
-    // is there a lighter-weight way to remove the cm instance?
-    if (this._codeMirror) {
-      this._codeMirror.toTextArea();
-    }
+    const container = this._container;
+    container.removeChild(container.children[0]);
+    this._codeMirror = null;
   }
 
   componentWillReceiveProps(nextProps: Props) {
@@ -93,15 +99,7 @@ export default class ReactCodeMirror extends React.Component {
   }
 
   render() {
-    return (
-      <textarea
-        autoComplete="off"
-        autoFocus={this.props.autoFocus}
-        defaultValue={this.props.value}
-        ref={this._setTextAreaRef}
-        placeholder={this.props.placeholder}
-      />
-    );
+    return <div className={styles.editor} ref={c => (this._container = c)} />;
   }
 
   _updateOption(optionName: string, newValue: any) {
@@ -117,11 +115,18 @@ export default class ReactCodeMirror extends React.Component {
       this.props.onChange(doc.getValue());
     }
   };
-
-  _setTextAreaRef = (ref: HTMLTextAreaElement) => {
-    this._textAreaRef = ref;
-  };
 }
+
+const styles = {
+  editor: css({
+    overflow: "auto",
+    position: "absolute",
+    top: "0",
+    left: "0",
+    right: "0",
+    bottom: "0",
+  }),
+};
 
 injectGlobal({
   ".CodeMirror": {

--- a/js/repl/CodeMirrorPanel.js
+++ b/js/repl/CodeMirrorPanel.js
@@ -6,6 +6,7 @@ import React from "react";
 import { colors } from "./styles";
 
 type Props = {
+  autoFocus?: boolean,
   className?: string,
   code: ?string,
   errorMessage: ?string,
@@ -16,13 +17,14 @@ type Props = {
 };
 
 export default function CodeMirrorPanel(props: Props) {
-  const { className = "", errorMessage, info, onChange } = props;
+  const { autoFocus, className = "", errorMessage, info, onChange } = props;
 
   return (
     <div className={`${styles.panel} ${className}`}>
       <div className={styles.codeMirror}>
         <CodeMirror
           onChange={onChange}
+          autoFocus={autoFocus}
           options={{
             ...props.options,
             readOnly: onChange == null,
@@ -54,6 +56,7 @@ const styles = {
     height: "100%",
     width: "100%",
     overflow: "auto",
+    position: "relative",
   }),
   error: css({
     order: 2,
@@ -70,10 +73,8 @@ const styles = {
     ...sharedBoxStyles,
   }),
   panel: css({
-    height: "100%",
     display: "flex",
     flexDirection: "column",
     justifyContent: "stretch",
-    overflow: "auto",
   }),
 };

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -35,6 +35,8 @@ type ToggleSetting = (name: string, isEnabled: boolean) => void;
 type OnTabExpandedChange = (name: string, isExpanded: boolean) => void;
 
 type Props = {
+  astLocations: boolean,
+  astTokens: boolean,
   babelVersion: ?string,
   builtIns: boolean,
   className: string,
@@ -45,7 +47,10 @@ type Props = {
   isExpanded: boolean,
   isPresetsTabExpanded: boolean,
   isSettingsTabExpanded: boolean,
+  isOutputTabExpanded: boolean,
   lineWrap: boolean,
+  outputAST: boolean,
+  outputCode: boolean,
   onEnvPresetSettingChange: ToggleEnvPresetSetting,
   onIsExpandedChange: ToggleExpanded,
   onSettingChange: ToggleSetting,
@@ -80,6 +85,8 @@ class ExpandedContainer extends Component {
 
   render() {
     const {
+      astLocations,
+      astTokens,
       babelVersion,
       builtIns,
       debugEnvPreset,
@@ -88,11 +95,14 @@ class ExpandedContainer extends Component {
       isEnvPresetTabExpanded,
       isPresetsTabExpanded,
       isSettingsTabExpanded,
+      isOutputTabExpanded,
       lineWrap,
       onIsExpandedChange,
       onSettingChange,
       pluginState,
       presetState,
+      outputCode,
+      outputAST,
       runtimePolyfillConfig,
       runtimePolyfillState,
     } = this.props;
@@ -132,6 +142,55 @@ class ExpandedContainer extends Component {
                 state={pluginState[config.package]}
               />
             ))}
+          </AccordionTab>
+          <AccordionTab
+            className={styles.section}
+            isExpanded={isOutputTabExpanded}
+            label="Output"
+            toggleIsExpanded={this._toggleOutputTab}
+          >
+            <label className={styles.settingsLabel}>
+              <input
+                checked={outputCode}
+                onChange={this._onOutputChange}
+                className={styles.inputCheckboxLeft}
+                name="output"
+                value="code"
+                type="radio"
+              />
+              Source Code
+            </label>
+            <label className={styles.settingsLabel}>
+              <input
+                checked={outputAST}
+                onChange={this._onOutputChange}
+                className={styles.inputCheckboxLeft}
+                name="output"
+                value="ast"
+                type="radio"
+              />
+              AST
+            </label>
+            <label className={styles.settingsLabel}>
+              <input
+                checked={astLocations}
+                onChange={this._onAstLocationsChange}
+                className={styles.inputCheckboxLeft}
+                disabled={!outputAST}
+                type="checkbox"
+              />
+              Locations
+            </label>
+            <label className={styles.settingsLabel}>
+              <input
+                checked={astTokens}
+                onChange={this._onAstTokensChange}
+                className={styles.inputCheckboxLeft}
+                disabled={!outputAST}
+                type="checkbox"
+              />
+              Tokens
+            </label>
           </AccordionTab>
           <AccordionTab
             className={styles.section}
@@ -307,6 +366,11 @@ class ExpandedContainer extends Component {
     );
   };
 
+  _onOutputChange = (event: SyntheticInputEvent) => {
+    this.props.onSettingChange("outputCode", event.target.value === "code");
+    this.props.onSettingChange("outputAST", event.target.value === "ast");
+  };
+
   _onIsElectronEnabledChange = (event: SyntheticInputEvent) => {
     this.props.onEnvPresetSettingChange(
       "isElectronEnabled",
@@ -320,6 +384,14 @@ class ExpandedContainer extends Component {
 
   _onLineWrappingChange = (event: SyntheticInputEvent) => {
     this.props.onSettingChange("lineWrap", event.target.checked);
+  };
+
+  _onAstTokensChange = (event: SyntheticInputEvent) => {
+    this.props.onSettingChange("astTokens", event.target.checked);
+  };
+
+  _onAstLocationsChange = (event: SyntheticInputEvent) => {
+    this.props.onSettingChange("astLocations", event.target.checked);
   };
 
   _onNodeChange = (event: SyntheticInputEvent) => {
@@ -344,6 +416,13 @@ class ExpandedContainer extends Component {
     this.props.onTabExpandedChange(
       "isSettingsTabExpanded",
       !this.props.isSettingsTabExpanded
+    );
+  };
+
+  _toggleOutputTab = () => {
+    this.props.onTabExpandedChange(
+      "isOutputTabExpanded",
+      !this.props.isOutputTabExpanded
     );
   };
 }

--- a/js/repl/UriUtils.js
+++ b/js/repl/UriUtils.js
@@ -5,6 +5,8 @@ import LZString from "lz-string";
 import type { PersistedState } from "./types";
 
 const URL_KEYS = [
+  "astLocations",
+  "astTokens",
   "babili",
   "browsers",
   "build",
@@ -14,6 +16,8 @@ const URL_KEYS = [
   "circleciRepo",
   "evaluate",
   "lineWrap",
+  "outputAST",
+  "outputCode",
   "presets",
   "prettier",
   "targets",

--- a/js/repl/WorkerApi.js
+++ b/js/repl/WorkerApi.js
@@ -34,7 +34,14 @@ export default class WorkerApi {
         config,
       })
       .then(
-        ({ compiled, compileErrorMessage, envPresetDebugInfo, sourceMap }) => {
+        ({
+          compiled,
+          ast,
+          transformTime,
+          compileErrorMessage,
+          envPresetDebugInfo,
+          sourceMap,
+        }) => {
           let evalErrorMessage = null;
 
           // Compilation is done in a web worker for performance reasons,
@@ -49,6 +56,8 @@ export default class WorkerApi {
 
           return {
             compiled,
+            ast,
+            transformTime,
             compileErrorMessage,
             envPresetDebugInfo,
             evalErrorMessage,

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -38,6 +38,8 @@ export const loadPersistedState = (): PersistedState => {
   };
 
   return {
+    astLocations: merged.astLocations != null ? merged.astLocations : false,
+    astTokens: merged.astTokens != null ? merged.astTokens : false,
     babili: merged.babili === true,
     browsers: merged.browsers || "",
     build: merged.build || "",
@@ -47,9 +49,12 @@ export const loadPersistedState = (): PersistedState => {
     debug: merged.debug === true,
     evaluate: merged.evaluate === true,
     isEnvPresetTabExpanded: merged.isEnvPresetTabExpanded === true,
+    isOutputTabExpanded: merged.isOutputTabExpanded === true,
     isPresetsTabExpanded: merged.isPresetsTabExpanded === true,
     isSettingsTabExpanded: merged.isSettingsTabExpanded !== false, // Default to show
     lineWrap: merged.lineWrap != null ? merged.lineWrap : true,
+    outputAST: merged.outputAST != null ? merged.outputAST : false,
+    outputCode: merged.outputCode != null ? merged.outputCode : true,
     presets: merged.hasOwnProperty("presets") ? merged.presets : null,
     prettier: merged.prettier === true,
     showSidebar: merged.showSidebar !== false, // Default to show

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -45,6 +45,8 @@ export type PluginState = LazyLoadedState & {
 export type PluginStateMap = { [name: string]: PluginState };
 
 export type CompileConfig = {
+  astLocations: boolean,
+  astTokens: boolean,
   debugEnvPreset: boolean,
   envConfig: ?EnvConfig,
   evaluate: boolean,
@@ -55,6 +57,8 @@ export type CompileConfig = {
 };
 
 export type PersistedState = {
+  astLocations: boolean,
+  astTokens: boolean,
   babili: boolean,
   browsers: string,
   build: string,
@@ -64,9 +68,12 @@ export type PersistedState = {
   debug: boolean,
   evaluate: boolean,
   isEnvPresetTabExpanded: boolean,
+  isOutputTabExpanded: boolean,
   isPresetsTabExpanded: boolean,
   isSettingsTabExpanded: boolean,
   lineWrap: boolean,
+  outputAST: boolean,
+  outputCode: boolean,
   presets: ?string,
   prettier: boolean,
   showSidebar: boolean,

--- a/repl.html
+++ b/repl.html
@@ -11,6 +11,9 @@ third_party_js:
 - https://unpkg.com/codemirror@5.30.0/mode/xml/xml.js
 - https://unpkg.com/codemirror@5.30.0/mode/jsx/jsx.js
 - https://unpkg.com/codemirror@5.30.0/keymap/sublime.js
+- https://unpkg.com/codemirror@5.30.0/addon/fold/foldcode.js
+- https://unpkg.com/codemirror@5.30.0/addon/fold/foldgutter.js
+- https://unpkg.com/codemirror@5.30.0/addon/fold/brace-fold.js
 - https://unpkg.com/codemirror@5.30.0/addon/comment/comment.js
 - https://unpkg.com/codemirror@5.30.0/addon/display/placeholder.js
 - https://unpkg.com/codemirror@5.30.0/addon/edit/matchbrackets.js
@@ -22,6 +25,7 @@ webpack_js:
 - repl
 ---
 <link rel="stylesheet" href="https://unpkg.com/codemirror@5.30.0/lib/codemirror.css">
+<link rel="stylesheet" href="https://unpkg.com/codemirror@5.30.0/addon/fold/foldgutter.css">
 
 <noscript>You need to enable JavaScript to run this app.</noscript>
 


### PR DESCRIPTION
This adds tabs to switch between babel output and AST.

I fixed also an issue, that an empty source was still compiled. I changed it to skip compilation if source is empty.

I had to change how the codemirror is rendered because of performance issues. The AST output can be quite large and it took 5 seconds to switch tabs. With the change from `textarea` to `div` and positioning the div absolute it is instant. (I found this behaviour on astexplorer)

There is one bug still, that I haven't figured out yet. In mobile when the options are uncollapsed and then get collapsed the editor is not using the complete height.

Design wise I am open to suggestions, I'm really not good with making design choices :)

<img width="1006" alt="bildschirmfoto 2017-10-15 um 12 36 28" src="https://user-images.githubusercontent.com/231804/31583989-8ab99a36-b1a5-11e7-85fd-81c32dd3b6a7.png">
