### PR TITLE
Fix version overriding for preset-env.

### DIFF
--- a/js/repl/loadBundle.js
+++ b/js/repl/loadBundle.js
@@ -126,7 +126,7 @@ export default async function loadBundle(
   if (config.instanceName === "babelPresetEnv") {
     const babelVersion = await workerApi.getBundleVersion("Babel");
     if (parseInt(babelVersion) === 7 && parseInt(version) < 7) {
-      version = SCOPED_PRESET_ENV_VERSION_FROM;
+      version = babelVersion;
     }
   }
   const packageName = formatBundleName(config.package, version);


### PR DESCRIPTION
If Babel is 7 and preset-env is 6, use Babel current version.

cc @existentialism 