### PR TITLE
Fix broken link on team page

### DIFF
--- a/website/pages/en/team.js
+++ b/website/pages/en/team.js
@@ -12,7 +12,7 @@ const Banner = () => {
         <h1>Meet the Team</h1>
         <p>
           <a
-            href="https://github.com/babel/website/blob/master/team.md"
+            href="https://github.com/babel/website/blob/master/website/data/team.yml"
             target="_blank"
             rel="noreferrer noopener"
           >


### PR DESCRIPTION
Currently, on the [team page](https://babeljs.io/team) when clicking 'Edit this page', it'll link to a not found page on Github. This PR fixes that.