### PR TITLE
Clean docs frontmatters to remove warnings

### DIFF
--- a/docs/babelrc.md
+++ b/docs/babelrc.md
@@ -1,7 +1,5 @@
 ---
 title: .babelrc
-description: How to use a .babelrc
-
 id: babelrc
 ---
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -1,7 +1,5 @@
 ---
 title: Caveats
-description: Just some things to keep in mind when using Babel.
-
 id: caveats
 ---
 

--- a/docs/core-packages.md
+++ b/docs/core-packages.md
@@ -1,7 +1,5 @@
 ---
 title: Babel's core packages
-description: The Babel repo is managed as a monorepo; it's composed of many npm packages
-
 id: core-packages
 ---
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -1,7 +1,5 @@
 ---
 title: Editors
-description: Learn how to use Babel in your editor of choice
-
 id: editors
 ---
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,8 +1,5 @@
 ---
-layout: docs
 title: babel-preset-es2015 -> babel-preset-env
-permalink: /env/
-
 id: env
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: FAQ
-description: Frequently Asked Questions and Answers
-permalink: /faq/
-
 id: faq
 ---
 

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: Learn ES2015
-description: A detailed overview of ECMAScript 2015 features. Based on Luke Hoban's es6features repo.
-permalink: /learn-es2015/
-
 id: learn
 ---
 

--- a/docs/v7-migration-api.md
+++ b/docs/v7-migration-api.md
@@ -1,6 +1,5 @@
 ---
 title:  "Upgrade to Babel 7 (API)"
-
 id: v7-migration-api
 ---
 

--- a/docs/v7-migration.md
+++ b/docs/v7-migration.md
@@ -1,6 +1,5 @@
 ---
 title:  "Upgrade to Babel 7"
-
 id: v7-migration
 ---
 

--- a/scripts/download-readmes.js
+++ b/scripts/download-readmes.js
@@ -9,11 +9,12 @@ const CONCURRENT_REQUESTS = 20;
 
 const addFrontMatter = (id, text) =>
   `---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js
 id: ${id}
 title: ${id}
 sidebar_label: ${id.replace(/^babel-(plugin|proposal|preset)-/, "")}
 ---
+
+[comment]: # Don't edit this file directly, it was copied using scripts/download-readmes.js
 
 ${text}
 `;

--- a/website/versioned_docs/version-6.x/babel.md
+++ b/website/versioned_docs/version-6.x/babel.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel
 title: babel
 sidebar_label: babel

--- a/website/versioned_docs/version-6.x/babelrc.md
+++ b/website/versioned_docs/version-6.x/babelrc.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: .babelrc
-description: How to use the .babelrc
-permalink: /docs/usage/babelrc/
-: 
 id: version-6.x-babelrc
 original_id: babelrc
 ---

--- a/website/versioned_docs/version-6.x/babylon.md
+++ b/website/versioned_docs/version-6.x/babylon.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babylon
 title: babylon
 sidebar_label: babylon

--- a/website/versioned_docs/version-6.x/caveats.md
+++ b/website/versioned_docs/version-6.x/caveats.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: Caveats
-description: Just some things to keep in mind when using Babel.
-permalink: /docs/usage/caveats/
-: 
 id: version-6.x-caveats
 original_id: caveats
 ---

--- a/website/versioned_docs/version-6.x/cli.md
+++ b/website/versioned_docs/version-6.x/cli.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-cli
 title: babel-cli
 sidebar_label: babel-cli

--- a/website/versioned_docs/version-6.x/code-frame.md
+++ b/website/versioned_docs/version-6.x/code-frame.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-code-frame
 title: babel-code-frame
 sidebar_label: babel-code-frame

--- a/website/versioned_docs/version-6.x/core-packages.md
+++ b/website/versioned_docs/version-6.x/core-packages.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: Babel's core packages
-description: The Babel repo is managed as a monorepo; it's composed of many npm packages
-permalink: /docs/core-packages/
-package: babel-core
 id: version-6.x-core-packages
 original_id: core-packages
 ---

--- a/website/versioned_docs/version-6.x/core.md
+++ b/website/versioned_docs/version-6.x/core.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-core
 title: babel-core
 sidebar_label: babel-core

--- a/website/versioned_docs/version-6.x/editors.md
+++ b/website/versioned_docs/version-6.x/editors.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: Editors
-description: Learn how to use Babel in your editor of choice
-permalink: /docs/editors
-: 
 id: version-6.x-editors
 original_id: editors
 ---

--- a/website/versioned_docs/version-6.x/env.md
+++ b/website/versioned_docs/version-6.x/env.md
@@ -1,8 +1,5 @@
 ---
-layout: docs
 title: babel-preset-es2015 -> babel-preset-env
-permalink: /env/
-: 
 id: version-6.x-env
 original_id: env
 ---

