### PR TITLE
Fix links to preset-stage-x

### DIFF
--- a/website/versioned_docs/version-6.x/preset-stage-0.md
+++ b/website/versioned_docs/version-6.x/preset-stage-0.md
@@ -21,9 +21,9 @@ This preset includes the following plugins:
 
 And all plugins from presets:
 
-- [preset-stage-1](https://babeljs.io/docs/en/babel-preset-stage-1)
-- [preset-stage-2](https://babeljs.io/docs/en/babel-preset-stage-2)
-- [preset-stage-3](https://babeljs.io/docs/en/babel-preset-stage-3)
+- [preset-stage-1](https://babeljs.io/docs/en/preset-stage-1)
+- [preset-stage-2](https://babeljs.io/docs/en/preset-stage-2)
+- [preset-stage-3](https://babeljs.io/docs/en/preset-stage-3)
 
 > You can check the src/index.js to be sure the plugins used.
 

--- a/website/versioned_docs/version-6.x/preset-stage-1.md
+++ b/website/versioned_docs/version-6.x/preset-stage-1.md
@@ -23,8 +23,8 @@ This preset includes the following plugins:
 
 And all plugins from presets:
 
-- [preset-stage-2](https://babeljs.io/docs/en/babel-preset-stage-2)
-- [preset-stage-3](https://babeljs.io/docs/en/babel-preset-stage-3)
+- [preset-stage-2](https://babeljs.io/docs/en/preset-stage-2)
+- [preset-stage-3](https://babeljs.io/docs/en/preset-stage-3)
 
 > You can check the src/index.js to be sure the plugins used.
 

--- a/website/versioned_docs/version-6.x/preset-stage-2.md
+++ b/website/versioned_docs/version-6.x/preset-stage-2.md
@@ -24,7 +24,7 @@ This preset includes the following plugins:
 
 And all plugins from presets:
 
-- [preset-stage-3](https://babeljs.io/docs/en/babel-preset-stage-3)
+- [preset-stage-3](https://babeljs.io/docs/en/preset-stage-3)
 
 > You can check the src/index.js to be sure the plugins used.
 


### PR DESCRIPTION
Links on the preset-stage-x pages were pointing to `/babel-preset-stage-x` rather than `/preset-stage-x`