### PR TITLE
Use heading ids generated by kramdown

### DIFF
--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -73,6 +73,8 @@
     }
   });
 
+  $('.docs-content a[href^=#]').addClass('smooth-scroll');
+
   var $root = $('html, body');
   $('a.smooth-scroll').on('click', function(event) {
       event.preventDefault();

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -1,36 +1,15 @@
 (function() {
 
-  var STRING_DECAMELIZE_REGEXP = (/([a-z\d])([A-Z])/g);
-  var STRING_STRIP_HTML_REGEXP = (/(<[^>]*>)/g);
-  var STRING_DASHERIZE_REGEXP  = (/[^a-z\d]+/g);
-
-  var decamelize = _.memoize(function(str) {
-    return str.replace(STRING_DECAMELIZE_REGEXP, '$1_$2').toLowerCase();
-  });
-
-  var stripHtml = _.memoize(function(str) {
-    return str.replace(STRING_STRIP_HTML_REGEXP, '');
-  });
-
-  var dasherize = _.memoize(function(str) {
-    return decamelize(stripHtml(str)).replace(STRING_DASHERIZE_REGEXP, '-');
-  });
-
   var headings = [];
   var current;
 
   $('h2, h3').each(function(index, heading) {
     var isSubHeading = heading.tagName.toUpperCase() !== 'H2';
-    var textContent = heading.textContent;
-    var idPrefix = isSubHeading && current ? current.id : '';
-    var id = dasherize(idPrefix + textContent);
-
-    heading.id = id;
 
     var value = {
       el: headings,
       id: heading.id,
-      text: textContent,
+      text: heading.textContent,
       children: []
     };
 


### PR DESCRIPTION
The current approach to create ids from `h2`'s id and `h3`'s text content has some problems.

1. Same anchor links work for only one of the website or README pages on GitHub. https://github.com/babel/babel/pull/7214#issuecomment-357510259
2. Algolia doesn't work well with the ids. It seems to index ids in HTML, which are generated by kramdown.
3. The current way of creating ids misses a `-` when `h3` starts with <code>`</code>.

https://github.com/babel/website/pull/1035 tried to fix an issue of duplicated ids in a page by prefixing an `h3` id with its parent `h2` id. However, kramdown already solves this by suffixing ids with `-1`, `-2`, and so on. GitHub seems to do the same for markdown files. e.g., https://github.com/babel/website/blob/master/docs/plugins.md#experimental-1

Also, adding animated scrolling to anchor links in content. For example, the link "See Helper aliasing" in https://babeljs.io/docs/plugins/transform-runtime/#options will have animated scrolling.
