### PR TITLE
external repl plugin search: use computedKeywords

### DIFF
--- a/js/repl/ExternalPlugins.js
+++ b/js/repl/ExternalPlugins.js
@@ -117,7 +117,7 @@ export default function ExternalPlugins({
           attributesToRetrieve={["name", "version"]}
           attributesToHighlight={["name"]}
           filters={
-            "keywords:babel-plugin" +
+            "computedKeywords:babel-plugin" +
             (showOfficialExternalPlugins ? " AND owner.name:babel" : "")
           }
         />


### PR DESCRIPTION
The value is still working for both `keywords` and `computedKeywords`, but I want to put the handling of special keywords like babel plugins in there alone and remove the messing with `keywords` in the index.

cc @xtuc