--- a/website/versioned_docs/version-6.x/faq.md
+++ b/website/versioned_docs/version-6.x/faq.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: FAQ
-description: Frequently Asked Questions and Answers
-permalink: /faq/
-: 
 id: version-6.x-faq
 original_id: faq
 ---

--- a/website/versioned_docs/version-6.x/generator.md
+++ b/website/versioned_docs/version-6.x/generator.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-generator
 title: babel-generator
 sidebar_label: babel-generator

--- a/website/versioned_docs/version-6.x/gulp-babel-minify.md
+++ b/website/versioned_docs/version-6.x/gulp-babel-minify.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-gulp-babel-minify
 title: gulp-babel-minify
 sidebar_label: gulp-babel-minify

--- a/website/versioned_docs/version-6.x/helper-bindify-decorators.md
+++ b/website/versioned_docs/version-6.x/helper-bindify-decorators.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-bindify-decorators
 title: babel-helper-bindify-decorators
 sidebar_label: babel-helper-bindify-decorators

--- a/website/versioned_docs/version-6.x/helper-builder-binary-assignment-operator-visitor.md
+++ b/website/versioned_docs/version-6.x/helper-builder-binary-assignment-operator-visitor.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-builder-binary-assignment-operator-visitor
 title: babel-helper-builder-binary-assignment-operator-visitor
 sidebar_label: babel-helper-builder-binary-assignment-operator-visitor

--- a/website/versioned_docs/version-6.x/helper-builder-conditional-assignment-operator-visitor.md
+++ b/website/versioned_docs/version-6.x/helper-builder-conditional-assignment-operator-visitor.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-builder-conditional-assignment-operator-visitor
 title: babel-helper-builder-conditional-assignment-operator-visitor
 sidebar_label: babel-helper-builder-conditional-assignment-operator-visitor

--- a/website/versioned_docs/version-6.x/helper-builder-react-jsx.md
+++ b/website/versioned_docs/version-6.x/helper-builder-react-jsx.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-builder-react-jsx
 title: babel-helper-builder-react-jsx
 sidebar_label: babel-helper-builder-react-jsx

--- a/website/versioned_docs/version-6.x/helper-call-delegate.md
+++ b/website/versioned_docs/version-6.x/helper-call-delegate.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-call-delegate
 title: babel-helper-call-delegate
 sidebar_label: babel-helper-call-delegate

--- a/website/versioned_docs/version-6.x/helper-define-map.md
+++ b/website/versioned_docs/version-6.x/helper-define-map.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-define-map
 title: babel-helper-define-map
 sidebar_label: babel-helper-define-map

--- a/website/versioned_docs/version-6.x/helper-evaluate-path.md
+++ b/website/versioned_docs/version-6.x/helper-evaluate-path.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-evaluate-path
 title: babel-helper-evaluate-path
 sidebar_label: babel-helper-evaluate-path

--- a/website/versioned_docs/version-6.x/helper-explode-assignable-expression.md
+++ b/website/versioned_docs/version-6.x/helper-explode-assignable-expression.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-explode-assignable-expression
 title: babel-helper-explode-assignable-expression
 sidebar_label: babel-helper-explode-assignable-expression

--- a/website/versioned_docs/version-6.x/helper-explode-class.md
+++ b/website/versioned_docs/version-6.x/helper-explode-class.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-explode-class
 title: babel-helper-explode-class
 sidebar_label: babel-helper-explode-class

--- a/website/versioned_docs/version-6.x/helper-fixtures.md
+++ b/website/versioned_docs/version-6.x/helper-fixtures.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-fixtures
 title: babel-helper-fixtures
 sidebar_label: babel-helper-fixtures

--- a/website/versioned_docs/version-6.x/helper-flip-expressions.md
+++ b/website/versioned_docs/version-6.x/helper-flip-expressions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-flip-expressions
 title: babel-helper-flip-expressions
 sidebar_label: babel-helper-flip-expressions

--- a/website/versioned_docs/version-6.x/helper-function-name.md
+++ b/website/versioned_docs/version-6.x/helper-function-name.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-function-name
 title: babel-helper-function-name
 sidebar_label: babel-helper-function-name

--- a/website/versioned_docs/version-6.x/helper-get-function-arity.md
+++ b/website/versioned_docs/version-6.x/helper-get-function-arity.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-get-function-arity
 title: babel-helper-get-function-arity
 sidebar_label: babel-helper-get-function-arity

--- a/website/versioned_docs/version-6.x/helper-hoist-variables.md
+++ b/website/versioned_docs/version-6.x/helper-hoist-variables.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-hoist-variables
 title: babel-helper-hoist-variables
 sidebar_label: babel-helper-hoist-variables

--- a/website/versioned_docs/version-6.x/helper-is-void-0.md
+++ b/website/versioned_docs/version-6.x/helper-is-void-0.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-is-void-0
 title: babel-helper-is-void-0
 sidebar_label: babel-helper-is-void-0

