### PR TITLE
Remove mention of babel-plugin-undeclared-variables-check

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -184,7 +184,6 @@ These plugins are in the minify repo.
 ## Misc Plugins
 
 - [external-helpers](/docs/plugins/external-helpers/)
-- [undeclared-variables-check](/docs/plugins/undeclared-variables-check/)
 
 ## Syntax Plugins
 


### PR DESCRIPTION
It doesn't work properly, so remove mention of this plugin.

For example, it results in the following error:
```
    ERROR in ./demo/react/main.jsx
    Module build failed: BabelLoaderError: /home/ubuntu/workspace/demo/react/main.jsx: Reference to undeclared variable "props"
    
      11 | class Demo extends Component { 
      12 |     constructor(props) {
    > 13 |         super(props)
         |               ^
      14 |         this.state = {
```