### PR TITLE
Add help tooltip for Minify

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -92,6 +92,7 @@ const pluginConfigs: Array<PluginConfig> = [
   {
     baseUrl: "https://unpkg.com",
     label: "Minify",
+    help: "babel-minify is a beta product, using it can cause unexpected bugs in transpilation",
     package: "babili-standalone", // TODO Switch to babel-minify-standalone
     version: "0",
   },

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -709,6 +709,24 @@ const styles = {
       opacity: 0.5,
     },
   }),
+  tooltip: css({
+    marginLeft: "5px",
+    backgroundColor: colors.inverseBackgroundDark,
+    borderRadius: "50%",
+    padding: "0 6px",
+
+    "&:hover::after": {
+      content: "attr(data-content)",
+      fontSize: "10px",
+      backgroundColor: color.inverseBackgroundDark,
+      display: "block",
+      position: "fixed",
+      padding: "10px",
+      width: "150px",
+      border: "1px solid black",
+      borderRadius: "2px",
+     } 
+  }),
   highlight: css({
     textTransform: "uppercase",
     fontSize: "0.75rem",

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -531,6 +531,7 @@ const PluginToggle = ({
       type="checkbox"
     />
     {state.isLoading ? <PresetLoadingAnimation /> : label || config.label}
+    {config.help ? <span className={styles.tooltip} data-content={config.help}>?</span> : null}
   </label>
 );
 

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -25,6 +25,7 @@ export type LoadScriptCallback = (success: boolean) => void;
 
 export type PluginConfig = {
   baseUrl?: string,
+  help?: string,
   isPreLoaded?: boolean,
   label: string,
   package: string,


### PR DESCRIPTION
I was using "minify" plugin option and found it to be buggy for my use-case, thought it'll be nice to have a tooltip.

<img width="1436" alt="screen shot 2018-05-03 at 6 47 04 pm" src="https://user-images.githubusercontent.com/7352827/39578711-82432584-4f02-11e8-8855-70abc27f1325.png">