--- a/website/versioned_docs/version-6.x/helper-mark-eval-scopes.md
+++ b/website/versioned_docs/version-6.x/helper-mark-eval-scopes.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-mark-eval-scopes
 title: babel-helper-mark-eval-scopes
 sidebar_label: babel-helper-mark-eval-scopes

--- a/website/versioned_docs/version-6.x/helper-optimise-call-expression.md
+++ b/website/versioned_docs/version-6.x/helper-optimise-call-expression.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-optimise-call-expression
 title: babel-helper-optimise-call-expression
 sidebar_label: babel-helper-optimise-call-expression

--- a/website/versioned_docs/version-6.x/helper-plugin-test-runner.md
+++ b/website/versioned_docs/version-6.x/helper-plugin-test-runner.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-plugin-test-runner
 title: babel-helper-plugin-test-runner
 sidebar_label: babel-helper-plugin-test-runner

--- a/website/versioned_docs/version-6.x/helper-regex.md
+++ b/website/versioned_docs/version-6.x/helper-regex.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-regex
 title: babel-helper-regex
 sidebar_label: babel-helper-regex

--- a/website/versioned_docs/version-6.x/helper-remap-async-to-generator.md
+++ b/website/versioned_docs/version-6.x/helper-remap-async-to-generator.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-remap-async-to-generator
 title: babel-helper-remap-async-to-generator
 sidebar_label: babel-helper-remap-async-to-generator

--- a/website/versioned_docs/version-6.x/helper-remove-or-void.md
+++ b/website/versioned_docs/version-6.x/helper-remove-or-void.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-remove-or-void
 title: babel-helper-remove-or-void
 sidebar_label: babel-helper-remove-or-void

--- a/website/versioned_docs/version-6.x/helper-replace-supers.md
+++ b/website/versioned_docs/version-6.x/helper-replace-supers.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-replace-supers
 title: babel-helper-replace-supers
 sidebar_label: babel-helper-replace-supers

--- a/website/versioned_docs/version-6.x/helper-to-multiple-sequence-expressions.md
+++ b/website/versioned_docs/version-6.x/helper-to-multiple-sequence-expressions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-to-multiple-sequence-expressions
 title: babel-helper-to-multiple-sequence-expressions
 sidebar_label: babel-helper-to-multiple-sequence-expressions

--- a/website/versioned_docs/version-6.x/helper-transform-fixture-test-runner.md
+++ b/website/versioned_docs/version-6.x/helper-transform-fixture-test-runner.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helper-transform-fixture-test-runner
 title: babel-helper-transform-fixture-test-runner
 sidebar_label: babel-helper-transform-fixture-test-runner

--- a/website/versioned_docs/version-6.x/helpers.md
+++ b/website/versioned_docs/version-6.x/helpers.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-helpers
 title: babel-helpers
 sidebar_label: babel-helpers

--- a/website/versioned_docs/version-6.x/learn.md
+++ b/website/versioned_docs/version-6.x/learn.md
@@ -1,9 +1,5 @@
 ---
-layout: docs
 title: Learn ES2015
-description: A detailed overview of ECMAScript 2015 features. Based on Luke Hoban's es6features repo.
-permalink: /learn-es2015/
-: 
 id: version-6.x-learn
 original_id: learn
 ---

--- a/website/versioned_docs/version-6.x/messages.md
+++ b/website/versioned_docs/version-6.x/messages.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-messages
 title: babel-messages
 sidebar_label: babel-messages

--- a/website/versioned_docs/version-6.x/minify.md
+++ b/website/versioned_docs/version-6.x/minify.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-minify
 title: babel-minify
 sidebar_label: babel-minify

--- a/website/versioned_docs/version-6.x/plugin-check-es2015-constants.md
+++ b/website/versioned_docs/version-6.x/plugin-check-es2015-constants.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-check-es2015-constants
 title: babel-plugin-check-es2015-constants
 sidebar_label: check-es2015-constants

--- a/website/versioned_docs/version-6.x/plugin-external-helpers.md
+++ b/website/versioned_docs/version-6.x/plugin-external-helpers.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-external-helpers
 title: babel-plugin-external-helpers
 sidebar_label: external-helpers

--- a/website/versioned_docs/version-6.x/plugin-minify-builtins.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-builtins.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-builtins
 title: babel-plugin-minify-builtins
 sidebar_label: minify-builtins

--- a/website/versioned_docs/version-6.x/plugin-minify-constant-folding.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-constant-folding.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-constant-folding
 title: babel-plugin-minify-constant-folding
 sidebar_label: minify-constant-folding

--- a/website/versioned_docs/version-6.x/plugin-minify-dead-code-elimination.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-dead-code-elimination.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-dead-code-elimination
 title: babel-plugin-minify-dead-code-elimination
 sidebar_label: minify-dead-code-elimination

