### PR TITLE
Fix on-page nav scroll

### DIFF
--- a/website/static/css/babel.css
+++ b/website/static/css/babel.css
@@ -208,3 +208,7 @@ a.anchor {
 footer.nav-footer {
   background: #767676;
 }
+
+.onPageNav {
+  align-self: flex-start;
+}


### PR DESCRIPTION
This fixes a css bug with the height of the on-page nav so that it's visible even when the nav is too short and the page is scrolled to the bottom.

We can wait for this to be upstreamed to docusaurus, or push now and remove it with next docusaurus version bump.