### PR TITLE
7.0 updates

### DIFF
--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -18,6 +18,10 @@ TL;DR is use `babel-preset-env` instead.
 
 What's better than having to decide for your what babel preset/plugin to use is if it was done for you, automatically. Although the amount of work that goes into maintaining the lists of data is humogous, it solves multiple issues: keeping users up to date with the spec, less configuration/package confusion, easier upgrade path, less issues about what is what. 
 
+### Not removing Stage presets (babel-preset-stage-x)
+
+https://twitter.com/left_pad/status/873242704364306433
+
 ### Scoped Packages (`@babel/x`)
 
 Alright we only just changed every single package for Babel again 😂..

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -10,7 +10,42 @@ share_text: "Nearing the 7.0 Release"
 
 > Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7) post for information up til the first beta release!
 
-# didn't start writing anything yet, so feel free to edit
+# Just started writing, so feel free to edit
+
+### Deprecate ES20xx presets
+
+> We already deprecated preset-latest a while ago, and ES2016/ES2017 [earlier](https://twitter.com/left_pad/status/897483806499885057)
+> It's annoying making a yearly preset (extra package/dependency, issues with npm package squatting unless we do scoped packages)
+
+Developers shouldn't even need to make the decision of what yearly preset to use? If we drop/deprecate these presets then everyone can use [babel-preset-env](https://github.com/babel/babel-preset-env) instead which will already update as the spec changes.
+
+### Scoped Packages (`@babel/x`)
+
+Alright we only just changed every single package for Babel again 😂..
+
+Here's a poll I did almost a year ago:
+
+<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Thoughts on <a href="https://twitter.com/babeljs">@babeljs</a> using npm scoped packages for 7.0?</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/821551189166878722">January 18, 2017</a></blockquote>
+<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+Back then, there weren't a lot of projects using scoped packages so most people didn't even know they existed. I believe you also had to pay for a npm org account while now it's free (and supports non scoped packages too). The issues with searching for scoped packages are solved and download counts work. The only thing left is that some 3rd party registries still don't support scoped. I think we are at a point where it seems pretty unreasonable to wait on that, and maybe moving Babel itself to a scoped namespace will push that effort forward anyway?
+
+Since people will complain/wonder why we are doing this:
+
+- Naming is difficult: we don't have to check if someone else decided to use our naming convention for their own plugin
+- Similarly, package squatting. Sometimes people will create `babel-preset-20xx` or some other package because it's funny and then we have to make an issue/email them to ask for it back.
+- What is an "official" package and what is a user/community package with the same name. We can get issue reports of people using misnamed or unofficial packages because they assumed it was part of Babel. One example of this was a report that `babel-env` was rewriting their `.babelrc` file, and it took a while to realize they thought it was `babel-preset-env`.
+
+So it seems obvious we should do this, and if anything should of done it much earlier 🙂!
+
+Examples of the scoped name change:
+
+`babel-cli` -> `@babel/cli`
+`babel-core` -> `@babel/core`
+`babel-preset-es2015` -> `@babel/preset-es2015` (this is deprecated though, so use preset-env)
+`babel-preset-env` -> `@babel/preset-env`
+
+### TC39 Proposal Plugins (what isn't JS yet)
 
 ### Integrations
 
@@ -43,36 +78,7 @@ Say you are using preset-env (which keeps up to date and currently includes ever
 
 If the spec to an experimental proposal changes, we should be free to make a breaking change and make a major version bump for that plugin only. Because it only affects that plugin, it doesn't affect anything else and people are free to update when possible. We just want to make sure that users update to the latest version of any experimental proposal when possible and provide the tools to do so automatically if that is reasonable as well.
 
-### TODOs?
+### Release Process
 
 > I believe the way we want to go about doing this is to move those packages into the `experimental/` folder in our [monorepo](https://github.com/babel/babel) instead of in `packages/`.
-> Then we should rename all proposals to `babel-plugin-proposal-` instead of `babel-plugin-transform-`
 > Change our publish process (probably through Lerna) to publish the packages in `experimental/` independently.
-
-### Deprecate ES20xx presets
-
-> We already deprecated preset-latest a while ago, and ES2016/ES2017 [earlier](https://twitter.com/left_pad/status/897483806499885057)
-> It's annoying making a yearly preset (extra package/dependency, issues with npm package squatting unless we do scoped packages)
-
-Developers shouldn't even need to make the decision of what yearly preset to use? If we drop/deprecate these presets then everyone can use [babel-preset-env](https://github.com/babel/babel-preset-env) instead which will already update as the spec changes.
-
-### Using npm Scoped Packages
-
-<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Thoughts on <a href="https://twitter.com/babeljs">@babeljs</a> using npm scoped packages for 7.0?</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/821551189166878722">January 18, 2017</a></blockquote>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-Seems like most who understood what scoped packages are were in favor?
-
-Pros
-
-- Don't have to worry about getting a certain package name (the reason why this was brought up in the first place).
-
-> Many package names have been taken (preset-es2016, preset-es2017, 2020, 2040, etc). Can always ask to transfer but not always easy to do and can lead to users believing certain packages are official due to the naming.
-
-Cons
-
-- We need to migrate to new syntax
-- Still unsupported on certain non-npm tools (lock-in)
-- No download counts unless we alias back to old names
-
-Sounds like we may want to defer, and in the very least it's not a breaking change given it's a name change.

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -12,12 +12,11 @@ share_text: "Nearing the 7.0 Release"
 
 # Just started writing, so feel free to edit
 
-### Deprecate ES20xx presets
+### Deprecate yearly presets (babel-preset-es20xx)
 
-> We already deprecated preset-latest a while ago, and ES2016/ES2017 [earlier](https://twitter.com/left_pad/status/897483806499885057)
-> It's annoying making a yearly preset (extra package/dependency, issues with npm package squatting unless we do scoped packages)
+TL;DR is use `babel-preset-env` instead.
 
-Developers shouldn't even need to make the decision of what yearly preset to use? If we drop/deprecate these presets then everyone can use [babel-preset-env](https://github.com/babel/babel-preset-env) instead which will already update as the spec changes.
+What's better than having to decide for your what babel preset/plugin to use is if it was done for you, automatically. Although the amount of work that goes into maintaining the lists of data is humogous, it solves multiple issues: keeping users up to date with the spec, less configuration/package confusion, easier upgrade path, less issues about what is what. 
 
 ### Scoped Packages (`@babel/x`)
 
@@ -33,7 +32,10 @@ Back then, there weren't a lot of projects using scoped packages so most people 
 Since people will complain/wonder why we are doing this:
 
 - Naming is difficult: we don't have to check if someone else decided to use our naming convention for their own plugin
-- Similarly, package squatting. Sometimes people will create `babel-preset-20xx` or some other package because it's funny and then we have to make an issue/email them to ask for it back.
+- Similarly, package squatting
+  - Sometimes people will create `babel-preset-20xx` or some other package we will use because it's funny and then we have to make an issue/email them to ask for it back.
+  - People have a legit package but it happens to be the same name as what we wanted to call it.
+  - People see that a new proposal is merge (optional chaining, pipeline operator) and decide to fork and publish a version of it under the same name so that when we publish it errors saying it was already published 🤔. Then I had to find their email and email both them and npm support to get the package back and republish.
 - What is an "official" package and what is a user/community package with the same name. We can get issue reports of people using misnamed or unofficial packages because they assumed it was part of Babel. One example of this was a report that `babel-env` was rewriting their `.babelrc` file, and it took a while to realize they thought it was `babel-preset-env`.
 
 So it seems obvious we should do this, and if anything should of done it much earlier 🙂!

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -10,9 +10,16 @@ share_text: "Nearing the 7.0 Release"
 
 > Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7) post for information up til the first beta release!
 
-# Just started writing, so feel free to edit
+## Project Updates
 
-### Deprecate yearly presets (babel-preset-es20xx)
+- We started a new [videos page](https://babeljs.io/docs/community/videos/)! Wanted to create this to provide a resource for people wanting to contribute to Babel.
+- We created a new [team page](https://babeljs.io/team)! I think we'll want to update this with more of what people work on and why they are involved!
+- Babel turned three years old on [Sept 28](https://babeljs.io/blog/2017/10/05/babel-turns-three)!
+- Daniel [moved](https://twitter.com/left_pad/status/926096965565370369) `babel/babylon` and `babel/babel-preset-env` into the main Babel monorepo: [babel/babel](https://github.com/babel/babel), including everything from git history, labels, issues.
+- We received a [$1k/month donation](https://twitter.com/left_pad/status/923696620935421953) from Facebook Open Source!
+  - We're looking to be able to fund our team full-time, but in the meantime will use our funds for sending people to TC39 meetings (every 2 months around the world). If someone wants to sponsor specifically for that we can create separate issues to track that so there are concrete/specific things a company can donate for.
+
+### Deprecated yearly presets (babel-preset-es20xx)
 
 TL;DR is use `babel-preset-env` instead.
 

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -38,9 +38,9 @@ Here's a poll I did almost a year ago:
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Thoughts on <a href="https://twitter.com/babeljs">@babeljs</a> using npm scoped packages for 7.0?</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/821551189166878722">January 18, 2017</a></blockquote>
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-Back then, there weren't a lot of projects using scoped packages so most people didn't even know they existed. I believe you also had to pay for a npm org account while now it's free (and supports non scoped packages too). The issues with searching for scoped packages are solved and download counts work. The only thing left is that some 3rd party registries still don't support scoped. I think we are at a point where it seems pretty unreasonable to wait on that, and maybe moving Babel itself to a scoped namespace will push that effort forward anyway?
+Back then, there weren't a lot of projects using scoped packages so most people didn't even know they existed. I believe you also had to pay for a npm org account while now it's free (and supports non scoped packages too). The issues with searching for scoped packages are solved and download counts work. The only thing left is that some 3rd party registries still don't support scoped. I think we are at a point where it seems pretty unreasonable to wait on that.
 
-Since people will complain/wonder why we are doing this:
+If you want reasons why:
 
 - Naming is difficult: we don't have to check if someone else decided to use our naming convention for their own plugin
 - Similarly, package squatting

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title:  "Nearing the 7.0 Release"
+author: Henry Zhu
+author_url: "https://twitter.com/left_pad"
+date:   2017-11-03 12:00:00
+categories: announcements
+share_text: "Nearing the 7.0 Release"
+---
+
+> Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7) post for information up til the first beta release!
+
+### Integrations
+
+Packages like `grunt-babel`, `gulp-babel`, `rollup-plugin-babel`, etc all used to have `babel-core` as a dependency.
+
+After v7, we plan to move `babel-core` to be a peerDependency like `babel-loader` has. This lets all these packages not have to bump major versions when the `babel-core` API hasn't changed. Thus they are already published as `7.0.0` since we don't expect any further changes to those packages.
+
+### [#5224](https://github.com/babel/babel/pull/5224) Independent Publishing of Experimental Packages
+
+> I mention this in [The State of Babel](http://babeljs.io/blog/2016/12/07/the-state-of-babel) in the `Versioning` section. [Github Issue](https://github.com/babel/babylon/issues/275)
+
+You might remember that after Babel 6, Babel became a set of npm packages with its own ecosystem of custom presets and plugins.
+
+However since then, we've always used a "fixed/synchronized" versioning system (so that no package is on v7.0 or above). When we do a new release such as `v6.23.0` only packages that have updated code in the source are published with the new version while the rest of the packages are left as is. This mostly works in practice because we use `^` in our packages.
+
+Unfortunately this kind of system requires that a major version be released for all packages once a single package needs it. This either means we make a lot small breaking changes (unnecessary) or we batch lots of breaking changes into a single release. Instead, we want to differentiate between the experimental packages (Stage 0, etc) and everything else (es2015).
+
+This means that we intend to make major version bumps to any experimental proposal plugins when the spec changes rather than waiting to update all of Babel. So anything that is < Stage 4 would be open to breaking changes in the form of major version bumps and same with the Stage presets themselves if we don't drop them entirely.
+
+For example:
+
+Say you are using preset-env (which keeps up to date and currently includes everything in es2015, es2016, es2017) + an experimental plugin. You also decide to use object-rest-spread because it's cool.
+
+```json
+{
+  "presets": ["env"],
+  "plugins": ["transform-object-rest-spread"]
+}
+```
+
+If the spec to an experimental proposal changes, we should be free to make a breaking change and make a major version bump for that plugin only. Because it only affects that plugin, it doesn't affect anything else and people are free to update when possible. We just want to make sure that users update to the latest version of any experimental proposal when possible and provide the tools to do so automatically if that is reasonable as well.
+
+### TODOs?
+
+> I believe the way we want to go about doing this is to move those packages into the `experimental/` folder in our [monorepo](https://github.com/babel/babel) instead of in `packages/`.
+> Then we should rename all proposals to `babel-plugin-proposal-` instead of `babel-plugin-transform-`
+> Change our publish process (probably through Lerna) to publish the packages in `experimental/` independently.
+
+### Deprecate ES20xx presets
+
+> We already deprecated preset-latest a while ago, and ES2016/ES2017 [earlier](https://twitter.com/left_pad/status/897483806499885057)
+> It's annoying making a yearly preset (extra package/dependency, issues with npm package squatting unless we do scoped packages)
+
+Developers shouldn't even need to make the decision of what yearly preset to use? If we drop/deprecate these presets then everyone can use [babel-preset-env](https://github.com/babel/babel-preset-env) instead which will already update as the spec changes.
+
+### Using npm Scoped Packages
+
+<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Thoughts on <a href="https://twitter.com/babeljs">@babeljs</a> using npm scoped packages for 7.0?</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/821551189166878722">January 18, 2017</a></blockquote>
+<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+Seems like most who understood what scoped packages are were in favor?
+
+Pros
+
+- Don't have to worry about getting a certain package name (the reason why this was brought up in the first place).
+
+> Many package names have been taken (preset-es2016, preset-es2017, 2020, 2040, etc). Can always ask to transfer but not always easy to do and can lead to users believing certain packages are official due to the naming.
+
+Cons
+
+- We need to migrate to new syntax
+- Still unsupported on certain non-npm tools (lock-in)
+- No download counts unless we alias back to old names
+
+Sounds like we may want to defer, and in the very least it's not a breaking change given it's a name change.

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -10,6 +10,8 @@ share_text: "Nearing the 7.0 Release"
 
 > Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7) post for information up til the first beta release!
 
+# didn't start writing anything yet, so feel free to edit
+
 ### Integrations
 
 Packages like `grunt-babel`, `gulp-babel`, `rollup-plugin-babel`, etc all used to have `babel-core` as a dependency.

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -8,25 +8,26 @@ categories: announcements
 share_text: "Nearing the 7.0 Release"
 ---
 
-> Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/09/12/planning-for-7.0) post for information up till the first beta release!
+> [Hey! Listen!](https://soundcloud.com/omnomthenom/hey-listen-a-dubstep-tribute-to-navi) Check out [Planning for 7.0](https://babeljs.io/blog/2017/09/12/planning-for-7.0) for updates throughout the 7.0 pre-releases.
 
 ## Project Updates
 
-- We started a new [videos page](https://babeljs.io/docs/community/videos/)! Wanted to create this to provide a resource for people wanting to learn more about how Babel works and help contribute back!
+- We started a new [videos page](https://babeljs.io/docs/community/videos/)! We created this for people wanting to learn more about how Babel works and to help contribute back.
 
 [![videos](https://i.imgur.com/DkBEsfo.png)](https://babeljs.io/docs/community/videos/)
 
-- We created a new [team page](https://babeljs.io/team)! We'll be updating this in the future with more information about what people work on and why they are involved! For such a large project, there are many ways to get involved and help out!
+- We created a new [team page](https://babeljs.io/team)! We will be updating this page in the future with more information about what people work on and why they are involved. For such a large project, there are many ways to get involved and help out.
 
 [![team](https://i.imgur.com/YcWgRwf.png)](https://babeljs.io/team)
 
-- Babel turned three years old on [Sept 28](https://babeljs.io/blog/2017/10/05/babel-turns-three)!
-- Daniel [moved](https://twitter.com/left_pad/status/926096965565370369) `babel/babylon` and `babel/babel-preset-env` into the main Babel monorepo: [babel/babel](https://github.com/babel/babel), including everything from git history, labels, issues!
+- Babel turned 3 years old on [September 28, 2017](https://babeljs.io/blog/2017/10/05/babel-turns-three)!
+- Daniel [moved](https://twitter.com/left_pad/status/926096965565370369) `babel/babylon` and `babel/babel-preset-env` into the main Babel monorepo, [babel/babel](https://github.com/babel/babel), and this includes all git history, labels, issues.
 - We received a [$1k/month donation](https://twitter.com/left_pad/status/923696620935421953) from Facebook Open Source!
-  - If your company would also like to give back and support a fundamental part of JavaScript development and it's future, consider donating to our [Open Collective](https://opencollective.com/babel) or donate developer time to helping maintain the project
-  - This the highest monthly donation we've gotten since the start (next highest is $100/month)
-  - We're definetely looking to be able to fund people on the team to work full-time
-  - In the meantime we will use our funds to meet in person and sending people to TC39 meetings (it's every 2 months around the world). If someone wants to sponsor specifically for that, we can create separate issues to track that so there are concrete/specific things a company can donate for. This has been previously difficult because we've had to pay out of pocket or for me had to find a conference on the same week to speak at to help cover expenses.
+  - If your company would like to **give back** by supporting a fundamental part of JavaScript development and it's future, consider donating to our [Open Collective](https://opencollective.com/babel). You can also donate developer time to help maintain the project.
+  - This the highest monthly donation we have gotten since the start (next highest is $100/month).
+  - We are definetely looking to be able to fund people on the team to work full-time.
+  - In the meantime, we will use our funds to meet in person and to send people to TC39 meetings. These meetings are every 2 months around the world.
+  - If a company wants to specifically sponsor something, we can create separate issues to track. This was previously difficult because we had to pay out of pocket, or we had to find a conference on the same week to speak at to help cover expenses.
 
 ### How you can help!
 
@@ -44,7 +45,7 @@ We will also be working on a upgrade tool that will help [rewrite your package.j
 
 ### Summary of the [previous post](https://babeljs.io/blog/2017/09/12/planning-for-7.0)
 
-- Drop Node 0.10/0.12/5 support.
+- Dropped Node 0.10/0.12/5 support.
 - Updated [TC39 proposals](https://github.com/babel/proposals/issues)
   - Numeric Separator: `1_000`
   - Optional Chaining Operator: `a?.b`
@@ -53,7 +54,7 @@ We will also be working on a upgrade tool that will help [rewrite your package.j
   - BigInt (parseble): `2n`
   - Split export extensions into `export-default-from` and `export-ns-form`
 - `.babelrc.js` support (a config using JavaScript instead of JSON)
-- A new Typescript Preset + separated the React/Flow presets
+- Added a new Typescript Preset + separated the React/Flow presets
 - Removed the internal `babel-runtime` dependency for smaller size
 
 ### Newly Updated TC39 Proposals
@@ -64,17 +65,17 @@ We will also be working on a upgrade tool that will help [rewrite your package.j
 
 ### Deprecated Yearly Presets (e.g. babel-preset-es20xx)
 
-TL;DR is use `babel-preset-env` instead.
+TL;DR: use `babel-preset-env`.
 
-What's better than you having to decide what Babel preset to use? If it was done for you, automatically!
+What's better than you having to decide which Babel preset to use? Having it done for you, automatically!
 
-Even though the amount of work that goes into maintaining the lists of data is humongous (again why we need help), it solves multiple issues: making sure users are up to date with the spec, less configuration/package confusion, an easier upgrade path, and less issues about what is what.
+Even though the amount of work that goes into maintaining the lists of data is humongous — again, why we need help — it solves multiple issues. It makes sure users are up to date with the spec. It means less configuration/package confusion. It means an easier upgrade path. And it means less issues about what is what.
 
 `babel-preset` is actually a pretty *old* preset that replaces every other syntax preset that you will need (es2015, es2016, es2017, es20xx, latest, etc...).
 
 ![npm presets](https://i.imgur.com/nNKKFcp.png)
 
-It compiles the latest yearly release of JavaScript (whatever is in Stage 4) which replaces all the old presets. But it also has the further abilitiy to compile according to the target environments you specify: whether it's for development mode (latest version of a browser), or different builds (one for IE, one for evergreen browsers).
+It compiles the latest yearly release of JavaScript (whatever is in Stage 4) which replaces all the old presets. But it also has the abilitiy to compile according to target environments you specify: whether that is for development mode, like the latest version of a browser, or for multiple builds, like a version for IE, and then another version for evergreen browsers.
 
 ### Not removing the Stage presets (babel-preset-stage-x)
 
@@ -82,28 +83,26 @@ It compiles the latest yearly release of JavaScript (whatever is in Stage 4) whi
 
 We can always keep it up to date, and maybe we just need to determine a better system than what these presets are currently.
 
-Right now, they are literally just a list of plugins that we manually update after a TC39 meeting happens. Of course to make this managable we will need to just allow for major version bumps for these "unstable" packages. Part of the reason for this is because the community will just re-create these packages anyway, so we might as well do it via an official package and have the ability to provide better messaging, etc.
+Right now, stage presets are literally just a list of plugins that we manually update after TC39 meetings. To make this managable, we need to allow major version bumps for these "unstable" packages. Part of the reason for this is because the community will re-create these packages anyway, so we might as well do it from an official package and then have the ability to provide better messaging, etc.
 
 ### Renames: Scoped Packages (`@babel/x`)
 
-Alright we only just changed every single package for Babel again 😂..
-
-Here's a poll I did almost a year ago:
+Here is a poll I did almost a year ago:
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Thoughts on <a href="https://twitter.com/babeljs">@babeljs</a> using npm scoped packages for 7.0?</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/821551189166878722">January 18, 2017</a></blockquote>
 
-Back then, there weren't a lot of projects using scoped packages so most people didn't even know they existed. I believe you also had to pay for a npm org account while now it's free (and supports non scoped packages too). The issues with searching for scoped packages are solved and download counts work. The only thing left is that some 3rd party registries still don't support scoped. I think we are at a point where it seems pretty unreasonable to wait on that.
+Back then, not a lot of projects used scoped packages, so most people didn't even know they existed. You may also have had to pay for a npm org account back then, while now it's free (and supports non scoped packages, too). The issues with searching for scoped packages are solved and download counts work. The only thing left is that some 3rd party registries still don't support scoped packages, and I think we are at a point where it seems pretty unreasonable to wait on that.
 
-If you want reasons why:
+If you want reasons why we prefer scoped packages:
 
-- Naming is difficult: we don't have to check if someone else decided to use our naming convention for their own plugin
+- Naming is difficult: we won’t have to check if someone else decided to use our naming convention for their own plugin
 - Similarly, package squatting
-  - Sometimes people will create `babel-preset-20xx` or some other package we will use because it's funny and then we have to make an issue/email them to ask for it back.
-  - People have a legit package but it happens to be the same name as what we wanted to call it.
-  - People see that a new proposal is merge (optional chaining, pipeline operator) and decide to fork and publish a version of it under the same name so that when we publish it errors saying it was already published 🤔. Then I had to find their email and email both them and npm support to get the package back and republish.
-- What is an "official" package and what is a user/community package with the same name. We can get issue reports of people using misnamed or unofficial packages because they assumed it was part of Babel. One example of this was a report that `babel-env` was rewriting their `.babelrc` file, and it took a while to realize they thought it was `babel-preset-env`.
+  - Sometimes people create `babel-preset-20xx` or some other package because it's funny, and then we have to make an issue/email to ask for it back.
+  - People have a legit package, but it happens to be the same name as what we wanted to call it.
+  - People see that a new proposal is merging (like optional chaining, pipeline operator) and decide to fork and publish a version of it under the same name. Then, when we publish, it tell us the package was already published 🤔. Then, I have to find their email and email both them and npm support to get the package back and republish.
+- What is an "official" package and what is a user/community package with the same name? We can get issue reports of people using misnamed or unofficial packages because they assumed it was part of Babel. One example of this was a report that `babel-env` was rewriting their `.babelrc` file, and it took them a while to realize it wasn't `babel-preset-env`.
 
-So it seems obvious we should do this, and if anything should of done it much earlier 🙂!
+So, it seems obvious we should use scoped packages, and, if anything, we should have done it much earlier 🙂!
 
 Examples of the scoped name change:
 
@@ -113,31 +112,30 @@ Examples of the scoped name change:
 
 ### Renames: `-proposal-`
 
-Any proposals will be named with the `-proposal` prefix now to signify that they aren't officially in JavaScript yet.
+Any proposals will be named with `-proposal-` now to signify that they aren't officially in JavaScript yet.
 
-So `@babel/plugin-transform-class-properties` -> `@babel/plugin-proposal-class-properties`. And we would name it back when it gets to Stage 4.
+So `@babel/plugin-transform-class-properties` becomes `@babel/plugin-proposal-class-properties`, and we would name it back once it gets into Stage 4.
 
 ### Renames: Drop the year from the plugin name
 
-Previous plugins had the year in the name, but it doesn't seem to be necessary.
+Previous plugins had the year in the name, but it doesn't seem to be necessary now.
 
-So `@babel/plugin-transform-es2015-classes` -> `@babel/plugin-transform-classes`.
+So `@babel/plugin-transform-es2015-classes` becomes `@babel/plugin-transform-classes`.
 
-Partially since this was only the case for es3/es2015 and we didn't change anything from es2016 or es2017. We are also deprecating the corresponding presets in favor of preset-env, and for the template literal revision just added it to the template literal transform for simplicity.
+Since years were only the case for es3/es2015, we didn't change anything from es2016 or es2017. However, we are deprecating those presets in favor of preset-env, and, for the template literal revision, we just added it to the template literal transform for simplicity.
 
 ### Peer Dependencies + Integrations
 
-We are introducing a peer dependency on `@babel/core` for all the plugins (`@babel/plugin-class-properties`), presets (`@babel/preset-env`), top level packages (`@babel/cli`, `babel-loader`).
+We are introducing a peer dependencies on `@babel/core` for all the plugins (`@babel/plugin-class-properties`), presets (`@babel/preset-env`), and top level packages (`@babel/cli`, `babel-loader`).
 
-`babel-loader` already had a `peerDependency` on `babel-core`, so this just changes it to `@babel/core`.
+> peerDependencies are dependencies expected to be used by your code, as opposed to dependencies only used as an implementation detail.
+> — [Stijn de Witt via StackOverflow](https://stackoverflow.com/a/34645112).
 
-This is just so that people aren't trying to install these packages on the wrong version of Babel.
+`babel-loader` already had a `peerDependency` on `babel-core`, so this just changes it to `@babel/core`. This is just so that people weren't trying to install these packages on the wrong version of Babel.
 
-> For tools that already have a `peerDependency` on `babel-core` and aren't ready for a major bump since changing the peer dependency is a breaking change, we have published a new version of `babel-core` to bridge the changes over with the version [babel-core@7.0.0-bridge.0](https://github.com/babel/babel-bridge). For more information check out [this issue](https://github.com/facebook/jest/pull/4557#issuecomment-344048628)
+For tools that already have a `peerDependency` on `babel-core` and aren't ready for a major bump (since changing the peer dependency is a breaking change), we have published a new version of `babel-core` to bridge the changes over with the new version [babel-core@7.0.0-bridge.0](https://github.com/babel/babel-bridge). For more information check out [this issue](https://github.com/facebook/jest/pull/4557#issuecomment-344048628).
 
-Similarly, packages like `gulp-babel`, `rollup-plugin-babel`, etc all used to have `babel-core` as a dependency. Now these will also just have a `peerDependency` on `@babel/core`.
-
-This lets all these packages not have to bump major versions when the `@babel/core` API hasn't changed.
+Similarly, packages like `gulp-babel`, `rollup-plugin-babel`, etc, all used to have `babel-core` as a dependency. Now these will just have a `peerDependency` on `@babel/core`. This lets these packages not have to bump major versions when the `@babel/core` API hasn't changed.
 
 ### [#5224](https://github.com/babel/babel/pull/5224) Independent Publishing of Experimental Packages
 
@@ -145,13 +143,13 @@ This lets all these packages not have to bump major versions when the `@babel/co
 
 You might remember that after Babel 6, Babel became a set of npm packages with its own ecosystem of custom presets and plugins.
 
-However since then, we've always used a "fixed/synchronized" versioning system (so that no package is on v7.0 or above). When we do a new release such as `v6.23.0` only packages that have updated code in the source are published with the new version while the rest of the packages are left as is. This mostly works in practice because we use `^` in our packages.
+However since then, we have always used a "fixed/synchronized" versioning system (so that no package is on v7.0 or above). When we do a new release such as `v6.23.0` only packages that have updated code in the source are published with the new version while the rest of the packages are left as is. This mostly works in practice because we use `^` in our packages.
 
-Unfortunately this kind of system requires that a major version be released for all packages once a single package needs it. This either means we make a lot small breaking changes (unnecessary) or we batch lots of breaking changes into a single release. Instead, we want to differentiate between the experimental packages (Stage 0, etc) and everything else (es2015).
+Unfortunately this kind of system requires that a major version be released for all packages once a single package needs it. This either means we make a lot small breaking changes (unnecessary), or we batch lots of breaking changes into a single release. Instead, we want to differentiate between the experimental packages (Stage 0, etc.) and everything else (es2015).
 
-This means that we intend to make major version bumps to any experimental proposal plugins when the spec changes rather than waiting to update all of Babel. So anything that is < Stage 4 would be open to breaking changes in the form of major version bumps and same with the Stage presets themselves if we don't drop them entirely.
+This means we intend to make major version bumps to any experimental proposal plugins when the spec changes rather than waiting to update all of Babel. So anything that is < Stage 4 would be open to breaking changes in the form of major version bumps and same with the Stage presets themselves (if we don't drop them entirely).
 
-This goes with our decision to change TC39 proposal plugins to have the `-proposal-` name. If the spec changes, we will do a major version bump to the plugin and the preset it belongs to (as opposed to just do a patch version which may break for people). Then we'll need to work on deprecating the old versions and figuring out how to setup the infrastructure to automatically update people so everyone is up to date on what the spec will become (and not get stuck on something like we have with decorators).
+This goes with our decision to change TC39 proposal plugins to use the `-proposal-` name. If the spec changes, we will do a major version bump to the plugin and the preset it belongs to (as opposed to just making a patch version which may break for people). Then, we will need to deprecate the old versions and setup an infrastructure to automatically update people so that everyone is up to date on what the spec will become (and so they don't get stuck on something, like we have with decorators).
 
 ### Speed
 
@@ -165,4 +163,3 @@ This goes with our decision to change TC39 proposal plugins to have the `-propos
 ### Upcoming
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -8,11 +8,11 @@ categories: announcements
 share_text: "Nearing the 7.0 Release"
 ---
 
-> [Hey! Listen!](https://soundcloud.com/omnomthenom/hey-listen-a-dubstep-tribute-to-navi) Check out [Planning for 7.0](https://babeljs.io/blog/2017/09/12/planning-for-7.0) for updates throughout the 7.0 pre-releases.
+> Check out [Planning for 7.0](https://babeljs.io/blog/2017/09/12/planning-for-7.0) for the last updates throughout the 7.0 pre-releases.
 
 ## Project Updates
 
-- We started a new [videos page](https://babeljs.io/docs/community/videos/)! We created this for people wanting to learn more about how Babel works and to help contribute back.
+- We started a new [videos page](https://babeljs.io/docs/community/videos/)! We created this for people wanting to learn more about how Babel works and to help others contribute back. Contains videos of conference talks on Babel and related concepts.
 
 [![videos](https://i.imgur.com/DkBEsfo.png)](https://babeljs.io/docs/community/videos/)
 
@@ -25,7 +25,8 @@ share_text: "Nearing the 7.0 Release"
 - We received a [$1k/month donation](https://twitter.com/left_pad/status/923696620935421953) from Facebook Open Source!
   - If your company would like to **give back** by supporting a fundamental part of JavaScript development and it's future, consider donating to our [Open Collective](https://opencollective.com/babel). You can also donate developer time to help maintain the project.
   - This the highest monthly donation we have gotten since the start (next highest is $100/month).
-  - We are definetely looking to be able to fund people on the team to work full-time.
+  - We are definetely looking to be able to fund people on the team to work full-time
+  - Logan in particular left his job a while ago and is using the funds to work on Babel part time at the moment.
   - In the meantime, we will use our funds to meet in person and to send people to TC39 meetings. These meetings are every 2 months around the world.
   - If a company wants to specifically sponsor something, we can create separate issues to track. This was previously difficult because we had to pay out of pocket, or we had to find a conference on the same week to speak at to help cover expenses.
 
@@ -39,9 +40,13 @@ share_text: "Nearing the 7.0 Release"
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Company: &quot;We&#39;d like to use SQL Server Enterprise&quot;<br>MS: &quot;That&#39;ll be a quarter million dollars + $20K/month&quot;<br>Company: &quot;Ok!&quot;<br>...<br>Company: &quot;We&#39;d like to use Babel&quot;<br>Babel: &quot;Ok! npm i babel --save&quot;<br>Company: &quot;Cool&quot;<br>Babel: &quot;Would you like to help contribute financially?&quot;<br>Company: &quot;lol no&quot;</p>&mdash; Adam Rackis (@AdamRackis) <a href="https://twitter.com/AdamRackis/status/931195056479965185?ref_src=twsrc%5Etfw">November 16, 2017</a></blockquote>
 
+#### #3 Contribute in other ways
+
+An example: [Angus](https://twitter.com/angustweets) made us an [official song](https://medium.com/@angustweets/hallelujah-in-praise-of-babel-977020010fad)!
+
 ### Upgrading
 
-We will also be working on a upgrade tool that will help [rewrite your package.json/.babelrc files](https://github.com/babel/notes/issues/44).
+We will also be working on a upgrade tool that will help [rewrite your package.json/.babelrc files](https://github.com/babel/notes/issues/44) and more. Please reach out to help and to post issues when trying to update.
 
 ### Summary of the [previous post](https://babeljs.io/blog/2017/09/12/planning-for-7.0)
 
@@ -55,6 +60,7 @@ We will also be working on a upgrade tool that will help [rewrite your package.j
   - Split export extensions into `export-default-from` and `export-ns-form`
 - `.babelrc.js` support (a config using JavaScript instead of JSON)
 - Added a new Typescript Preset + separated the React/Flow presets
+  - Added [JSX Fragment Support](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html) and various Flow updates
 - Removed the internal `babel-runtime` dependency for smaller size
 
 ### Newly Updated TC39 Proposals
@@ -73,7 +79,7 @@ Even though the amount of work that goes into maintaining the lists of data is h
 
 `babel-preset` is actually a pretty *old* preset that replaces every other syntax preset that you will need (es2015, es2016, es2017, es20xx, latest, etc...).
 
-![npm presets](https://i.imgur.com/nNKKFcp.png)
+[![npm presets](https://i.imgur.com/nNKKFcp.png)](https://npm-stat.com/charts.html?package=babel-preset-env&package=babel-preset-es2015&package=babel-preset-es2016&package=babel-preset-es2017&package=babel-preset-latest&from=2016-11-21&to=2017-11-21)
 
 It compiles the latest yearly release of JavaScript (whatever is in Stage 4) which replaces all the old presets. But it also has the abilitiy to compile according to target environments you specify: whether that is for development mode, like the latest version of a browser, or for multiple builds, like a version for IE, and then another version for evergreen browsers.
 
@@ -151,15 +157,63 @@ This means we intend to make major version bumps to any experimental proposal pl
 
 This goes with our decision to change TC39 proposal plugins to use the `-proposal-` name. If the spec changes, we will do a major version bump to the plugin and the preset it belongs to (as opposed to just making a patch version which may break for people). Then, we will need to deprecate the old versions and setup an infrastructure to automatically update people so that everyone is up to date on what the spec will become (and so they don't get stuck on something, like we have with decorators).
 
+### The `env` option in `.babelrc` is not deprecated
+
+Unlike in the [last post](https://babeljs.io/blog/2017/09/12/planning-for-7.0#deprecate-the-env-option-in-babelrc), we just fixed the merging behavior to be [more consistent](https://twitter.com/left_pad/status/936687774098444288).
+
+The configuration in `env` is given higher priority than root config items, and instead of just being a weird approach of using both, plugins and presets now merge based on their identity, so you can do
+
+```js
+{
+  presets: [
+    ['env', { modules: false}],
+  ],
+  env: {
+    test: {
+      presets: [
+         'env'
+      ],
+    }
+  },
+}
+```
+
+with `BABEL_ENV=test`, which would replace the root env config, with the one from test, which has no options.
+
+### [Support `class A extends Array` (oldest caveat)](https://twitter.com/left_pad/status/940723982638157829)
+
+Babel will automatically wrap any native built-ins like `Array`, `Error`, `HTMLElement` etc so that doing this just works when compiling classes.
+
 ### Speed
 
-- fixes from bmuerer: https://twitter.com/rauchg/status/924349334346276864
-- benchmark: https://github.com/v8/web-tooling-benchmark/issues/27
-- 60% faster https://twitter.com/left_pad/status/927554660508028929
+- Many [fixes](https://twitter.com/rauchg/status/924349334346276864
+) from [bmeurer](https://twitter.com/bmeurer)
+- Benchmark PRs: https://github.com/v8/web-tooling-benchmark/issues/27
+- 60% faster via the [web-tooling-benchmark](https://github.com/v8/web-tooling-benchmark) https://twitter.com/left_pad/status/927554660508028929
 
-### Compiling `node_modules`
 ### preset-env: `"useBuiltins": "usage"`
 
-### Upcoming
+### Misc Updates
+
+- [`babel-template`](https://github.com/babel/babel/blob/master/packages/babel-template) is faster/easier to use
+- [regenerator](https://github.com/facebook/regenerator) was released under the [MIT License](https://twitter.com/left_pad/status/938825429955125248) - it's the dependency used to compile generators/async
+- "lazy" option to the `modules-commonjs` plugin via [#6952](https://github.com/babel/babel/pull/6952)
+- You can now use `envName: "something"` in .babelrc or pass via cli `babel --envName=something` instead of having to use `process.env.BABEL_ENV` or `process.env.NODE_ENV`
+- `["transform-for-of", { "assumeArray": true }]` to make all for-of loops output as regular arrays
+- Exclude `transform-typeof-symbol` in loose mode for preset-env [#6831](https://github.com/babel/babel/pull/6831)
+- [Landed PR for better error messages with syntax errors](https://twitter.com/left_pad/status/942859244759666691)
+
+### Todos Before Release
+
+- [Handle `.babelrc` lookup](https://github.com/babel/babel/issues/6766) (want this done before first RC release)
+- ["overrides" support](https://github.com/babel/babel/pull/7091): different config based on glob pattern
+- Caching and invalidation logic in babel-core.
+- Better story around external helpers.
+- Either implement or have plan in place for versioning and handling polyfills independently from helpers, so we aren't explicitly tied to core-js 2 or 3, since people may have things that depend on one or the other and won't want to load both a lot of the time.
+- Either a [working decorator implementation](https://github.com/babel/babel/pull/6107), or functional legacy implementation, with clear path to land current spec behavior during 7.x's lifetime.
+
+Looking forward to a release:
+
+https://github.com/babel/notes
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -8,7 +8,7 @@ categories: announcements
 share_text: "Nearing the 7.0 Release"
 ---
 
-> Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7) post for information up till the first beta release!
+> Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/09/12/planning-for-7.0) post for information up till the first beta release!
 
 ## Project Updates
 
@@ -19,6 +19,26 @@ share_text: "Nearing the 7.0 Release"
 - We received a [$1k/month donation](https://twitter.com/left_pad/status/923696620935421953) from Facebook Open Source!
   - We're looking to be able to fund our team full-time, but in the meantime will use our funds for sending people to TC39 meetings (every 2 months around the world). If someone wants to sponsor specifically for that we can create separate issues to track that so there are concrete/specific things a company can donate for.
 
+### Summary of the [previous post](https://babeljs.io/blog/2017/09/12/planning-for-7.0)
+
+- Drop Node 0.10/0.12
+- Updated [TC39 proposals](https://github.com/babel/proposals/issues)
+  - Numeric Separator: `1_000`
+  - Optional Chaining Operator: `a?.b`
+  - `import.meta` (parseble)
+  - Optional Catch Binding: `try { a } catch {}`
+  - BigInt (parseble): `2n`
+  - Split export extensions into `export-default-from` and `export-ns-form`
+- `.babelrc.js`
+- Typescript Preset, separate React/Flow presets
+- Removed `babel-runtime` dep for smaller size
+
+### Newly Updated TC39 Proposals
+
+- Pipeline Operator: `a |> b`
+- Throw Expressions: `() => throw 'hi'`
+- Nullish Coalescing Operator: `a ?? b`
+
 ### Deprecated Yearly Presets (e.g. babel-preset-es20xx)
 
 TL;DR is use `babel-preset-env` instead.
@@ -27,7 +47,7 @@ What's better than add new docs/messages/having you decide what babel preset to 
 
 Even though the amount of work that goes into maintaining the lists of data is humogous (again why we need help), it solves multiple issues: making sure users are up to date with the spec, less configuration/package confusion, an easier upgrade path, and less issues about what is what.
 
-## Not removing the Stage presets (babel-preset-stage-x)
+### Not removing the Stage presets (babel-preset-stage-x)
 
 https://twitter.com/left_pad/status/873242704364306433
 
@@ -35,7 +55,7 @@ We can always keep it up to date, and maybe we just need to determine a better s
 
 Right now, they are literally just a list of plugins that we manually update after a TC39 meeting happens. Of course to make this managable we will need to just allow for major version bumps for these "unstable" packages. Part of the reason for this is because the community will just re-create these packages anyway so might as well do it via an official package.
 
-### Scoped Packages (`@babel/x`)
+### Renames: Scoped Packages (`@babel/x`)
 
 Alright we only just changed every single package for Babel again 😂..
 
@@ -64,6 +84,20 @@ Examples of the scoped name change:
 `babel-preset-es2015` -> `@babel/preset-es2015` (this is deprecated though, so use preset-env)
 `babel-preset-env` -> `@babel/preset-env`
 
+### Renames: `-proposal-`
+
+Any proposals will be named with the `-proposal` prefix now to signify that they aren't officially in JavaScript yet.
+
+So `@babel/plugin-transform-class-properties` -> `@babel/plugin-proposal-class-properties`. And we would name it back when it gets to Stage 4.
+
+### Renames: Drop the year from the plugin name
+
+Previous plugins had the year in the name, but it doesn't seem to be necessary.
+
+So `@babel/plugin-transform-es2015-classes` -> `@babel/plugin-transform-classes`.
+
+Partially since this was only the case for es3/es2015 and we didn't change anything from es2016 or es2017. We are also deprecating the corresponding presets in favor of preset-env, and for the template literal revision just added it to the template literal transform for simplicity.
+
 ### Peer Dependencies + Integrations
 
 We are introducing a peer dependency on `@babel/core` for all the plugins (`@babel/plugin-class-properties`), presets (`@babel/preset-env`), top level packages (`@babel/cli`, `babel-loader`).
@@ -77,8 +111,6 @@ This is just so that people aren't trying to install these packages on the wrong
 Similarly, packages like `gulp-babel`, `rollup-plugin-babel`, etc all used to have `babel-core` as a dependency. Now these will also just have a `peerDependency` on `@babel/core`.
 
 This lets all these packages not have to bump major versions when the `@babel/core` API hasn't changed.
-
-### TC39 Proposal Plugins (what isn't JS yet)
 
 ### [#5224](https://github.com/babel/babel/pull/5224) Independent Publishing of Experimental Packages
 
@@ -110,15 +142,19 @@ If the spec to an experimental proposal changes, we should be free to make a bre
 > I believe the way we want to go about doing this is to move those packages into the `experimental/` folder in our [monorepo](https://github.com/babel/babel) instead of in `packages/`.
 > Change our publish process (probably through Lerna) to publish the packages in `experimental/` independently.
 
-## Handle `.mjs` files
+### Handle `.mjs` files
 
 - @jdd handled using `@std/esm` with `@babel/register`
 - [#5624](https://github.com/babel/babel/pull/5624) Hook into compiling .mjs files in `@babel/cli` and `@babel/register`
 - [#570](https://github.com/babel/babel/pull/5700) Always force `.mjs` to be parsed as module
 - [#6221](https://github.com/babel/babel/pull/6221) Add `--keep-file-extension` option to `@babel/cli` to retain `.mjs` file instead of converting to `.js`
 
-### Open Issues
+#### Open Issues
 
 - [ ] How can we make `@babel/register` work with modules? [#6737](https://github.com/babel/babel/issues/6737)
 - [ ] `--watch` with `.mjs` files [#6800](https://github.com/babel/babel/issues/6800)
 - [ ] Output `.mjs` extension [#6222](https://github.com/babel/babel/issues/6222)
+
+### Speed
+### Compiling `node_modules`
+### preset-env: `"useBuiltins": "usage"`

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -45,7 +45,7 @@ TL;DR is use `babel-preset-env` instead.
 
 What's better than add new docs/messages/having you decide what babel preset to use? If it was done for you, automatically. 
 
-Even though the amount of work that goes into maintaining the lists of data is humogous (again why we need help), it solves multiple issues: making sure users are up to date with the spec, less configuration/package confusion, an easier upgrade path, and less issues about what is what.
+Even though the amount of work that goes into maintaining the lists of data is humongous (again why we need help), it solves multiple issues: making sure users are up to date with the spec, less configuration/package confusion, an easier upgrade path, and less issues about what is what.
 
 ### Not removing the Stage presets (babel-preset-stage-x)
 

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -12,16 +12,41 @@ share_text: "Nearing the 7.0 Release"
 
 ## Project Updates
 
-- We started a new [videos page](https://babeljs.io/docs/community/videos/)! Wanted to create this to provide a resource for people wanting to contribute to Babel.
-- We created a new [team page](https://babeljs.io/team)! I think we'll want to update this with more of what people work on and why they are involved!
+- We started a new [videos page](https://babeljs.io/docs/community/videos/)! Wanted to create this to provide a resource for people wanting to learn more about how Babel works and help contribute back!
+
+[![videos](https://i.imgur.com/DkBEsfo.png)](https://babeljs.io/docs/community/videos/)
+
+- We created a new [team page](https://babeljs.io/team)! We'll be updating this in the future with more information about what people work on and why they are involved! For such a large project, there are many ways to get involved and help out!
+
+[![team](https://i.imgur.com/YcWgRwf.png)](https://babeljs.io/team)
+
 - Babel turned three years old on [Sept 28](https://babeljs.io/blog/2017/10/05/babel-turns-three)!
-- Daniel [moved](https://twitter.com/left_pad/status/926096965565370369) `babel/babylon` and `babel/babel-preset-env` into the main Babel monorepo: [babel/babel](https://github.com/babel/babel), including everything from git history, labels, issues.
+- Daniel [moved](https://twitter.com/left_pad/status/926096965565370369) `babel/babylon` and `babel/babel-preset-env` into the main Babel monorepo: [babel/babel](https://github.com/babel/babel), including everything from git history, labels, issues!
 - We received a [$1k/month donation](https://twitter.com/left_pad/status/923696620935421953) from Facebook Open Source!
-  - We're looking to be able to fund our team full-time, but in the meantime will use our funds for sending people to TC39 meetings (every 2 months around the world). If someone wants to sponsor specifically for that we can create separate issues to track that so there are concrete/specific things a company can donate for.
+  - If your company would also like to give back and support a fundamental part of JavaScript development and it's future, consider donating to our [Open Collective](https://opencollective.com/babel) or donate developer time to helping maintain the project
+  - This the highest monthly donation we've gotten since the start (next highest is $100/month)
+  - We're definetely looking to be able to fund people on the team to work full-time
+  - In the meantime we will use our funds to meet in person and sending people to TC39 meetings (it's every 2 months around the world). If someone wants to sponsor specifically for that, we can create separate issues to track that so there are concrete/specific things a company can donate for. This has been previously difficult because we've had to pay out of pocket or for me had to find a conference on the same week to speak at to help cover expenses.
+
+### How you can help!
+
+#### #1 Help Maintain the Project (developer time at work)
+
+<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Engineer: There&#39;s a thing in SQL Server Enterprise blocking us<br>Company: Let&#39;s set up a call next week with them an ongoing discussion to resolve it next quarter<br><br>Engineer: There&#39;s a thing we need in babel, can I spent 2 days with a PR for it<br>Company: lol no it&#39;s their job <a href="https://t.co/icgaoJ0dTe">https://t.co/icgaoJ0dTe</a></p>&mdash; Shiya (@ShiyaLuo) <a href="https://twitter.com/ShiyaLuo/status/931230821976907776?ref_src=twsrc%5Etfw">November 16, 2017</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+#### #2 Fund development
+
+<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Company: &quot;We&#39;d like to use SQL Server Enterprise&quot;<br>MS: &quot;That&#39;ll be a quarter million dollars + $20K/month&quot;<br>Company: &quot;Ok!&quot;<br>...<br>Company: &quot;We&#39;d like to use Babel&quot;<br>Babel: &quot;Ok! npm i babel --save&quot;<br>Company: &quot;Cool&quot;<br>Babel: &quot;Would you like to help contribute financially?&quot;<br>Company: &quot;lol no&quot;</p>&mdash; Adam Rackis (@AdamRackis) <a href="https://twitter.com/AdamRackis/status/931195056479965185?ref_src=twsrc%5Etfw">November 16, 2017</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+### Upgrading
+
+We will also be working on a upgrade tool that will help [rewrite your package.json/.babelrc files](https://github.com/babel/notes/issues/44).
 
 ### Summary of the [previous post](https://babeljs.io/blog/2017/09/12/planning-for-7.0)
 
-- Drop Node 0.10/0.12
+- Drop Node 0.10/0.12/5 support.
 - Updated [TC39 proposals](https://github.com/babel/proposals/issues)
   - Numeric Separator: `1_000`
   - Optional Chaining Operator: `a?.b`
@@ -29,9 +54,9 @@ share_text: "Nearing the 7.0 Release"
   - Optional Catch Binding: `try { a } catch {}`
   - BigInt (parseble): `2n`
   - Split export extensions into `export-default-from` and `export-ns-form`
-- `.babelrc.js`
-- Typescript Preset, separate React/Flow presets
-- Removed `babel-runtime` dep for smaller size
+- `.babelrc.js` support (a config using JavaScript instead of JSON)
+- A new Typescript Preset + separated the React/Flow presets
+- Removed the internal `babel-runtime` dependency for smaller size
 
 ### Newly Updated TC39 Proposals
 
@@ -43,17 +68,24 @@ share_text: "Nearing the 7.0 Release"
 
 TL;DR is use `babel-preset-env` instead.
 
-What's better than add new docs/messages/having you decide what babel preset to use? If it was done for you, automatically. 
+What's better than you having to decide what Babel preset to use? If it was done for you, automatically!
 
 Even though the amount of work that goes into maintaining the lists of data is humongous (again why we need help), it solves multiple issues: making sure users are up to date with the spec, less configuration/package confusion, an easier upgrade path, and less issues about what is what.
 
+`babel-preset` is actually a pretty *old* preset that replaces every other syntax preset that you will need (es2015, es2016, es2017, es20xx, latest, etc...).
+
+![npm presets](https://i.imgur.com/nNKKFcp.png)
+
+It compiles the latest yearly release of JavaScript (whatever is in Stage 4) which replaces all the old presets. But it also has the further abilitiy to compile according to the target environments you specify: whether it's for development mode (latest version of a browser), or different builds (one for IE, one for evergreen browsers).
+
 ### Not removing the Stage presets (babel-preset-stage-x)
 
-https://twitter.com/left_pad/status/873242704364306433
+<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Frustration level if we remove the Stage presets in Babel? (in favor explicitly requiring proposal plugins since they aren&#39;t JavaScript yet)</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/873242704364306433?ref_src=twsrc%5Etfw">June 9, 2017</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 We can always keep it up to date, and maybe we just need to determine a better system than what these presets are currently.
 
-Right now, they are literally just a list of plugins that we manually update after a TC39 meeting happens. Of course to make this managable we will need to just allow for major version bumps for these "unstable" packages. Part of the reason for this is because the community will just re-create these packages anyway so might as well do it via an official package.
+Right now, they are literally just a list of plugins that we manually update after a TC39 meeting happens. Of course to make this managable we will need to just allow for major version bumps for these "unstable" packages. Part of the reason for this is because the community will just re-create these packages anyway, so we might as well do it via an official package and have the ability to provide better messaging, etc.
 
 ### Renames: Scoped Packages (`@babel/x`)
 
@@ -79,10 +111,9 @@ So it seems obvious we should do this, and if anything should of done it much ea
 
 Examples of the scoped name change:
 
-`babel-cli` -> `@babel/cli`
-`babel-core` -> `@babel/core`
-`babel-preset-es2015` -> `@babel/preset-es2015` (this is deprecated though, so use preset-env)
-`babel-preset-env` -> `@babel/preset-env`
+- `babel-cli` -> `@babel/cli`
+- `babel-core` -> `@babel/core`
+- `babel-preset-env` -> `@babel/preset-env`
 
 ### Renames: `-proposal-`
 
@@ -124,37 +155,15 @@ Unfortunately this kind of system requires that a major version be released for 
 
 This means that we intend to make major version bumps to any experimental proposal plugins when the spec changes rather than waiting to update all of Babel. So anything that is < Stage 4 would be open to breaking changes in the form of major version bumps and same with the Stage presets themselves if we don't drop them entirely.
 
-For example:
-
-Say you are using preset-env (which keeps up to date and currently includes everything in es2015, es2016, es2017) + an experimental plugin. You also decide to use object-rest-spread because it's cool.
-
-```json
-{
-  "presets": ["env"],
-  "plugins": ["transform-object-rest-spread"]
-}
-```
-
-If the spec to an experimental proposal changes, we should be free to make a breaking change and make a major version bump for that plugin only. Because it only affects that plugin, it doesn't affect anything else and people are free to update when possible. We just want to make sure that users update to the latest version of any experimental proposal when possible and provide the tools to do so automatically if that is reasonable as well.
-
-### Release Process
-
-> I believe the way we want to go about doing this is to move those packages into the `experimental/` folder in our [monorepo](https://github.com/babel/babel) instead of in `packages/`.
-> Change our publish process (probably through Lerna) to publish the packages in `experimental/` independently.
-
-### Handle `.mjs` files
-
-- @jdd handled using `@std/esm` with `@babel/register`
-- [#5624](https://github.com/babel/babel/pull/5624) Hook into compiling .mjs files in `@babel/cli` and `@babel/register`
-- [#570](https://github.com/babel/babel/pull/5700) Always force `.mjs` to be parsed as module
-- [#6221](https://github.com/babel/babel/pull/6221) Add `--keep-file-extension` option to `@babel/cli` to retain `.mjs` file instead of converting to `.js`
-
-#### Open Issues
-
-- [ ] How can we make `@babel/register` work with modules? [#6737](https://github.com/babel/babel/issues/6737)
-- [ ] `--watch` with `.mjs` files [#6800](https://github.com/babel/babel/issues/6800)
-- [ ] Output `.mjs` extension [#6222](https://github.com/babel/babel/issues/6222)
+This goes with our decision to change TC39 proposal plugins to have the `-proposal-` name. If the spec changes, we will do a major version bump to the plugin and the preset it belongs to (as opposed to just do a patch version which may break for people). Then we'll need to work on deprecating the old versions and figuring out how to setup the infrastructure to automatically update people so everyone is up to date on what the spec will become (and not get stuck on something like we have with decorators).
 
 ### Speed
+
+- fixes from bmuerer: https://twitter.com/rauchg/status/924349334346276864
+- benchmark: https://github.com/v8/web-tooling-benchmark/issues/27
+- 60% faster https://twitter.com/left_pad/status/927554660508028929
+
 ### Compiling `node_modules`
 ### preset-env: `"useBuiltins": "usage"`
+
+### Upcoming

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -8,7 +8,7 @@ categories: announcements
 share_text: "Nearing the 7.0 Release"
 ---
 
-> Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7) post for information up til the first beta release!
+> Please check out the previous [Planning for 7.0](https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7) post for information up till the first beta release!
 
 ## Project Updates
 
@@ -19,15 +19,21 @@ share_text: "Nearing the 7.0 Release"
 - We received a [$1k/month donation](https://twitter.com/left_pad/status/923696620935421953) from Facebook Open Source!
   - We're looking to be able to fund our team full-time, but in the meantime will use our funds for sending people to TC39 meetings (every 2 months around the world). If someone wants to sponsor specifically for that we can create separate issues to track that so there are concrete/specific things a company can donate for.
 
-### Deprecated yearly presets (babel-preset-es20xx)
+### Deprecated Yearly Presets (e.g. babel-preset-es20xx)
 
 TL;DR is use `babel-preset-env` instead.
 
-What's better than having to decide for your what babel preset/plugin to use is if it was done for you, automatically. Although the amount of work that goes into maintaining the lists of data is humogous, it solves multiple issues: keeping users up to date with the spec, less configuration/package confusion, easier upgrade path, less issues about what is what. 
+What's better than add new docs/messages/having you decide what babel preset to use? If it was done for you, automatically. 
 
-### Not removing Stage presets (babel-preset-stage-x)
+Even though the amount of work that goes into maintaining the lists of data is humogous (again why we need help), it solves multiple issues: making sure users are up to date with the spec, less configuration/package confusion, an easier upgrade path, and less issues about what is what.
+
+## Not removing the Stage presets (babel-preset-stage-x)
 
 https://twitter.com/left_pad/status/873242704364306433
+
+We can always keep it up to date, and maybe we just need to determine a better system than what these presets are currently.
+
+Right now, they are literally just a list of plugins that we manually update after a TC39 meeting happens. Of course to make this managable we will need to just allow for major version bumps for these "unstable" packages. Part of the reason for this is because the community will just re-create these packages anyway so might as well do it via an official package.
 
 ### Scoped Packages (`@babel/x`)
 
@@ -58,13 +64,21 @@ Examples of the scoped name change:
 `babel-preset-es2015` -> `@babel/preset-es2015` (this is deprecated though, so use preset-env)
 `babel-preset-env` -> `@babel/preset-env`
 
+### Peer Dependencies + Integrations
+
+We are introducing a peer dependency on `@babel/core` for all the plugins (`@babel/plugin-class-properties`), presets (`@babel/preset-env`), top level packages (`@babel/cli`, `babel-loader`).
+
+`babel-loader` already had a `peerDependency` on `babel-core`, so this just changes it to `@babel/core`.
+
+This is just so that people aren't trying to install these packages on the wrong version of Babel.
+
+> For tools that already have a `peerDependency` on `babel-core` and aren't ready for a major bump since changing the peer dependency is a breaking change, we have published a new version of `babel-core` to bridge the changes over with the version [babel-core@7.0.0-bridge.0](https://github.com/babel/babel-bridge). For more information check out [this issue](https://github.com/facebook/jest/pull/4557#issuecomment-344048628)
+
+Similarly, packages like `gulp-babel`, `rollup-plugin-babel`, etc all used to have `babel-core` as a dependency. Now these will also just have a `peerDependency` on `@babel/core`.
+
+This lets all these packages not have to bump major versions when the `@babel/core` API hasn't changed.
+
 ### TC39 Proposal Plugins (what isn't JS yet)
-
-### Integrations
-
-Packages like `grunt-babel`, `gulp-babel`, `rollup-plugin-babel`, etc all used to have `babel-core` as a dependency.
-
-After v7, we plan to move `babel-core` to be a peerDependency like `babel-loader` has. This lets all these packages not have to bump major versions when the `babel-core` API hasn't changed. Thus they are already published as `7.0.0` since we don't expect any further changes to those packages.
 
 ### [#5224](https://github.com/babel/babel/pull/5224) Independent Publishing of Experimental Packages
 
@@ -95,3 +109,16 @@ If the spec to an experimental proposal changes, we should be free to make a bre
 
 > I believe the way we want to go about doing this is to move those packages into the `experimental/` folder in our [monorepo](https://github.com/babel/babel) instead of in `packages/`.
 > Change our publish process (probably through Lerna) to publish the packages in `experimental/` independently.
+
+## Handle `.mjs` files
+
+- @jdd handled using `@std/esm` with `@babel/register`
+- [#5624](https://github.com/babel/babel/pull/5624) Hook into compiling .mjs files in `@babel/cli` and `@babel/register`
+- [#570](https://github.com/babel/babel/pull/5700) Always force `.mjs` to be parsed as module
+- [#6221](https://github.com/babel/babel/pull/6221) Add `--keep-file-extension` option to `@babel/cli` to retain `.mjs` file instead of converting to `.js`
+
+### Open Issues
+
+- [ ] How can we make `@babel/register` work with modules? [#6737](https://github.com/babel/babel/issues/6737)
+- [ ] `--watch` with `.mjs` files [#6800](https://github.com/babel/babel/issues/6800)
+- [ ] Output `.mjs` extension [#6222](https://github.com/babel/babel/issues/6222)

--- a/_posts/2017-11-03-nearing-the-7.0-release.md
+++ b/_posts/2017-11-03-nearing-the-7.0-release.md
@@ -33,12 +33,10 @@ share_text: "Nearing the 7.0 Release"
 #### #1 Help Maintain the Project (developer time at work)
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Engineer: There&#39;s a thing in SQL Server Enterprise blocking us<br>Company: Let&#39;s set up a call next week with them an ongoing discussion to resolve it next quarter<br><br>Engineer: There&#39;s a thing we need in babel, can I spent 2 days with a PR for it<br>Company: lol no it&#39;s their job <a href="https://t.co/icgaoJ0dTe">https://t.co/icgaoJ0dTe</a></p>&mdash; Shiya (@ShiyaLuo) <a href="https://twitter.com/ShiyaLuo/status/931230821976907776?ref_src=twsrc%5Etfw">November 16, 2017</a></blockquote>
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 #### #2 Fund development
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Company: &quot;We&#39;d like to use SQL Server Enterprise&quot;<br>MS: &quot;That&#39;ll be a quarter million dollars + $20K/month&quot;<br>Company: &quot;Ok!&quot;<br>...<br>Company: &quot;We&#39;d like to use Babel&quot;<br>Babel: &quot;Ok! npm i babel --save&quot;<br>Company: &quot;Cool&quot;<br>Babel: &quot;Would you like to help contribute financially?&quot;<br>Company: &quot;lol no&quot;</p>&mdash; Adam Rackis (@AdamRackis) <a href="https://twitter.com/AdamRackis/status/931195056479965185?ref_src=twsrc%5Etfw">November 16, 2017</a></blockquote>
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 ### Upgrading
 
@@ -81,7 +79,6 @@ It compiles the latest yearly release of JavaScript (whatever is in Stage 4) whi
 ### Not removing the Stage presets (babel-preset-stage-x)
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Frustration level if we remove the Stage presets in Babel? (in favor explicitly requiring proposal plugins since they aren&#39;t JavaScript yet)</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/873242704364306433?ref_src=twsrc%5Etfw">June 9, 2017</a></blockquote>
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 We can always keep it up to date, and maybe we just need to determine a better system than what these presets are currently.
 
@@ -94,7 +91,6 @@ Alright we only just changed every single package for Babel again 😂..
 Here's a poll I did almost a year ago:
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Thoughts on <a href="https://twitter.com/babeljs">@babeljs</a> using npm scoped packages for 7.0?</p>&mdash; Henry Zhu (@left_pad) <a href="https://twitter.com/left_pad/status/821551189166878722">January 18, 2017</a></blockquote>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 Back then, there weren't a lot of projects using scoped packages so most people didn't even know they existed. I believe you also had to pay for a npm org account while now it's free (and supports non scoped packages too). The issues with searching for scoped packages are solved and download counts work. The only thing left is that some 3rd party registries still don't support scoped. I think we are at a point where it seems pretty unreasonable to wait on that.
 
@@ -167,3 +163,6 @@ This goes with our decision to change TC39 proposal plugins to have the `-propos
 ### preset-env: `"useBuiltins": "usage"`
 
 ### Upcoming
+
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+


### PR DESCRIPTION
progress updates

I just copied part of the stuff from the older post

- name for integrations
- peerDep on babel-core
- versioning
- scoped packages
- removing the `-es2015-` part of some transforms
- moved babylon/preset-env repos into this repo
- transform -> proposal for Stage x proposals
- deprecated es20xx presets