--- a/website/versioned_docs/version-6.x/plugin-minify-flip-comparisons.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-flip-comparisons.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-flip-comparisons
 title: babel-plugin-minify-flip-comparisons
 sidebar_label: minify-flip-comparisons

--- a/website/versioned_docs/version-6.x/plugin-minify-guarded-expressions.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-guarded-expressions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-guarded-expressions
 title: babel-plugin-minify-guarded-expressions
 sidebar_label: minify-guarded-expressions

--- a/website/versioned_docs/version-6.x/plugin-minify-infinity.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-infinity.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-infinity
 title: babel-plugin-minify-infinity
 sidebar_label: minify-infinity

--- a/website/versioned_docs/version-6.x/plugin-minify-mangle-names.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-mangle-names.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-mangle-names
 title: babel-plugin-minify-mangle-names
 sidebar_label: minify-mangle-names

--- a/website/versioned_docs/version-6.x/plugin-minify-numeric-literals.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-numeric-literals.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-numeric-literals
 title: babel-plugin-minify-numeric-literals
 sidebar_label: minify-numeric-literals

--- a/website/versioned_docs/version-6.x/plugin-minify-replace.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-replace.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-replace
 title: babel-plugin-minify-replace
 sidebar_label: minify-replace

--- a/website/versioned_docs/version-6.x/plugin-minify-simplify.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-simplify.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-simplify
 title: babel-plugin-minify-simplify
 sidebar_label: minify-simplify

--- a/website/versioned_docs/version-6.x/plugin-minify-type-constructors.md
+++ b/website/versioned_docs/version-6.x/plugin-minify-type-constructors.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-minify-type-constructors
 title: babel-plugin-minify-type-constructors
 sidebar_label: minify-type-constructors

--- a/website/versioned_docs/version-6.x/plugin-syntax-async-functions.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-async-functions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-async-functions
 title: babel-plugin-syntax-async-functions
 sidebar_label: syntax-async-functions

--- a/website/versioned_docs/version-6.x/plugin-syntax-async-generators.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-async-generators.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-async-generators
 title: babel-plugin-syntax-async-generators
 sidebar_label: syntax-async-generators

--- a/website/versioned_docs/version-6.x/plugin-syntax-class-constructor-call.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-class-constructor-call.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-class-constructor-call
 title: babel-plugin-syntax-class-constructor-call
 sidebar_label: syntax-class-constructor-call

--- a/website/versioned_docs/version-6.x/plugin-syntax-class-properties.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-class-properties.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-class-properties
 title: babel-plugin-syntax-class-properties
 sidebar_label: syntax-class-properties

--- a/website/versioned_docs/version-6.x/plugin-syntax-decorators.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-decorators.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-decorators
 title: babel-plugin-syntax-decorators
 sidebar_label: syntax-decorators

--- a/website/versioned_docs/version-6.x/plugin-syntax-do-expressions.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-do-expressions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-do-expressions
 title: babel-plugin-syntax-do-expressions
 sidebar_label: syntax-do-expressions

--- a/website/versioned_docs/version-6.x/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-dynamic-import.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-dynamic-import
 title: babel-plugin-syntax-dynamic-import
 sidebar_label: syntax-dynamic-import

--- a/website/versioned_docs/version-6.x/plugin-syntax-exponentiation-operator.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-exponentiation-operator.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-exponentiation-operator
 title: babel-plugin-syntax-exponentiation-operator
 sidebar_label: syntax-exponentiation-operator

--- a/website/versioned_docs/version-6.x/plugin-syntax-export-extensions.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-export-extensions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-export-extensions
 title: babel-plugin-syntax-export-extensions
 sidebar_label: syntax-export-extensions

--- a/website/versioned_docs/version-6.x/plugin-syntax-flow.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-flow.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-flow
 title: babel-plugin-syntax-flow
 sidebar_label: syntax-flow

--- a/website/versioned_docs/version-6.x/plugin-syntax-function-bind.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-function-bind.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-function-bind
 title: babel-plugin-syntax-function-bind
 sidebar_label: syntax-function-bind

--- a/website/versioned_docs/version-6.x/plugin-syntax-function-sent.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-function-sent.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-function-sent
 title: babel-plugin-syntax-function-sent
 sidebar_label: syntax-function-sent

--- a/website/versioned_docs/version-6.x/plugin-syntax-jsx.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-jsx.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-jsx
 title: babel-plugin-syntax-jsx
 sidebar_label: syntax-jsx

--- a/website/versioned_docs/version-6.x/plugin-syntax-object-rest-spread.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-object-rest-spread.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-object-rest-spread
 title: babel-plugin-syntax-object-rest-spread
 sidebar_label: syntax-object-rest-spread

