### PR TITLE
docs: styling babel-parser

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -4,7 +4,7 @@ title: babel-parser
 sidebar_label: babel-parser
 ---
 
-<p align="center">
+<p align="left">
   The Babel parser (previously Babylon) is a JavaScript parser used in <a href="https://github.com/babel/babel">Babel</a>.
 </p>
 


### PR DESCRIPTION
align to middle looks so strange.
![image](https://user-images.githubusercontent.com/13050025/41761704-d9ffa258-762a-11e8-8642-fdca95602e8d.png)
