### PR TITLE
Fix edit links

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -30,7 +30,7 @@ layout: default
             &nbsp; · &nbsp;
             <a href="{{source}}/blob/master{{packageReadme}}/README.md">Edit this page</a>
           {% else %}
-            <a href="https://github.com/babel/babel.github.io/blob/master/{{page.path}}">Edit this page</a>
+            <a href="https://github.com/babel/website/blob/master/{{page.path}}">Edit this page</a>
           {% endif %}
         </p>
       </div>


### PR DESCRIPTION
Since we changed the repo name the edit links doesn't work anymore.