--- a/website/versioned_docs/version-6.x/plugin-syntax-trailing-function-commas.md
+++ b/website/versioned_docs/version-6.x/plugin-syntax-trailing-function-commas.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-syntax-trailing-function-commas
 title: babel-plugin-syntax-trailing-function-commas
 sidebar_label: syntax-trailing-function-commas

--- a/website/versioned_docs/version-6.x/plugin-transform-async-functions.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-async-functions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-async-functions
 title: babel-plugin-transform-async-functions
 sidebar_label: transform-async-functions

--- a/website/versioned_docs/version-6.x/plugin-transform-async-generator-functions.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-async-generator-functions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-async-generator-functions
 title: babel-plugin-transform-async-generator-functions
 sidebar_label: transform-async-generator-functions

--- a/website/versioned_docs/version-6.x/plugin-transform-async-to-generator.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-async-to-generator.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-async-to-generator
 title: babel-plugin-transform-async-to-generator
 sidebar_label: transform-async-to-generator

--- a/website/versioned_docs/version-6.x/plugin-transform-async-to-module-method.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-async-to-module-method.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-async-to-module-method
 title: babel-plugin-transform-async-to-module-method
 sidebar_label: transform-async-to-module-method

--- a/website/versioned_docs/version-6.x/plugin-transform-class-constructor-call.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-class-constructor-call.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-class-constructor-call
 title: babel-plugin-transform-class-constructor-call
 sidebar_label: transform-class-constructor-call

--- a/website/versioned_docs/version-6.x/plugin-transform-class-properties.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-class-properties.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-class-properties
 title: babel-plugin-transform-class-properties
 sidebar_label: transform-class-properties

--- a/website/versioned_docs/version-6.x/plugin-transform-decorators.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-decorators.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-decorators
 title: babel-plugin-transform-decorators
 sidebar_label: transform-decorators

--- a/website/versioned_docs/version-6.x/plugin-transform-do-expressions.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-do-expressions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-do-expressions
 title: babel-plugin-transform-do-expressions
 sidebar_label: transform-do-expressions

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-arrow-functions.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-arrow-functions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-arrow-functions
 title: babel-plugin-transform-es2015-arrow-functions
 sidebar_label: transform-es2015-arrow-functions

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-block-scoped-functions.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-block-scoped-functions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-block-scoped-functions
 title: babel-plugin-transform-es2015-block-scoped-functions
 sidebar_label: transform-es2015-block-scoped-functions

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-block-scoping.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-block-scoping.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-block-scoping
 title: babel-plugin-transform-es2015-block-scoping
 sidebar_label: transform-es2015-block-scoping

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-classes.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-classes.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-classes
 title: babel-plugin-transform-es2015-classes
 sidebar_label: transform-es2015-classes

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-computed-properties.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-computed-properties.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-computed-properties
 title: babel-plugin-transform-es2015-computed-properties
 sidebar_label: transform-es2015-computed-properties

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-destructuring.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-destructuring.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-destructuring
 title: babel-plugin-transform-es2015-destructuring
 sidebar_label: transform-es2015-destructuring

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-duplicate-keys.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-duplicate-keys.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-duplicate-keys
 title: babel-plugin-transform-es2015-duplicate-keys
 sidebar_label: transform-es2015-duplicate-keys

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-for-of.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-for-of.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-for-of
 title: babel-plugin-transform-es2015-for-of
 sidebar_label: transform-es2015-for-of

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-function-name.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-function-name.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-function-name
 title: babel-plugin-transform-es2015-function-name
 sidebar_label: transform-es2015-function-name

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-instanceof.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-instanceof.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-instanceof
 title: babel-plugin-transform-es2015-instanceof
 sidebar_label: transform-es2015-instanceof

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-literals.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-literals.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-literals
 title: babel-plugin-transform-es2015-literals
 sidebar_label: transform-es2015-literals

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-amd.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-amd.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-modules-amd
 title: babel-plugin-transform-es2015-modules-amd
 sidebar_label: transform-es2015-modules-amd

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-commonjs.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-commonjs.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-modules-commonjs
 title: babel-plugin-transform-es2015-modules-commonjs
 sidebar_label: transform-es2015-modules-commonjs

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-systemjs.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-systemjs.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-modules-systemjs
 title: babel-plugin-transform-es2015-modules-systemjs
 sidebar_label: transform-es2015-modules-systemjs

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-umd.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-modules-umd.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-modules-umd
 title: babel-plugin-transform-es2015-modules-umd
 sidebar_label: transform-es2015-modules-umd

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-object-super.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-object-super.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-object-super
 title: babel-plugin-transform-es2015-object-super
 sidebar_label: transform-es2015-object-super

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-parameters.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-parameters.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-parameters
 title: babel-plugin-transform-es2015-parameters
 sidebar_label: transform-es2015-parameters

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-shorthand-properties.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-shorthand-properties.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-shorthand-properties
 title: babel-plugin-transform-es2015-shorthand-properties
 sidebar_label: transform-es2015-shorthand-properties

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-spread.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-spread.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-spread
 title: babel-plugin-transform-es2015-spread
 sidebar_label: transform-es2015-spread

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-sticky-regex.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-sticky-regex.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-sticky-regex
 title: babel-plugin-transform-es2015-sticky-regex
 sidebar_label: transform-es2015-sticky-regex

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-template-literals.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-template-literals.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-template-literals
 title: babel-plugin-transform-es2015-template-literals
 sidebar_label: transform-es2015-template-literals

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-typeof-symbol.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-typeof-symbol.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-typeof-symbol
 title: babel-plugin-transform-es2015-typeof-symbol
 sidebar_label: transform-es2015-typeof-symbol

