### PR TITLE
Update mocha `--compiler` deprecation syntax

### DIFF
--- a/_includes/tools/mocha/usage.md
+++ b/_includes/tools/mocha/usage.md
@@ -1,3 +1,9 @@
+#### Mocha 4
+
+Updated in Mocha v4.0.0
+
+`--compilers` is deprecated as of Mocha v4.0.0. See [further explanation and workarounds](https://github.com/mochajs/mocha/wiki/compilers-deprecation).
+
 In your `package.json` file make the following changes:
 
 ```json
@@ -18,6 +24,26 @@ npm install --save-dev babel-polyfill
 {
   "scripts": {
     "test": "mocha --require babel-polyfill babel-register"
+  }
+}
+```
+
+#### Mocha 3
+
+
+```json
+{
+  "scripts": {
+    "test": "mocha --compilers js:babel-register"
+  }
+}
+
+with polyfill
+
+```json
+{
+  "scripts": {
+    "test": "mocha --require babel-polyfill --compilers js:babel-register"
   }
 }
 ```

--- a/_includes/tools/mocha/usage.md
+++ b/_includes/tools/mocha/usage.md
@@ -1,7 +1,5 @@
 #### Mocha 4
 
-Updated in Mocha v4.0.0
-
 `--compilers` is deprecated as of Mocha v4.0.0. See [further explanation and workarounds](https://github.com/mochajs/mocha/wiki/compilers-deprecation).
 
 In your `package.json` file make the following changes:

--- a/_includes/tools/mocha/usage.md
+++ b/_includes/tools/mocha/usage.md
@@ -3,7 +3,7 @@ In your `package.json` file make the following changes:
 ```json
 {
   "scripts": {
-    "test": "mocha --compilers js:babel-register"
+    "test": "mocha --require babel-register"
   }
 }
 ```
@@ -17,7 +17,7 @@ npm install --save-dev babel-polyfill
 ```json
 {
   "scripts": {
-    "test": "mocha --require babel-polyfill --compilers js:babel-register"
+    "test": "mocha --require babel-polyfill babel-register"
   }
 }
 ```

--- a/_includes/tools/mocha/usage.md
+++ b/_includes/tools/mocha/usage.md
@@ -37,8 +37,9 @@ npm install --save-dev babel-polyfill
     "test": "mocha --compilers js:babel-register"
   }
 }
+```
 
-with polyfill
+With polyfill:
 
 ```json
 {


### PR DESCRIPTION
https://github.com/mochajs/mocha/wiki/compilers-deprecation
Mocha will deprecate `--compiler` syntax