### PR TITLE
Use legacy decorators

### DIFF
--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -82,9 +82,16 @@ export default function compile(code: string, config: CompileConfig): Return {
     const babelConfig = {
       babelrc: false,
       filename: "repl",
-      presets: config.presets,
-      plugins: config.plugins,
       sourceMap: config.sourceMap,
+
+      // HACK: decorators needs to be set to "legacy" until they are implemented
+      presets: config.presets.map(preset => {
+        if (typeof preset === "string" && /^stage-[0-2]$/.test(preset)) {
+          return [preset, { decoratorsLegacy: true }];
+        }
+        return preset;
+      }),
+      plugins: config.plugins,
     };
 
     const transformed = Babel.transform(code, babelConfig);


### PR DESCRIPTION
The repl currently is broken because of https://github.com/babel/babel/pull/7734. This PR should fix it.