### PR TITLE
Hide markdown comment from pages

### DIFF
--- a/scripts/download-readmes.js
+++ b/scripts/download-readmes.js
@@ -14,7 +14,7 @@ title: ${id}
 sidebar_label: ${id.replace(/^babel-(plugin|proposal|preset)-/, "")}
 ---
 
-[comment]: # Don't edit this file directly, it was copied using scripts/download-readmes.js
+[comment]: # (Don't edit this file directly, it was copied using scripts/download-readmes.js)
 
 ${text}
 `;


### PR DESCRIPTION
Don't know how I missed this before. My "comments" were showing up in pages like [this](https://new.babeljs.io/docs/en/next/babel-preset-stage-3.html)