--- a/website/versioned_docs/version-6.x/plugin-transform-es2015-unicode-regex.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es2015-unicode-regex.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es2015-unicode-regex
 title: babel-plugin-transform-es2015-unicode-regex
 sidebar_label: transform-es2015-unicode-regex

--- a/website/versioned_docs/version-6.x/plugin-transform-es3-member-expression-literals.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es3-member-expression-literals.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es3-member-expression-literals
 title: babel-plugin-transform-es3-member-expression-literals
 sidebar_label: transform-es3-member-expression-literals

--- a/website/versioned_docs/version-6.x/plugin-transform-es3-property-literals.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es3-property-literals.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es3-property-literals
 title: babel-plugin-transform-es3-property-literals
 sidebar_label: transform-es3-property-literals

--- a/website/versioned_docs/version-6.x/plugin-transform-es5-property-mutators.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-es5-property-mutators.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-es5-property-mutators
 title: babel-plugin-transform-es5-property-mutators
 sidebar_label: transform-es5-property-mutators

--- a/website/versioned_docs/version-6.x/plugin-transform-eval.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-eval.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-eval
 title: babel-plugin-transform-eval
 sidebar_label: transform-eval

--- a/website/versioned_docs/version-6.x/plugin-transform-exponentiation-operator.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-exponentiation-operator.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-exponentiation-operator
 title: babel-plugin-transform-exponentiation-operator
 sidebar_label: transform-exponentiation-operator

--- a/website/versioned_docs/version-6.x/plugin-transform-export-extensions.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-export-extensions.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-export-extensions
 title: babel-plugin-transform-export-extensions
 sidebar_label: transform-export-extensions

--- a/website/versioned_docs/version-6.x/plugin-transform-flow-comments.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-flow-comments.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-flow-comments
 title: babel-plugin-transform-flow-comments
 sidebar_label: transform-flow-comments

--- a/website/versioned_docs/version-6.x/plugin-transform-flow-strip-types.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-flow-strip-types.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-flow-strip-types
 title: babel-plugin-transform-flow-strip-types
 sidebar_label: transform-flow-strip-types

--- a/website/versioned_docs/version-6.x/plugin-transform-function-bind.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-function-bind.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-function-bind
 title: babel-plugin-transform-function-bind
 sidebar_label: transform-function-bind

--- a/website/versioned_docs/version-6.x/plugin-transform-inline-consecutive-adds.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-inline-consecutive-adds.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-inline-consecutive-adds
 title: babel-plugin-transform-inline-consecutive-adds
 sidebar_label: transform-inline-consecutive-adds

--- a/website/versioned_docs/version-6.x/plugin-transform-inline-environment-variables.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-inline-environment-variables.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-inline-environment-variables
 title: babel-plugin-transform-inline-environment-variables
 sidebar_label: transform-inline-environment-variables

--- a/website/versioned_docs/version-6.x/plugin-transform-jscript.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-jscript.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-jscript
 title: babel-plugin-transform-jscript
 sidebar_label: transform-jscript

--- a/website/versioned_docs/version-6.x/plugin-transform-member-expression-literals.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-member-expression-literals.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-member-expression-literals
 title: babel-plugin-transform-member-expression-literals
 sidebar_label: transform-member-expression-literals

--- a/website/versioned_docs/version-6.x/plugin-transform-merge-sibling-variables.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-merge-sibling-variables.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-merge-sibling-variables
 title: babel-plugin-transform-merge-sibling-variables
 sidebar_label: transform-merge-sibling-variables

--- a/website/versioned_docs/version-6.x/plugin-transform-minify-booleans.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-minify-booleans.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-minify-booleans
 title: babel-plugin-transform-minify-booleans
 sidebar_label: transform-minify-booleans

--- a/website/versioned_docs/version-6.x/plugin-transform-node-env-inline.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-node-env-inline.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-node-env-inline
 title: babel-plugin-transform-node-env-inline
 sidebar_label: transform-node-env-inline

