### PR TITLE
Fix snippets cut off in mobile

### DIFF
--- a/website/static/css/code-blocks.css
+++ b/website/static/css/code-blocks.css
@@ -4,6 +4,7 @@
   padding: 1em;
   position: relative;
   overflow-x: visible;
+  white-space: pre-wrap;
   border-left: 0;
   /* base 20px + header height */
   margin: 54px 0 20px;


### PR DESCRIPTION
Fix #1549 

The code snippets were cut off on small screens. This is not a bug with Docusaurus, since removing the custom CSS for `.hljs` at https://github.com/babel/website/blob/3ec8a278bb9416bd1ebf604d6b9fc96fc1f77346/website/static/css/code-blocks.css#L2 and https://github.com/babel/website/blob/3ec8a278bb9416bd1ebf604d6b9fc96fc1f77346/website/static/css/code-blocks.css#L13 brings in a scroll bar. I believe the reason for the snippets being cut off is `.h1js::before`, which is unique to the babel website. Also, other sites like [jest](https://facebook.github.io/jest/) use Docusaurus and they automatically get scroll bars.

Because we want a custom header like thing for the snippets, we'll have to make do with wrapped text and won't be able use a scroll bar. So, just adding a way to handle `white-space`.

Some screenshots*:

## Before
![js_before](https://user-images.githubusercontent.com/6594255/35765101-8844e09a-08e3-11e8-838f-c7cf86fe0668.PNG)
![shell_before](https://user-images.githubusercontent.com/6594255/35765120-be6a62e4-08e3-11e8-822d-4070961e95f0.PNG)

## After
![js_after](https://user-images.githubusercontent.com/6594255/35765127-d2ae5aee-08e3-11e8-85b6-a9fc105fccda.PNG)
![shell_after](https://user-images.githubusercontent.com/6594255/35765128-d2e7c5ae-08e3-11e8-8934-ce351d93e333.PNG)

_*The screenshots were taken using the Chrome devtools by simulating mobile view using Responsive - Mobile S_