### PR TITLE
Tweak repl sidebar design

### DIFF
--- a/js/repl/AccordionTab.js
+++ b/js/repl/AccordionTab.js
@@ -27,7 +27,6 @@ export default class AccordionTab extends React.Component<Props> {
     return (
       <div className={`${styles.AccordionTab} ${className || ""}`}>
         <div className={styles.HeaderRow} onClick={this.handleToggle}>
-          <div className={styles.Label}>{label}</div>
           <Svg
             className={`${styles.Arrow} ${isExpanded
               ? styles.ArrowExpanded
@@ -42,6 +41,7 @@ export default class AccordionTab extends React.Component<Props> {
               L15.41,16.58
               Z"
           />
+          <div className={styles.Label}>{label}</div>
         </div>
         {isExpanded && <div className={styles.Content}>{children}</div>}
       </div>
@@ -76,16 +76,19 @@ const styles = {
   }),
   Label: css({
     flex: "1",
-    fontWeight: "400",
-    fontSize: "0.875rem",
+    fontSize: "0.75rem",
+    fontWeight: "700",
+    textTransform: "uppercase",
   }),
   Arrow: css({
-    height: "1.5rem",
-    width: "1.5rem",
+    height: "1rem",
+    margin: "0 0.33rem 0 0",
+    transform: "rotateZ(180deg)",
     transition: "transform 250ms ease-in-out",
+    width: "1rem",
   }),
   ArrowExpanded: css({
-    transform: "rotateZ(-90deg)",
+    transform: "rotateZ(270deg)",
   }),
   Content: css({
     display: "flex",

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -755,17 +755,33 @@ const styles = {
     },
   }),
   selectLabel: css({
-    [media.medium]: {
-      flexDirection: "column",
-      flexBasis: "3rem",
-      alignItems: "flex-start",
-    },
+    alignItems: "flex-start",
+    flexDirection: "column",
+    flexBasis: "4rem",
+    margin: "1rem 0 0 0",
+    padding: "0 0.5rem",
   }),
   sourceTypeSelect: css({
-    marginLeft: "0.5rem",
+    appearance: "none",
+    backgroundColor: "#2D3035",
+    backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='${colors.inverseForegroundLight}'><polygon points='0,0 100,0 50,50'/></svg>")`,
+    backgroundRepeat: "no-repeat",
+    backgroundSize: "8px",
+    backgroundPosition: "calc(100% - 1rem) calc(100% - 8px)",
+    border: 0,
+    color: colors.inverseForegroundLight,
+    height: "30px",
+    margin: "0.25rem 0 0 0",
+    padding: "0 0.5rem",
+    transition: "all 0.25s ease-in",
+    width: "100%",
 
-    [media.medium]: {
-      marginLeft: "0",
+    "&:hover": {
+      backgroundColor: "#32353A",
+    },
+
+    "&::-ms-expand": {
+      display: "none",
     },
   }),
   envPresetColumn: css({


### PR DESCRIPTION
Small tweaks:

* Reduced some caret density by moving the section expanded status to the left of the label

* Tweaked style of the source type dropdown

![image](https://user-images.githubusercontent.com/56288/41106562-df40de68-6a35-11e8-967d-b940b3b4f8e3.png)
