### PR TITLE
Use HTTPS for member links to Twitter/GitHub

### DIFF
--- a/_includes/member.html
+++ b/_includes/member.html
@@ -2,13 +2,13 @@
   <h3 class="team__name">{{ include.title }}</h3>
   {% for member in include.members %}
     <div class="col-md-3 col-sm-4 col-xs-12 team__member">
-      <img class="member__image" alt="{{member.name}}" src="//avatars.githubusercontent.com/{{member.github}}" />
+      <img class="member__image" alt="{{member.name}}" src="https://avatars.githubusercontent.com/{{member.github}}" />
         <p class="member__name">{{ member.name }}</p>
         {% if member.github %}
-          <p>{% include icons/github.svg %}<a href="//www.github.com/{{member.github}}" target="_blank">{{member.github}}</a></p>
+          <p>{% include icons/github.svg %}<a href="https://github.com/{{member.github}}" target="_blank">{{member.github}}</a></p>
         {% endif %}
         {% if member.twitter %}
-          <p>{% include icons/twitter.svg %}<a href="//www.twitter.com/{{member.twitter}}" target="_blank">{{member.twitter}}</a></p>
+          <p>{% include icons/twitter.svg %}<a href="https://twitter.com/{{member.twitter}}" target="_blank">{{member.twitter}}</a></p>
         {% endif %}
     </div>
   {% endfor %}


### PR DESCRIPTION
Protocol-relative URLs are an antipattern. https://github.com/konklone/cdns-to-https#background

This patch also avoids a redirect from e.g. www.twitter.com → twitter.com.
