### PR TITLE
Re-enable prettier v1.6.1

### DIFF
--- a/js/repl/CircleCI.js
+++ b/js/repl/CircleCI.js
@@ -22,7 +22,7 @@ async function sendRequest(repo: ?string, uri: string): Promise<Object> {
 export async function loadBuildArtifacts(
   repo: ?string,
   build: string,
-  cb: (url: string, error?: string) => void
+  cb: (url: string, error?: string) => void // eslint-disable-line no-unused-vars
 ): Promise<string> {
   try {
     const response = await sendRequest(repo, `${build}/artifacts`);

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -40,7 +40,7 @@ const pluginConfigs: Array<PluginConfig> = [
   {   
     label: "Prettify",    
     package: "prettier",    
-    version: "1",   
+    version: "1.6.1",   
   },
 ];
 

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -37,6 +37,11 @@ const pluginConfigs: Array<PluginConfig> = [
     package: "babili-standalone", // TODO Switch to babel-minify-standalone
     version: "0",
   },
+  {   
+    label: "Prettify",    
+    package: "prettier",    
+    version: "1",   
+  },
 ];
 
 export {

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -37,10 +37,10 @@ const pluginConfigs: Array<PluginConfig> = [
     package: "babili-standalone", // TODO Switch to babel-minify-standalone
     version: "0",
   },
-  {   
-    label: "Prettify",    
-    package: "prettier",    
-    version: "1.6.1",   
+  {
+    label: "Prettify",
+    package: "prettier",
+    version: "1.6.1",
   },
 ];
 

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -40,7 +40,7 @@ const pluginConfigs: Array<PluginConfig> = [
   {
     label: "Prettify",
     package: "prettier",
-    version: "1.6.1",
+    version: "1.6.1", // v1.7.0+ causes runtime errors; see issue #1388
   },
 ];
 

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -292,7 +292,7 @@ class Repl extends React.Component {
         // Because it's loaded in a worker, we need to configure it there as well.
         this._workerApi
           .registerEnvPreset()
-          .then(success => this._updateCode(this.state.code));
+          .then(() => this._updateCode(this.state.code));
       });
     }
   }

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -77,6 +77,7 @@ class Repl extends React.Component {
 
     const defaultPlugins = {
       "babili-standalone": persistedState.babili,
+      prettier: persistedState.prettier,
     };
 
     const presets =
@@ -314,6 +315,7 @@ class Repl extends React.Component {
         evaluate:
           runtimePolyfillState.isEnabled && runtimePolyfillState.isLoaded,
         presets: presetsArray,
+        prettify: state.plugins.prettier.isEnabled,
         sourceMap: runtimePolyfillState.isEnabled,
         useBuiltIns: state.builtIns,
       })
@@ -417,6 +419,7 @@ class Repl extends React.Component {
       isSettingsTabExpanded: state.isSettingsTabExpanded,
       lineWrap: state.lineWrap,
       presets: presetsArray.join(","),
+      prettier: plugins.prettier.isEnabled,
       showSidebar: state.isSidebarExpanded,
       targets: envConfigToTargetsString(envConfig),
       version: state.babel.version,

--- a/js/repl/UriUtils.js
+++ b/js/repl/UriUtils.js
@@ -15,6 +15,7 @@ const URL_KEYS = [
   "evaluate",
   "lineWrap",
   "presets",
+  "prettier",
   "targets",
   "version",
 ];

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -86,7 +86,7 @@ export default function compile(code: string, config: CompileConfig): Return {
       }
     }
 
