### PR TITLE
Map /build/7.0 to master in REPL

### DIFF
--- a/js/repl/loadBabel.js
+++ b/js/repl/loadBabel.js
@@ -45,10 +45,14 @@ export default async function loadBabel(
     try {
       if (!isBuildNumeric) {
         // Build in URL is *not* numeric, assume it's a branch name
-        // Get the latest build number for this branch
+        // Get the latest build number for this branch.
+        //
+        // NOTE:
+        // Since we switched the 7.0 branch to master, we map /build/7.0 to
+        // /build/master for backwards compatibility.
         build = await loadLatestBuildNumberForBranch(
           config.circleciRepo,
-          build
+          build === "7.0" ? "master" : build
         );
       }
       const url = await loadBuildArtifacts(config.circleciRepo, build, doLoad);


### PR DESCRIPTION
Fixes using the REPL with the latest v7 build, since the 7.0 branch is now master.

Right now, http://babeljs.io/repl/build/7.0 is mapping to circle's last known `7.0` branch build ([v7.0.0-alpha.20](https://circleci.com/gh/babel/babel/tree/7.0)).

Now:
https://deploy-preview-1426--babel.netlify.com/repl/build/7.0