--- a/website/versioned_docs/version-6.x/plugin-transform-object-assign.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-object-assign.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-object-assign
 title: babel-plugin-transform-object-assign
 sidebar_label: transform-object-assign

--- a/website/versioned_docs/version-6.x/plugin-transform-object-rest-spread.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-object-rest-spread.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-object-rest-spread
 title: babel-plugin-transform-object-rest-spread
 sidebar_label: transform-object-rest-spread

--- a/website/versioned_docs/version-6.x/plugin-transform-object-set-prototype-of-to-assign.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-object-set-prototype-of-to-assign.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-object-set-prototype-of-to-assign
 title: babel-plugin-transform-object-set-prototype-of-to-assign
 sidebar_label: transform-object-set-prototype-of-to-assign

--- a/website/versioned_docs/version-6.x/plugin-transform-property-literals.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-property-literals.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-property-literals
 title: babel-plugin-transform-property-literals
 sidebar_label: transform-property-literals

--- a/website/versioned_docs/version-6.x/plugin-transform-proto-to-assign.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-proto-to-assign.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-proto-to-assign
 title: babel-plugin-transform-proto-to-assign
 sidebar_label: transform-proto-to-assign

--- a/website/versioned_docs/version-6.x/plugin-transform-react-constant-elements.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-react-constant-elements.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-react-constant-elements
 title: babel-plugin-transform-react-constant-elements
 sidebar_label: transform-react-constant-elements

--- a/website/versioned_docs/version-6.x/plugin-transform-react-display-name.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-react-display-name.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-react-display-name
 title: babel-plugin-transform-react-display-name
 sidebar_label: transform-react-display-name

--- a/website/versioned_docs/version-6.x/plugin-transform-react-inline-elements.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-react-inline-elements.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-react-inline-elements
 title: babel-plugin-transform-react-inline-elements
 sidebar_label: transform-react-inline-elements

--- a/website/versioned_docs/version-6.x/plugin-transform-react-jsx-compat.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-react-jsx-compat.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-react-jsx-compat
 title: babel-plugin-transform-react-jsx-compat
 sidebar_label: transform-react-jsx-compat

--- a/website/versioned_docs/version-6.x/plugin-transform-react-jsx-self.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-react-jsx-self.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-react-jsx-self
 title: babel-plugin-transform-react-jsx-self
 sidebar_label: transform-react-jsx-self

--- a/website/versioned_docs/version-6.x/plugin-transform-react-jsx-source.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-react-jsx-source.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-react-jsx-source
 title: babel-plugin-transform-react-jsx-source
 sidebar_label: transform-react-jsx-source

--- a/website/versioned_docs/version-6.x/plugin-transform-react-jsx.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-react-jsx.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-react-jsx
 title: babel-plugin-transform-react-jsx
 sidebar_label: transform-react-jsx

--- a/website/versioned_docs/version-6.x/plugin-transform-regenerator.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-regenerator.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-regenerator
 title: babel-plugin-transform-regenerator
 sidebar_label: transform-regenerator

--- a/website/versioned_docs/version-6.x/plugin-transform-regexp-constructors.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-regexp-constructors.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-regexp-constructors
 title: babel-plugin-transform-regexp-constructors
 sidebar_label: transform-regexp-constructors

--- a/website/versioned_docs/version-6.x/plugin-transform-remove-console.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-remove-console.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-remove-console
 title: babel-plugin-transform-remove-console
 sidebar_label: transform-remove-console

--- a/website/versioned_docs/version-6.x/plugin-transform-remove-debugger.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-remove-debugger.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-remove-debugger
 title: babel-plugin-transform-remove-debugger
 sidebar_label: transform-remove-debugger

--- a/website/versioned_docs/version-6.x/plugin-transform-remove-undefined.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-remove-undefined.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-remove-undefined
 title: babel-plugin-transform-remove-undefined
 sidebar_label: transform-remove-undefined

--- a/website/versioned_docs/version-6.x/plugin-transform-runtime.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-runtime.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-runtime
 title: babel-plugin-transform-runtime
 sidebar_label: transform-runtime

--- a/website/versioned_docs/version-6.x/plugin-transform-simplify-comparison-operators.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-simplify-comparison-operators.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-simplify-comparison-operators
 title: babel-plugin-transform-simplify-comparison-operators
 sidebar_label: transform-simplify-comparison-operators

--- a/website/versioned_docs/version-6.x/plugin-transform-strict-mode.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-strict-mode.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-strict-mode
 title: babel-plugin-transform-strict-mode
 sidebar_label: transform-strict-mode

--- a/website/versioned_docs/version-6.x/plugin-transform-undefined-to-void.md
+++ b/website/versioned_docs/version-6.x/plugin-transform-undefined-to-void.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-transform-undefined-to-void
 title: babel-plugin-transform-undefined-to-void
 sidebar_label: transform-undefined-to-void

