### PR TITLE
add ga

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,4 +36,13 @@
   <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <meta name="twitter:image:src" content="https://babeljs.io/images/share-image.png">
   <meta name="twitter:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-114990275-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-114990275-1');
+  </script>
 </head>


### PR DESCRIPTION
Didn't see where cloudflare could track what pages were being visited or not. Would like to know number of users going to the home page, repl, and docs. Tracking repl usage should help us actually modify the UI and be a proxy for how people might use it in the tool itself since we won't be adding analytics there.

hope this is correct