### PR TITLE
Add a section explaining how to tell if you depend on deprecated presets or not

### DIFF
--- a/env.md
+++ b/env.md
@@ -11,6 +11,16 @@ permalink: /env/
 
 If you are using Babel version 7 you will need to run `npm install @babel/preset-env` and have `"presets": ["@babel/preset-env"]` in your configuration.
 
+## Before you do anything
+
+You might end up on this page because you saw a message in the terminal like this:
+
+>🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
+
+Before you proceed further, ask yourself: are you *using* Babel? Check your `package.json` and look for `babel-preset-es2015` or a similar preset there. If you see a preset like this in your `package.json`, read on!
+
+If you don't use Babel or don't use deprecated yearly presets, you probably saw this message because *another package* you depend on uses them. **In that case there's nothing *you* need to do**. Nevertheless, it might be a good idea to find out which package uses the deprecated presets, and help them migrate by sending a pull request. You can find this out by running `npm ls babel-preset-es2015` which will show the dependency tree. 
+
 ## Upgrading to `babel-preset-env`
 
 ### Install


### PR DESCRIPTION
See my thread here:

https://mobile.twitter.com/dan_abramov/status/950385471846264833

Beginners see this message regardless of whether they use Babel directly. The advice on this page encourages them to always install this preset. In case of tools like Create React App this can actually break their setups (due to version incompatibility).