--- a/website/versioned_docs/version-6.x/plugin-undeclared-variables-check.md
+++ b/website/versioned_docs/version-6.x/plugin-undeclared-variables-check.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-plugin-undeclared-variables-check
 title: babel-plugin-undeclared-variables-check
 sidebar_label: undeclared-variables-check

--- a/website/versioned_docs/version-6.x/polyfill.md
+++ b/website/versioned_docs/version-6.x/polyfill.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-polyfill
 title: babel-polyfill
 sidebar_label: babel-polyfill

--- a/website/versioned_docs/version-6.x/preset-env.md
+++ b/website/versioned_docs/version-6.x/preset-env.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-env
 title: babel-preset-env
 sidebar_label: env

--- a/website/versioned_docs/version-6.x/preset-es2015.md
+++ b/website/versioned_docs/version-6.x/preset-es2015.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-es2015
 title: babel-preset-es2015
 sidebar_label: es2015

--- a/website/versioned_docs/version-6.x/preset-es2016.md
+++ b/website/versioned_docs/version-6.x/preset-es2016.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-es2016
 title: babel-preset-es2016
 sidebar_label: es2016

--- a/website/versioned_docs/version-6.x/preset-es2017.md
+++ b/website/versioned_docs/version-6.x/preset-es2017.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-es2017
 title: babel-preset-es2017
 sidebar_label: es2017

--- a/website/versioned_docs/version-6.x/preset-flow.md
+++ b/website/versioned_docs/version-6.x/preset-flow.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-flow
 title: babel-preset-flow
 sidebar_label: flow

--- a/website/versioned_docs/version-6.x/preset-latest.md
+++ b/website/versioned_docs/version-6.x/preset-latest.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-latest
 title: babel-preset-latest
 sidebar_label: latest

--- a/website/versioned_docs/version-6.x/preset-minify.md
+++ b/website/versioned_docs/version-6.x/preset-minify.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-minify
 title: babel-preset-minify
 sidebar_label: minify

--- a/website/versioned_docs/version-6.x/preset-react.md
+++ b/website/versioned_docs/version-6.x/preset-react.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-react
 title: babel-preset-react
 sidebar_label: react

--- a/website/versioned_docs/version-6.x/preset-stage-0.md
+++ b/website/versioned_docs/version-6.x/preset-stage-0.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-stage-0
 title: babel-preset-stage-0
 sidebar_label: stage-0

--- a/website/versioned_docs/version-6.x/preset-stage-1.md
+++ b/website/versioned_docs/version-6.x/preset-stage-1.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-stage-1
 title: babel-preset-stage-1
 sidebar_label: stage-1

--- a/website/versioned_docs/version-6.x/preset-stage-2.md
+++ b/website/versioned_docs/version-6.x/preset-stage-2.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-stage-2
 title: babel-preset-stage-2
 sidebar_label: stage-2

--- a/website/versioned_docs/version-6.x/preset-stage-3.md
+++ b/website/versioned_docs/version-6.x/preset-stage-3.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-preset-stage-3
 title: babel-preset-stage-3
 sidebar_label: stage-3

--- a/website/versioned_docs/version-6.x/register.md
+++ b/website/versioned_docs/version-6.x/register.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-register
 title: babel-register
 sidebar_label: babel-register

--- a/website/versioned_docs/version-6.x/runtime.md
+++ b/website/versioned_docs/version-6.x/runtime.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-runtime
 title: babel-runtime
 sidebar_label: babel-runtime

--- a/website/versioned_docs/version-6.x/template.md
+++ b/website/versioned_docs/version-6.x/template.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-template
 title: babel-template
 sidebar_label: babel-template

--- a/website/versioned_docs/version-6.x/traverse.md
+++ b/website/versioned_docs/version-6.x/traverse.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-traverse
 title: babel-traverse
 sidebar_label: babel-traverse

--- a/website/versioned_docs/version-6.x/types.md
+++ b/website/versioned_docs/version-6.x/types.md
@@ -1,5 +1,4 @@
 ---
-# Don't edit this file directly, it was copied using scripts/download-readmes.js: 
 id: version-6.x-babel-types
 title: babel-types
 sidebar_label: babel-types


### PR DESCRIPTION
Invalid fields in the docs front matter like `layout` and `description` cause warnings when building or running docusaurus.

I removed the fields from current version docs, and updated the download-readmes script to place comment outside of front matter in https://github.com/babel/website/commit/62218c459d28ed82676892c4b374e0374d0523df.

Old version docs don't cause any warnings but I still removed them for consistency. Manually edited the 7 files in https://github.com/babel/website/commit/eaea5cc72dd763317f52ce756d997e84636f9aac, and did a find and replace in https://github.com/babel/website/commit/ca23dc32da4b7ce00185c02a0d9c2ee4f849971e.