### PR TITLE
Add flow and typescript presets to repl

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -39,6 +39,10 @@ const pluginConfigs: Array<PluginConfig> = [
   },
 ];
 
+// A list of presets available for use in the REPL.
+//
+// Items marked with `isPreLoaded` are checked against available presets
+// from the currently loaded @babel/standalone version.
 const presetPluginConfigs: Array<PluginConfig> = [
   {
     label: "es2015",

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -39,61 +39,9 @@ const pluginConfigs: Array<PluginConfig> = [
   },
 ];
 
-// A list of presets available for use in the REPL.
-//
-// Items marked with `isPreLoaded` are checked against available presets
-// from the currently loaded @babel/standalone version.
-const presetPluginConfigs: Array<PluginConfig> = [
-  {
-    label: "es2015",
-    isPreLoaded: true,
-  },
-  {
-    label: "es2015-loose",
-    isPreLoaded: true,
-  },
-  {
-    label: "es2016",
-    isPreLoaded: true,
-  },
-  {
-    label: "es2017",
-    isPreLoaded: true,
-  },
-  {
-    label: "react",
-    isPreLoaded: true,
-  },
-  {
-    label: "stage-0",
-    isPreLoaded: true,
-  },
-  {
-    label: "stage-1",
-    isPreLoaded: true,
-  },
-  {
-    label: "stage-2",
-    isPreLoaded: true,
-  },
-  {
-    label: "stage-3",
-    isPreLoaded: true,
-  },
-  {
-    label: "flow",
-    isPreLoaded: true,
-  },
-  {
-    label: "typescript",
-    isPreLoaded: true,
-  },
-];
-
 export {
   envPresetConfig,
   envPresetDefaults,
   pluginConfigs,
-  presetPluginConfigs,
   runtimePolyfillConfig,
 };

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -76,6 +76,14 @@ const presetPluginConfigs: Array<PluginConfig> = [
     label: "stage-3",
     isPreLoaded: true,
   },
+  {
+    label: "flow",
+    isPreLoaded: true,
+  },
+  {
+    label: "typescript",
+    isPreLoaded: true,
+  },
 ];
 
 export {

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -16,7 +16,6 @@ import PresetLoadingAnimation from "./PresetLoadingAnimation";
 import {
   envPresetConfig,
   pluginConfigs,
-  presetPluginConfigs,
   runtimePolyfillConfig,
 } from "./PluginConfig";
 import {
@@ -203,18 +202,12 @@ class Repl extends React.Component {
   async _setupBabel(defaultPresets) {
     const babelState = await loadBabel(this.state.babel, this._workerApi);
 
-    // Filter the list of preloaded presets with those available with
-    // the loaded version of @babel/standalone.
-    const availablePresetConfigs = babelState.isLoaded
-      ? presetPluginConfigs.filter(
-          ({ label, isPreLoaded }) =>
-            !isPreLoaded || babelState.availablePresets.indexOf(label) > -1
-        )
-      : presetPluginConfigs;
-
     this.setState({
       babel: babelState,
-      presets: configArrayToStateMap(availablePresetConfigs, defaultPresets),
+      presets: configArrayToStateMap(
+        babelState.availablePresets,
+        defaultPresets
+      ),
     });
 
     if (babelState.isLoaded) {

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -2,11 +2,7 @@
 
 import { css } from "emotion";
 import React, { Component } from "react";
-import {
-  envPresetDefaults,
-  pluginConfigs,
-  presetPluginConfigs,
-} from "./PluginConfig";
+import { envPresetDefaults, pluginConfigs } from "./PluginConfig";
 import AccordionTab from "./AccordionTab";
 import PresetLoadingAnimation from "./PresetLoadingAnimation";
 import Svg from "./Svg";

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -129,14 +129,17 @@ class ExpandedContainer extends Component {
             label="Presets"
             toggleIsExpanded={this._togglePresetsTab}
           >
-            {presetPluginConfigs.map(config => (
-              <PluginToggle
-                config={config}
-                key={config.label}
-                onSettingChange={onSettingChange}
-                state={presetState[config.label]}
-              />
-            ))}
+            {Object.keys(presetState).map(label => {
+              const state = presetState[label];
+              return (
+                <PluginToggle
+                  config={state.config}
+                  key={label}
+                  onSettingChange={onSettingChange}
+                  state={state}
+                />
+              );
+            })}
           </AccordionTab>
           <AccordionTab
             className={`${styles.section} ${styles.sectionEnv}`}

--- a/js/repl/Worker.js
+++ b/js/repl/Worker.js
@@ -23,6 +23,13 @@ registerPromiseWorker(message => {
         return null;
       }
 
+    case "getAvailablePresets":
+      try {
+        return Object.keys(Babel.availablePresets);
+      } catch (error) {
+        return null;
+      }
+
     case "loadScript":
       try {
         importScripts(message.url);

--- a/js/repl/Worker.js
+++ b/js/repl/Worker.js
@@ -24,11 +24,12 @@ registerPromiseWorker(message => {
       }
 
     case "getAvailablePresets":
-      try {
-        return Object.keys(Babel.availablePresets);
-      } catch (error) {
-        return null;
-      }
+      if (!Babel) return [];
+
+      return Object.keys(Babel.availablePresets).map(p => ({
+        label: p,
+        isPreLoaded: true,
+      }));
 
     case "loadScript":
       try {

--- a/js/repl/WorkerApi.js
+++ b/js/repl/WorkerApi.js
@@ -62,6 +62,10 @@ export default class WorkerApi {
     return this._worker.postMessage({ method: "getBabelVersion" });
   }
 
+  getAvailablePresets(): Promise<Array<string>> {
+    return this._worker.postMessage({ method: "getAvailablePresets" });
+  }
+
   loadPlugin(state: PluginState): Promise<boolean> {
     const { config } = state;
 

--- a/js/repl/loadBabel.js
+++ b/js/repl/loadBabel.js
@@ -14,9 +14,13 @@ export default async function loadBabel(
         config.isLoaded = true;
         config.isLoading = false;
 
-        // Incoming version might be unspecific (eg "6")
-        // Resolve to a more specific version to show in the UI.
-        return workerApi.getBabelVersion().then(version => {
+        return Promise.all([
+          // Incoming version might be unspecific (eg "6")
+          // Resolve to a more specific version to show in the UI.
+          workerApi.getBabelVersion(),
+          workerApi.getAvailablePresets(),
+        ]).then(([version, presets]) => {
+          config.availablePresets = presets;
           config.version = version;
           return config;
         });

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -62,6 +62,7 @@ type DefaultPlugins = { [name: string]: boolean };
 export const persistedStateToBabelState = (
   persistedState: PersistedState
 ): BabelState => ({
+  availablePresets: [],
   build: persistedState.build,
   circleciRepo: persistedState.circleciRepo,
   didError: false,

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -30,6 +30,7 @@ export type LazyLoadedState = {
 };
 
 export type BabelState = LazyLoadedState & {
+  availablePresets?: Array<string>,
   build: string,
   errorMessage?: string,
   circleciRepo: string,

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -30,7 +30,7 @@ export type LazyLoadedState = {
 };
 
 export type BabelState = LazyLoadedState & {
-  availablePresets?: Array<string>,
+  availablePresets: Array<string>,
   build: string,
   errorMessage?: string,
   circleciRepo: string,


### PR DESCRIPTION
Supersedes/Closes https://github.com/babel/website/pull/1360.

Only real difference is presets marked with `isPreLoaded` inside `presetPluginConfigs` are now  checked against `availablePresets` from `@babel/standalone` to prevent the invalid/missing preset errors (i.e. trying to load Flow/TypeScript preset with 6.x)

Examples:

[6.26.0](https://deploy-preview-1462--babel.netlify.com/repl#?babili=false&browsers=&build=&builtIns=false&code_lz=PTAEAEDMBsHsHcBQA3AhgJ1ADwFygM4Au6AlgHYDmoAvKAOSSywBGGdA3EA&debug=false&circleciRepo=&evaluate=false&lineWrap=true&presets=es2015%2Creact%2Cstage-2&targets=&version=6.26.0) (no flow/ts)

[7.0.0-alpha.15](https://deploy-preview-1462--babel.netlify.com/repl#?babili=false&browsers=&build=&builtIns=false&code_lz=PTAEAEDMBsHsHcBQA3AhgJ1ADwFygM4Au6AlgHYDmoAvKAOSSywBGGdA3EA&debug=false&circleciRepo=&evaluate=false&lineWrap=true&presets=es2015%2Creact%2Cstage-2&targets=&version=7.0.0-alpha.15) (no flow/ts)

[7.0.0-alpha.20](https://deploy-preview-1462--babel.netlify.com/repl#?babili=false&browsers=&build=&builtIns=false&code_lz=PTAEAEDMBsHsHcBQA3AhgJ1ADwFygM4Au6AlgHYDmoAvKAOSSywBGGdA3EA&debug=false&circleciRepo=&evaluate=false&lineWrap=true&presets=es2015%2Creact%2Cstage-2&targets=&version=7.0.0-alpha.20) (flow/ts)
