### PR TITLE
Fix documentation example for mutable properties

### DIFF
--- a/docs/plugin-transform-react-constant-elements.md
+++ b/docs/plugin-transform-react-constant-elements.md
@@ -47,7 +47,7 @@ const Hr = () => {
 > See https://github.com/facebook/react/issues/3226 for more on this
 
   ```js
-  <div width={{width: 100}} />
+  <div style={{width: 100}} />
   ```
 
 ## Installation


### PR DESCRIPTION
Should be `style` instead of `width` :) in the babel-plugin-transform-react-constant-elements example for mutable properties