### PR TITLE
Update FAQ, babel-preset-es2015 → babel-preset-env

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -63,12 +63,12 @@ get all the same transforms that were in Babel 5:
 
 ```json
 {
-  "presets": ["es2015", "react", "stage-2"]
+  "presets": ["env", "react", "stage-2"]
 }
 ```
 
 ```sh
-npm install babel-preset-es2015 babel-preset-react babel-preset-stage-2 --save-dev
+npm install babel-preset-env babel-preset-react babel-preset-stage-2 --save-dev
 ```
 
 Also check out our [Setting up Babel 6](http://babeljs.io/blog/2015/10/31/setting-up-babel-6) blog post.


### PR DESCRIPTION
As far as I understand [babel-preset-es2015 is deprecated](http://babeljs.io/env), so we should not mention installing it anywhere in the docs. Please let me know if I'm misunderstanding :)