-    if (config.prettify && prettier !== undefined) {    
+    if (config.prettify && typeof prettier !== "undefined") {    
       // TODO Don't re-parse; just pass Prettier the AST we already have.   
       // This will have to wait until we've updated to Babel 7 since Prettier uses it.    
       // Prettier doesn't handle ASTs from Babel 6.   

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -15,16 +15,16 @@ type Return = {
   sourceMap: ?string,
 };
 
-const DEFAULT_PRETTIER_CONFIG = {   
-  bracketSpacing: true,   
-  jsxBracketSameLine: false,    
-  parser: "babylon",    
-  printWidth: 80,   
-  semi: true,   
-  singleQuote: false,   
-  tabWidth: 2,    
-  trailingComma: "none",    
-  useTabs: false,   
+const DEFAULT_PRETTIER_CONFIG = {
+  bracketSpacing: true,
+  jsxBracketSameLine: false,
+  parser: "babylon",
+  printWidth: 80,
+  semi: true,
+  singleQuote: false,
+  tabWidth: 2,
+  trailingComma: "none",
+  useTabs: false,
 };
 
 export default function compile(code: string, config: CompileConfig): Return {
@@ -86,18 +86,18 @@ export default function compile(code: string, config: CompileConfig): Return {
       }
     }
 
-    if (config.prettify && typeof prettier !== "undefined") {    
-      // TODO Don't re-parse; just pass Prettier the AST we already have.   
-      // This will have to wait until we've updated to Babel 7 since Prettier uses it.    
-      // Prettier doesn't handle ASTs from Babel 6.   
-      // if (   
-      //   prettier.__debug !== undefined &&    
-      //   typeof prettier.__debug.formatAST === 'function'   
-      // ) {    
-      //   compiled = prettier.__debug.formatAST(transformed.ast, DEFAULT_PRETTIER_CONFIG);   
-      // } else {   
-      compiled = prettier.format(compiled, DEFAULT_PRETTIER_CONFIG);    
-      // }    
+    if (config.prettify && typeof prettier !== "undefined") {
+      // TODO Don't re-parse; just pass Prettier the AST we already have.
+      // This will have to wait until we've updated to Babel 7 since Prettier uses it.
+      // Prettier doesn't handle ASTs from Babel 6.
+      // if (
+      //   prettier.__debug !== undefined &&
+      //   typeof prettier.__debug.formatAST === 'function'
+      // ) {
+      //   compiled = prettier.__debug.formatAST(transformed.ast, DEFAULT_PRETTIER_CONFIG);
+      // } else {
+      compiled = prettier.format(compiled, DEFAULT_PRETTIER_CONFIG);
+      // }
     }
   } catch (error) {
     compiled = null;

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -2,6 +2,7 @@
 
 // Globals pre-loaded by Worker
 declare var Babel: any;
+declare var prettier: any;
 
 import { getDebugInfoFromEnvResult } from "./replUtils";
 
@@ -12,6 +13,18 @@ type Return = {
   compileErrorMessage: ?string,
   envPresetDebugInfo: ?string,
   sourceMap: ?string,
+};
+
+const DEFAULT_PRETTIER_CONFIG = {   
+  bracketSpacing: true,   
+  jsxBracketSameLine: false,    
+  parser: "babylon",    
+  printWidth: 80,   
+  semi: true,   
+  singleQuote: false,   
+  tabWidth: 2,    
+  trailingComma: "none",    
+  useTabs: false,   
 };
 
 export default function compile(code: string, config: CompileConfig): Return {
@@ -71,6 +84,20 @@ export default function compile(code: string, config: CompileConfig): Return {
       } catch (error) {
         console.error(`Source Map generation failed: ${error}`);
       }
+    }
+
+    if (config.prettify && prettier !== undefined) {    
+      // TODO Don't re-parse; just pass Prettier the AST we already have.   
+      // This will have to wait until we've updated to Babel 7 since Prettier uses it.    
+      // Prettier doesn't handle ASTs from Babel 6.   
+      // if (   
+      //   prettier.__debug !== undefined &&    
+      //   typeof prettier.__debug.formatAST === 'function'   
+      // ) {    
+      //   compiled = prettier.__debug.formatAST(transformed.ast, DEFAULT_PRETTIER_CONFIG);   
+      // } else {   
+      compiled = prettier.format(compiled, DEFAULT_PRETTIER_CONFIG);    
+      // }    
     }
   } catch (error) {
     compiled = null;

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -51,6 +51,7 @@ export const loadPersistedState = (): PersistedState => {
     isSettingsTabExpanded: merged.isSettingsTabExpanded !== false, // Default to show
     lineWrap: merged.lineWrap != null ? merged.lineWrap : true,
     presets: merged.hasOwnProperty("presets") ? merged.presets : null,
+    prettier: merged.prettier === true,
     showSidebar: merged.showSidebar !== false, // Default to show
     targets: merged.targets || "",
     version: merged.version || "",

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -49,6 +49,7 @@ export type CompileConfig = {
   envConfig: ?EnvConfig,
   evaluate: boolean,
   presets: BabelPresets,
+  prettify: boolean,
   sourceMap: boolean,
   useBuiltIns: boolean,
 };
@@ -67,6 +68,7 @@ export type PersistedState = {
   isSettingsTabExpanded: boolean,
   lineWrap: boolean,
   presets: ?string,
+  prettier: boolean,
   showSidebar: boolean,
   targets: string,
   version: string,


### PR DESCRIPTION
Follow up for PR #1395

Looks like Prettier v1.7.0 broke for the browser with the error "_cosmiconfig requires at least version 4 of Node_" and v1.8.0 broke with the error "_os$2.homedir is not a function_". Version 1.6.1 was working before though, so I'm re-enabling and pinning us to that version for the time being.

Note that I'm seeing 3 Flow errors in this branch when I run `yarn flow` locally, but I also see those 3 errors on master. ☹️  Seems like this got broken at some point?