### PR TITLE
Sentence reordering

### DIFF
--- a/docs/babelrc.md
+++ b/docs/babelrc.md
@@ -35,7 +35,7 @@ module.exports = {
 
 ## Use via `package.json`
 
-You can alternatively choose to specify your `.babelrc` config from within `package.json` like so:
+Alternatively, you can choose to specify your `.babelrc` config from within `package.json` like so:
 
 ```json
 {


### PR DESCRIPTION
Instead of, 'You can alternatively choose', you could use, 'Alternatively, you can choose'.