### PR TITLE
Add Node.js 4 and 5 dropped support in migration docs

### DIFF
--- a/docs/v7-migration.md
+++ b/docs/v7-migration.md
@@ -13,7 +13,7 @@ Because not every breaking change will affect every project, we've sorted the se
 
 ## All of Babel
 
-> Support for Node.js 0.10 and 0.12 has been dropped [#5025](https://github.com/babel/babel/pull/5025), [#5041](https://github.com/babel/babel/pull/5041), [#5186](https://github.com/babel/babel/pull/5186) ![high](https://img.shields.io/badge/level%20of%20awesomeness%3F-high-red.svg)
+> Support for Node.js 0.10, 0.12, 4 and 5 has been dropped [#5025](https://github.com/babel/babel/pull/5025), [#5041](https://github.com/babel/babel/pull/5041), [#7755](https://github.com/babel/babel/pull/7755), [#5186](https://github.com/babel/babel/pull/5186) ![high](https://img.shields.io/badge/level%20of%20awesomeness%3F-high-red.svg)
 
 We highly encourage you to use a newer version of Node.js (LTS v8) since the previous versions are not maintained.
 See [nodejs/LTS](https://github.com/nodejs/LTS) for more information.


### PR DESCRIPTION
### Changes

- [x] Mention that  support for Node.js 4 and 5 has been dropped
- [x] Mention #7755 (drop support for Node.js v4)

### Rationale

Since support for Node.js 4 and 5 have been dropped, migration documentation should reflect that. This will prevent people digging into errors such as the `@babel/cli` running on Node.js 4 (I'm mentioning this here for search-ability purposes):

```sh
...node_modules/@babel/cli/lib/babel/dir.js:172
  function sequentialHandle(filenames, index = 0) {
                                             ^
SyntaxError: Unexpected token =
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/travis/build/amercier/npm-package-skeleton/node_modules/@babel/cli/lib/babel/index.js:54:35)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
```