### PR TITLE
Update download-readmes.js -> Babylon

### DIFF
--- a/scripts/download-readmes.js
+++ b/scripts/download-readmes.js
@@ -45,7 +45,7 @@ Promise.all([getDirectoryListing('babel', '6.x'), getDirectoryListing('minify')]
       },
       {
         name: 'babylon',
-        uri: '/babel/babylon/master/README.md',
+        uri: '/babel/babel/master/packages/babylon/README.md',
       },
     ];
 


### PR DESCRIPTION
Babylon has been moved into the main Babel mono-repo.
Change download uri to /babel/babel/master/packages/babylon/README.md.