### PR TITLE
Add babel-core to the gulp-babel install

### DIFF
--- a/_includes/tools/gulp/install.md
+++ b/_includes/tools/gulp/install.md
@@ -1,3 +1,3 @@
 ```sh
-npm install --save-dev gulp-babel
+npm install --save-dev gulp-babel babel-core
 ```


### PR DESCRIPTION
`babel-core` is now listed as a peer dependency in `gulp-babel`, therefore it needs to be explicitly installed.

Following the issue referenced here: https://github.com/babel/gulp-babel/issues/124