### PR TITLE
Publishing ES6+ Post 

### DIFF
--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -8,12 +8,11 @@ categories: announcements
 share_text: "On Consuming (and Publishing) ES6+ Packages"
 ---
 
-How can we make compiling dependencies normal?
+How can we make compiling dependencies not just possible, but normal?
 
 <!--truncate-->
 
-<!-- I would probably add a TLDR; mention of what Dan wrote. Just a brief introduction to the topic. -->
-> Inspired by [Dan's tweet](https://twitter.com/dan_abramov/status/1009179550134296577)
+> Inspired by [Dan's tweet](https://twitter.com/dan_abramov/status/1009179550134296577) about how we can conflate shipping source code, ES6+, ESM
 
 This is a pretty enabling feature request for the whole ecosystem, so I'm glad we've tried to make this easier in Babel v7 (I just realized this whole post is a good pitch for using it). Hopefully it can be made more standard moving forward (if we're collectively able to figure out some things I outline below).
 
@@ -70,8 +69,7 @@ This is what Dan was warning about. There are many issues with *shipping* uncomp
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="und" dir="ltr"><a href="https://t.co/femUb4vgxh">pic.twitter.com/femUb4vgxh</a></p>&mdash; Rach Smith 🌈 (@rachsmithtweets) <a href="https://twitter.com/rachsmithtweets/status/892478598765887488?ref_src=twsrc%5Etfw">August 1, 2017</a></blockquote>
 
-<!-- added "simply" to emphasys like in the hyronically "just use" (if that's what you intended) -->
-First, we already recommend people be careful with *simply using* syntax less than Stage 3.
+We already recommend people be careful with using proposals lower than Stage 3, let alone publishing them.
 
 But telling people not to use Stage X goes against the whole purpose of Babel in the first place. A big reason why proposals move forward or are shaped to be better is precisely because of the feedback the committee can get from real-world usage (whether in production or not) based on using it in Babel.
 
@@ -143,14 +141,8 @@ One suggestion is to provide an ES5 version but also publish a version that incl
 
 TODO:
 
-- Due to complexity and tooling, it may be difficult for projects to publish ES6/ESM without more setup. This is probably the biggest issue to get right. We should add some feature requests to `@babel/cli` to make this easier, and maybe make the `babel` package do this by default.
-
-<!-- jshcrowthe: Getting into the library dev scene I definitely felt the lack of good tooling/guides for publishing modules "correctly." Would be awesome if we could do something here -->
-
-- Tools like @developit's [microbundle](https://github.com/developit/microbundle) may help a lot with this.
-- How do we deal with polyfills? Mention `preset-env` + polyfills
-
-<!-- jshcrowthe: As you said above, polyfills are application specific, based on the target environment. Would love it if, as a library dev, didn't have to worry about these at all and these were handled by application tooling. -->
+- Due to complexity and tooling, it may be difficult for projects to publish ES6/ESM without more setup. This is probably the biggest issue to get right, even docs aren't enough. We should add some feature requests to `@babel/cli` to make this easier, and maybe make the `babel` package do this by default? Tools like @developit's [microbundle](https://github.com/developit/microbundle) may help a lot with this.
+- How do we deal with polyfills? This could be it's own post (I never finished it). Mention `preset-env` + polyfills. What would it look like for a library author not to have to think about polyfills (or the user).
 
 ### Compiler Complexity
 

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -155,10 +155,8 @@ One suggestion is to provide an ES5 version but also publish a version that incl
 
 ### Dependencies May Not Publish ES2015+
 
-TODO:
-
 - Due to complexity and tooling, it may be difficult for projects to publish ES2015/ESM without more setup. This is probably the biggest issue to get right, even docs aren't enough. We should add some feature requests to `@babel/cli` to make this easier, and maybe make the `babel` package do this by default? Tools like @developit's [microbundle](https://github.com/developit/microbundle) may help a lot with this.
-- How do we deal with polyfills? This could be it's own post (I never finished it). Mention `preset-env` + polyfills. What would it look like for a library author not to have to think about polyfills (or the user).
+- How do we deal with polyfills (I have another post to discuss this)? What would it look like for a library author not to have to think about polyfills (or the user).
 
 With that said, how does Babel help with all this?
 

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -8,23 +8,24 @@ categories: announcements
 share_text: "On Consuming (and Publishing) ES2015+ Packages"
 ---
 
-How can we make compiling dependencies not just possible, but normal?
+How can we make compiling our dependencies not just possible, but normal?
 
 <!--truncate-->
 
-Being able to compile dependencies is an enabling feature request for the whole ecosystem. With some of the changes we made in Babel v7, hopefully it can be made more standard moving forward.
+The ability to compile dependencies is an enabling feature request for the whole ecosystem. Starting with some of the changes we made in Babel v7, we hope to see it standardized moving forward.
 
 ## Assumptions
 
-- You can ship to modern browsers (don't have to support IE) or are able to send multiple types of bundles (one way being [checking for script`type=module`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)).
-- Your dependencies actually publish ES2015+ instead of ES5/ES3.
+- We can and will ship to modern browsers that support ES2015+ natively (don't have to support IE) or are able to send multiple kinds of bundles (i.e. [checking for script`type=module`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)).
+- Our dependencies actually publish ES2015+ instead of the current baseline of ES5/ES3.
+- The future baseline shouldn't be fixed at ES2015, but is a changing target.
 
 ## Why
 
-Why is compiling your dependencies desirable in the first place (vs. your own code)?
+Why is compiling dependencies desirable in the first place (vs. our own code)?
 
-- You can ship less code to users, since JavaScript has a [cost](https://medium.com/dev-channel/the-cost-of-javascript-84009f51e99e).
-- You get the freedom to make the tradeoffs of where your code is able to run (vs. the library).
+- We can ship less code to users, since JavaScript has a [cost](https://medium.com/dev-channel/the-cost-of-javascript-84009f51e99e).
+- We get the freedom to make the tradeoffs of where our code is able to run (vs. the library).
 
 ## The Ephemeral JavaScript Runtime
 
@@ -32,36 +33,36 @@ When thinking about Babel's role not just in moving the language itself forward,
 
 Thus, the argument for why compiling dependencies would be helpful is the same for why we eventually introduced `@babel/preset-env`.
 
-Babel used to be `6to5`, since it only converted from ES2015 to ES5. Back then, the browser support for ES2015 was almost non-existent, so the idea of a JavaScript compiler was both novel and useful: you could write modern code and have it work for all of your users. But what about the browser runtimes themselves?
+Babel used to be `6to5`, since it only converted from ES2015 to ES5. Back then, the browser support for ES2015 was almost non-existent, so the idea of a JavaScript compiler was both novel and useful: we could write modern code and have it work for all of our users.
 
-Browsers will eventually catch up to the standard (and have with ES2015). Creating `preset-env` helps us align with the browsers since if we only compiled to ES5, no one would ever run native code in the browsers.
+But what about the browser runtimes themselves? Because rowsers will eventually catch up to the standard (and have with ES2015), creating `preset-env` helps Babel and the community align with both the browsers and TC39 itself. If we only compiled to ES5, no one would ever run native code in the browsers.
 
 The real difference is realizing that there will _always_ be a sliding window of support:
 
-- Application code (your supported environments)
+- Application code (our supported environments)
 - Browsers (Chrome, Firefox, Edge, Safari)
 - Babel (the abstraction layer)
 - TC39/ECMAScript Proposals (and Babel implementations)
 
-Thus the need isn't just for `6to5` to be renamed to Babel because it compiles to `7to5`, but for Babel to change the implicit assumption it only targets ES5. With `@babel/preset-env`, you are able to write the latest JavaScript and target whichever browser (environment) you want!
+Thus the need isn't just for `6to5` to be renamed to Babel because it compiles to `7to5`, but for Babel to change the implicit assumption it only targets ES5. With `@babel/preset-env`, we are able to write the latest JavaScript and target whichever browser (environment)!
 
-Using Babel and `preset-env` helps you keep up with that sliding window. However, even if you use it, it's mainly for *your application code* and not what your code depends upon.
+Using Babel and `preset-env` helps us keep up with that constantly changing sliding window. However, even if we use it, it's mainly for *our application code* and not what our code depends upon.
 
 ## Who's Problem is It?
 
-You have control over your own code to be able to take advantage of `preset-env`: by writing in ES2015+ and targeting ES2015+ browsers.
+Because we have control over our own code, we are able to take advantage of `preset-env`: both writing in ES2015+ and targeting ES2015+ browsers.
 
-Even though this isn't necessarily the case for your dependencies, you'll want to think about it in order to get the same benefits as compiling your application code.
+Even though this isn't necessarily the case for our dependencies, we'll want to think about it in order to get the same benefits as compiling our application code.
 
-Is it as straightforward as just running Babel over `node_modules` with the same configuration for your application?
+Is it as straightforward as just running Babel over `node_modules` with the same configuration for our applications?
 
 ## Complexities in Compiling Dependencies
 
 ### Compiler Complexity
 
-Every compiler has bugs, although the risk is lower if there are so many users and sufficient tests. We should just be aware that compiling dependencies does increase the surface area of potential bugs, but I don't believe that should deter us from making this a common practice.
+Every compiler has bugs, although the risk is lower if there are so many users and sufficient tests. We should just be aware that compiling dependencies does increase the surface area of potential bugs, but it shouldn't deter us from making this a common practice.
 
-- Babel v6 assumed everything that it compiled was a module and thus in strict mode (one could argue this is actually a good thing). Thus if you tried to run Babel on all your `node_modules` and it encountered something that was a `script` like a jQuery plugin it might cause a lot of issues. This is changed in v7 so that it won't always auto inject the `"use strict"` directive unless it actually is a module.
+- Babel v6 assumed everything that it compiled was a module and thus in strict mode (one could argue this is actually a good thing). Thus if we tried to run Babel on all our `node_modules` and it encountered something that was a `script` like a jQuery plugin it might cause a lot of issues. This is changed in v7 so that it won't always auto inject the `"use strict"` directive unless it actually is a module.
 - React Native has always compiled `node_modules` by default and has probably learned a lot from issues like ^.
 - `preset-env` could have its own bugs because we use `compat-table` vs. test262.
 - Browsers themselves can have issues with running native ES2015+ code vs. ES5.
@@ -74,9 +75,9 @@ There are many issues with *shipping* uncompiled proposal syntax. (This post was
 
 #### Staging Process
 
-- The [TC39 staging process](https://tc39.github.io/process-document/) does not always move forward: there is the possibility for a proposal to move to any point in the process: even moving backwards from Stage 3 to Stage 2 as the case with Numeric Separators (`1_000`) or dropped entirely (`Object.observe()`, and others you may have forgotten)
-- It can be hard to differentitate between the stages if you aren't involved: most people would advise that Stage 0-2 is unstable though.
+- The [TC39 staging process](https://tc39.github.io/process-document/) does not always move forward: there is the possibility for a proposal to move to any point in the process: even moving backwards from Stage 3 to Stage 2 as the case with Numeric Separators (`1_000`) or dropped entirely (`Object.observe()`, and others we may have forgotten 😁)
 - Summary: Stage 0 has no criteria and is just an idea, Stage 1 is accepting that the problem is worth solving, Stage 2 is about describing a solution in spec text, Stage 3 means the specific solution is thought out, and Stage 4 means that it is ready for inclusion with tests, multiple browser implementations, and in-the-field experience.
+- The committee would advise that Stage 0-2 is still experimental.
 
 #### Using Proposals
 
@@ -94,15 +95,15 @@ One of the most common things people do is use the Stage 0 or Stage 2 presets. W
 
 ### Publishing Non-standard Syntax
 
-Publishing non-standard syntax in a library is setting your users up for possible inconsistencies, refactoring, and breakage of their projects. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means you will inevitability have to change the code.
+As a library author, publishing non-standard syntax is setting our users up for possible inconsistencies, refactoring, and breakage of their projects. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means we will inevitability have to change the library code.
 
-At least if you ship the compiled version, it will still work and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it, and will have to have the same configuration of Babel as you. This is in the same bucket as using TS/JSX/Flow: you wouldn't expect consumers to configure the same compiler environment just because you used them.
+At least if we ship the compiled version, it will still work and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it, and will have to have the same configuration of Babel as us. This is in the same bucket as using TS/JSX/Flow: we wouldn't expect consumers to configure the same compiler environment just because we used them.
 
 TODO: Or a proposal might just stall because people are busy, etc. Decorators are a great example of this.
 
 ### Conflating ESM and ES2015+
 
-When you do `import foo from "foo"` or `require("foo")` and `foo` doesn't have an `index.js`, it will resolve to the `main` field in the `package.json` of the module.
+When we write `import foo from "foo"` or `require("foo")` and `foo` doesn't have an `index.js`, it will resolve to the `main` field in the `package.json` of the module.
 
 Some tools like Rollup/Webpack will also read from another field called `module` (previously `jsnext:main`). It uses this to instead resolve to the ESM file.
 
@@ -147,16 +148,16 @@ This was an issue with Babel itself: we had intended to continue to publish year
 
 Publishing it based on specific environments/syntax would seem to be even worse as the amount of combinations only increases.
 
-What about providing just the source? That may have similar problems if you used non-standard syntax as mentioned earlier.
+What about providing just the source? That may have similar problems if we used non-standard syntax as mentioned earlier.
 
-Having a `esnext` field may not be helpful either. The "latest" version of JavaScript changes depending on the point in time you authored the code.
+Having a `esnext` field may not be helpful either. The "latest" version of JavaScript changes depending on the point in time we authored the code.
 
 One suggestion is to provide an ES5 version but also publish a version that includes the latest standard syntax so it can be compiled with `preset-env`.
 
 ### Dependencies May Not Publish ES2015+
 
 - Due to complexity and tooling, it may be difficult for projects to publish ES2015/ESM without more setup. This is probably the biggest issue to get right, even docs aren't enough. We should add some feature requests to `@babel/cli` to make this easier, and maybe make the `babel` package do this by default? Tools like @developit's [microbundle](https://github.com/developit/microbundle) may help a lot with this.
-- How do we deal with polyfills (I have another post to discuss this)? What would it look like for a library author not to have to think about polyfills (or the user).
+- How do we deal with polyfills (this will be an upcoming post)? What would it look like for a library author not to have to think about polyfills (or the user).
 
 With that said, how does Babel help with all this?
 
@@ -164,7 +165,7 @@ With that said, how does Babel help with all this?
 
 As I've discussed, compiling dependencies in Babel v6 can be pretty painful. Babel v7 will address some of these pain points. 
 
-One issue (which we have fixed in v7) is around config lookup. Babel currently runs per file so when compiling a file, it tries to find the closest config to know what to compile against. If it doesn't find it in the same directory, it keeps looking up directories (this is why if you don't specify a config but have one in your home directory it might try to load that instead).
+One issue (which we have fixed in v7) is around config lookup. Babel currently runs per file so when compiling a file, it tries to find the closest config to know what to compile against. If it doesn't find it in the same directory, it keeps looking up directories (this is why if we don't specify a config but have one in our home directory it might try to load that instead).
 
 ```
 project
@@ -178,12 +179,12 @@ project
 
 We made a [few changes](https://github.com/babel/babel/pull/7358):
 
-- One is to stop lookup at the package boundary (stop when you find a `package.json`). This makes sure Babel won't try to load a config file outside.
-- If you use a monorepo, you'll may want to have a `.babelrc` per-package that extends some other central config.
-- Babel itself is a monorepo, so instead we are using the new `babel.config.js` which allows you to resolve all files to that config (no more lookup).
-- We added an [`"overrides"`](https://github.com/babel/babel/pull/7091) option which allows you to basically create a new config for any set of paths.
+- One is to stop lookup at the package boundary (stop when we find a `package.json`). This makes sure Babel won't try to load a config file outside.
+- If we use a monorepo, we'll may want to have a `.babelrc` per-package that extends some other central config.
+- Babel itself is a monorepo, so instead we are using the new `babel.config.js` which allows us to resolve all files to that config (no more lookup).
+- We added an [`"overrides"`](https://github.com/babel/babel/pull/7091) option which allows us to basically create a new config for any set of paths.
 
-This allows you to have a single config for your whole app: maybe you want to compile your server JavaScript code differently than the client code as well as compile something in `node_modules`.
+This allows us to have a single config for our whole app: maybe we want to compile our server JavaScript code differently than the client code as well as compile something in `node_modules`.
 
 ```js
 // babel.config.js
@@ -215,7 +216,7 @@ module.exports = {
 
 Potential recommendation: package authors should also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on (I don't believe `module` should be that key) but continue to publish ES5 under `main`. Consumers can use `preset-env` and opt-in into running on `node_modules`.
 
-Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of the poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
+Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of a poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
 
 ## Let's Do This!
 

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -12,7 +12,7 @@ How can we make compiling dependencies not just possible, but normal?
 
 <!--truncate-->
 
-> Inspired by [Dan's tweet](https://twitter.com/dan_abramov/status/1009179550134296577) about how we can conflate shipping source code, ES6+, ESM
+This post is inspired by [Dan's tweet](https://twitter.com/dan_abramov/status/1009179550134296577) about how we can conflate shipping source code, ES6+, ESM
 
 This is a pretty enabling feature request for the whole ecosystem, so I'm glad we've tried to make this easier in Babel v7 (I just realized this whole post is a good pitch for using it). Hopefully it can be made more standard moving forward (if we're collectively able to figure out some things I outline below).
 
@@ -214,3 +214,5 @@ Babel v7 should be out soon, this post goes into some of the ways it should help
 Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of the poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
 
 Potential recommendation: package authors should also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on (I don't believe `module` should be that key) but continue to publish ES5 under `main`. Consumers can use `preset-env` and opt-in into running on `node_modules`.
+
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -51,13 +51,13 @@ But assuming people even know it exists or have starting using it at all, it's m
 
 You have control over your own code to be able to take advantage of preset-env: write in ES6+ and target ES6+ browsers.
 
-However, this isn't necessarily the case for your dependencies (you should take ownership for them though).
+However, this isn't necessarily the case for your dependencies (though you _should_ take ownership of them).
 
 ## What Then?
 
-The next step is to start thinking, how do we actually make this happen?
+The next step is to start thinking "how do we actually make this happen"?
 
-It sounds like it's as straightforward as running Babel over `node_modules` with the same configuration for your application.
+Is it as straightforward as just running Babel over `node_modules` with the same configuration for your application?
 
 ## Caveats
 
@@ -69,23 +69,23 @@ This is what Dan was warning about. There are many issues with *shipping* uncomp
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="und" dir="ltr"><a href="https://t.co/femUb4vgxh">pic.twitter.com/femUb4vgxh</a></p>&mdash; Rach Smith 🌈 (@rachsmithtweets) <a href="https://twitter.com/rachsmithtweets/status/892478598765887488?ref_src=twsrc%5Etfw">August 1, 2017</a></blockquote>
 
-We already recommend people be careful with using proposals lower than Stage 3, let alone publishing them.
+We already recommend that people should be careful when using proposals lower than Stage 3, let alone publishing them.
 
-But telling people not to use Stage X goes against the whole purpose of Babel in the first place. A big reason why proposals move forward or are shaped to be better is precisely because of the feedback the committee can get from real-world usage (whether in production or not) based on using it in Babel.
+But telling people not to use Stage X goes against the whole purpose of Babel in the first place. A big reason why proposals gain improvements and move forward are because of the feedback the committee gets from real-world usage (whether in production or not) based on using it via Babel.
 
-So there is certainly a balance to be had here. We don't want to scare people away from using new syntax (that is a hard sell 😂), but we also don't want people to get the idea that "once it's in Babel, the syntax is official or immutable". Ideally people look into the purpose of a proposal and make the tradeoffs for their use case.
+There is certainly a balance to be had here. We don't want to scare people away from using new syntax (that is a hard sell 😂), but we also don't want people to get the idea that "once it's in Babel, the syntax is official or immutable". Ideally people look into the purpose of a proposal and make the tradeoffs for their use case.
 
-One of the most common things people do is use the Stage 0 or Stage 2 presets. We plan to remove these Stage presets in v7 after much back and forth. I thought at first it would be convienent, that people would make their own unofficial ones anyway, or it might help with "JavaScript fatigue". I find now that it just causes more of an issue: people continue to copy paste configs and not understanding what goes into a preset in the first place. After all, seeing `"stage-0"` says nothing. My hope is that in actually making the decision explicit, people will have to learn what non-standard syntax they are opting into.
+One of the most common things people do is use the Stage 0 or Stage 2 presets. We plan to remove the stage presets in v7 after much back and forth. I thought at first it would be convienent, that people would make their own unofficial ones anyway, or it might help with "JavaScript fatigue". I find now that it just causes more of an issue: people continue to copy/paste configs with out understanding what goes into a preset in the first place. After all, seeing `"stage-0"` says nothing. My hope is that in making the decision to use proposal plugins explicit, people will have to learn what non-standard syntax they are opting into.
 
 #### Staging Process
 
-- The [TC39 staging process](https://tc39.github.io/process-document/) does not always move foward: there is the possibility for a proposal to move to any point in the process: even moving backwards from Stage 3 to Stage 2 as the case with Numeric Separators (`1_000`) or dropped entirely (`Object.observe()`, others you may have forgotten)
+- The [TC39 staging process](https://tc39.github.io/process-document/) does not always move forward: there is the possibility for a proposal to move to any point in the process: even moving backwards from Stage 3 to Stage 2 as the case with Numeric Separators (`1_000`) or dropped entirely (`Object.observe()`, and others you may have forgotten)
 - It can be hard to differentitate between the stages if you aren't involved: most people would advise that Stage 0-2 is unstable though.
 - Summary: Stage 0 has no criteria and is just an idea, Stage 1 is accepting that the problem is worth solving, Stage 2 is about describing a solution in spec text, Stage 3 means the specific solution is thought out, and Stage 4 means that it is ready for inclusion with tests, multiple browser implementations, and in-the-field experience.
 
 #### Publishing Non-standard Syntax
 
-So actually publishing it in a library may cause even more issues. Because a proposal on TC39 (even at Stage 3) has a possibility of changing, it means you will inevitability will have to change the code.
+So actually publishing it in a library may cause even more issues. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means you will inevitability have to change the code.
 
 At least if you ship the compiled version, it will still work and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it, and will have to have the same version of Babel as you. This is no different than using TS/JSX/Flow which you wouldn't publish either.
 
@@ -108,9 +108,9 @@ Some tools like Rollup/Webpack will also read from another field called `module`
 }
 ```
 
-The reason this was introduced is so that users can consume ES2015 modules (ESM).
+This was introduced so that users could consume ES2015 modules (ESM).
 
-However, the sole intention of this field is ESM not anything else. The [Rollup docs](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features) on this make it clear that it's not intended for future JavaScript syntax.
+However, the sole intention of this field is ESM, not anything else. The [Rollup docs](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features) make it clear that it's not intended for future JavaScript syntax.
 
 What this means is that we may need another way to handle ES6+ even though some libraries may choose to do this anyway.
 
@@ -129,9 +129,9 @@ A common suggestion is for libraries to start publishing ES2015 under another fi
 }
 ```
 
-This works for ES2015 but the question next is what about ES2016? Are we supposed to create a new folder for each year and a new field in `package.json`? That also seems unsustainable later, and even produces even larger `node_modules` still.
+This works for ES2015 but the question next is what about ES2016? Are we supposed to create a new folder for each year and a new field in `package.json`? That seems unsustainable, and will continue to produce larger `node_modules`.
 
-I feel like this is similar to how we had a babel preset for each year and ended up creating `preset-latest` which included all the yearly plugins (we removed that soon after in favor of `preset-env`).
+I feel like this is similar to how we had a Babel preset for each year and ended up creating `preset-latest` which included all the yearly plugins (we removed that soon after in favor of `preset-env`).
 
 Having a field like `es-latest` or `esnext` may not be helpful either because we want the library versions to be fixed yet changing. And providing only the source may not always be helpful if you use non-standard syntax, TS, Flow, JSX, etc which might have different behavior based on compiler version. Maybe we need some changes on the `npm` side?
 
@@ -150,7 +150,7 @@ Every compiler has bugs, although the risk is lower if there are so many users a
 
 - Babel v6 assumed everything that it compiled was a module and thus in strict mode (one could argue this is actually a good thing). Thus if you tried to run Babel on all your `node_modules` and it encountered something that was a `script` like a jQuery plugin it might cause a lot of issues. This is changed in v7 so that it won't always auto inject the `"use strict"` directive unless it actually is a module.
 - React Native has always compiled `node_modules` by default and has probably learned a lot from issues like ^.
-- `preset-env` could have it's own bugs because we use `compat-table` vs. test262.
+- `preset-env` could have its own bugs because we use `compat-table` vs. test262.
 - Browsers themselves can have issues with running native ES6+ code vs. ES5.
 - Question of how do we determine what is "supported": https://github.com/babel/babel-preset-env/issues/54 example of edge case.
 

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -17,13 +17,13 @@ The ability to compile dependencies is an enabling feature request for the whole
 ## Assumptions
 
 - We believe compiling our own app code is useful.
-- We can and will ship to modern browsers that support ES2015+ [natively](https://kangax.github.io/compat-table/es6/) (don't have to support IE) or are able to send multiple kinds of bundles (i.e. [checking for script`type=module`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)).
+- We can and will ship to modern browsers that support ES2015+ [natively](https://kangax.github.io/compat-table/es6/) (don't have to support IE) or are able to send multiple kinds of bundles (i.e. [by using `<script type="module">` and `<script nomodule>`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)).
 - Our dependencies actually publish ES2015+ instead of the current baseline of ES5/ES3.
 - The future baseline shouldn't be fixed at ES2015, but is a changing target.
 
 ## Why
 
-Why is compiling dependencies desirable in the first place (vs. our own code)?
+Why is compiling dependencies (as opposed to just compiling our own code) desirable in the first place?
 
 - To have the freedom to make the tradeoffs of where code is able to run (vs. the library).
 - To ship less code to users, since JavaScript has a [cost](https://medium.com/dev-channel/the-cost-of-javascript-84009f51e99e).
@@ -32,20 +32,20 @@ Why is compiling dependencies desirable in the first place (vs. our own code)?
 
 The argument for why compiling dependencies would be helpful is the same for why Babel [eventually](https://github.com/babel/babel/pull/3476) introduced [`@babel/preset-env`](https://babeljs.io/docs/en/next/babel-preset-env.html). We saw that developers would eventually want to move past only compiling to ES5. 
 
-Babel used to be [`6to5`](https://babeljs.io/blog/2017/10/05/babel-turns-three), since it only converted from ES2015 to ES5. Back then, the browser support for ES2015 was almost non-existent, so the idea of a JavaScript compiler was both novel and useful: we could write modern code, and have it work for all of our users.
+Babel used to be [`6to5`](https://babeljs.io/blog/2017/10/05/babel-turns-three), since it only converted from ES2015 (known as ES6 back then) to ES5. Back then, the browser support for ES2015 was almost non-existent, so the idea of a JavaScript compiler was both novel and useful: we could write modern code, and have it work for all of our users.
 
-But what about the browser runtimes themselves? Because evergreen browsers will eventually catch up to the standard (and they have with ES2015), creating `preset-env` helps Babel and the community align with both the browsers and TC39 itself. If we only compiled to ES5, no one would ever run native code in the browsers.
+But what about the browser runtimes themselves? Because evergreen browsers will eventually catch up to the standard (as they have with ES2015), creating `preset-env` helps Babel and the community align with both the browsers and TC39 itself. If we only compiled to ES5, no one would ever run native code in the browsers.
 
 The real difference is realizing that there will _always_ be a sliding window of support:
 
 - Application code (our supported environments)
 - Browsers (Chrome, Firefox, Edge, Safari)
 - Babel (the abstraction layer)
-- TC39/ECMAScript Proposals (and Babel implementations)
+- TC39/ECMAScript proposals (and Babel implementations)
 
-Thus, the need isn't just for `6to5` to be renamed to Babel because it compiles to `7to5`, but for Babel to change the implicit assumption it only targets ES5. With `@babel/preset-env`, we are able to write the latest JavaScript and target whichever browser (environment)!
+Thus, the need isn't just for `6to5` to be renamed to Babel because it compiles to `7to5`, but for Babel to change the implicit assumption it only targets ES5. With `@babel/preset-env`, we are able to write the latest JavaScript and target whichever browser/environment!
 
-Using Babel and `preset-env` helps us keep up with that constantly changing sliding window. However, even if we use it, it's currently used for *our application code* and not what our code depends upon.
+Using Babel and `preset-env` helps us keep up with that constantly changing sliding window. However, even if we use it, it's currently used only for *our application code*, and not for our code’s dependencies.
 
 ## Who Owns Our Dependencies?
 
@@ -62,17 +62,17 @@ Is it as straightforward as just running Babel over `node_modules`?
 Although it shouldn't deter us from making this a common practice, we should be aware that compiling dependencies does increase the surface area of issues and complexity.
 
 - Compilers are no different than other programs and have bugs. 
-- `preset-env` itself could have bugs because we use [`compat-table`](https://kangax.github.io/compat-table/es6/) for our data vs. [test262](https://github.com/tc39/test262) (the official test suite).
+- `preset-env` itself could have bugs because we use [`compat-table`](https://kangax.github.io/compat-table/es6/) for our data vs. [Test262](https://github.com/tc39/test262) (the official test suite).
 - Browsers themselves can have issues with running native ES2015+ code vs. ES5.
 - There is still a question of determining what is "supported": https://github.com/babel/babel-preset-env/issues/54 is an example of an edge case.
 
 #### Specific Issues in v6
 
-Running a `script` as a `module` will either cause a `SyntaxError`, new runtime errors, or unexpected behavior due to the differences in semantics.
+Running a `script` as a `module` either causes a `SyntaxError`, new runtime errors, or unexpected behavior due to the differences in semantics between classic scripts and modules.
 
 Babel v6 viewed every file as a `module` and thus in ["strict mode"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode).
 
-> One could argue this is actually a good thing, since everyone using Babel will be opt-ing into strict mode by default 🙂.
+> One could argue this is actually a good thing, since everyone using Babel is opting in to strict mode by default 🙂.
 
 Running Babel with a conventional setup on all our `node_modules` may cause issues with code that is a `script` such as a jQuery plugin.
 
@@ -81,7 +81,7 @@ An example of an issue is how [`this` gets converted to `undefined`](https://git
 ```js
 // Input
 (function($) {
-  // ...
+  // …
 }(this.jQuery));
 ```
 
@@ -90,11 +90,11 @@ An example of an issue is how [`this` gets converted to `undefined`](https://git
 "use strict";
 
 (function ($) {
-  // ...
+  // …
 })(undefined.jQuery);
 ```
 
-This was [changed in v7](https://github.com/babel/babel/pull/6280) so that it won't auto inject the `"use strict"` directive unless it is a `module`.
+This was [changed in v7](https://github.com/babel/babel/pull/6280) so that it won't auto-inject the `"use strict"` directive unless the source file is a `module`.
 
 It was also not in Babel's original scope to compile dependencies: we actually got issue reports that people would accidently do it, making the build slower. There is a lot of defaults and documentation in the tooling that purposely disable compiling `node_modules`.
 
@@ -104,9 +104,9 @@ There are many issues with *shipping* uncompiled proposal syntax (this post was 
 
 #### Staging Process
 
-The [TC39 staging process](https://tc39.github.io/process-document/) does not always move forward: a proposal can move to any point in the process: even moving backwards from Stage 3 to Stage 2 as the case with Numeric Separators (`1_000`),  dropped entirely (`Object.observe()`, and others we may have forgotten 😁), or just stall like function bind (`a::b`) or decorators until recently.
+The [TC39 staging process](https://tc39.github.io/process-document/) does not always move forward: a proposal can move to any point in the process: even moving backwards from Stage 3 to Stage 2 as was the case with Numeric Separators (`1_000`),  dropped entirely (`Object.observe()`, and others we may have forgotten 😁), or just stall like function bind (`a::b`) or decorators until recently.
 
-- Summary of the Stages: Stage 0 has no criteria and is just an idea, Stage 1 is accepting that the problem is worth solving, Stage 2 is about describing a solution in spec text, Stage 3 means the specific solution is thought out, and Stage 4 means that it is ready for inclusion with tests, multiple browser implementations, and in-the-field experience.
+- Summary of the Stages: Stage 0 has no criteria and means the proposal is just an idea, Stage 1 is accepting that the problem is worth solving, Stage 2 is about describing a solution in spec text, Stage 3 means the specific solution is thought out, and Stage 4 means that it is ready for inclusion in the spec with tests, multiple browser implementations, and in-the-field experience.
 
 #### Using Proposals
 
@@ -122,19 +122,19 @@ There is certainly a balance to be had here: we don't want to scare people away 
 
 Even though one of the most common things people do is use the Stage 0 preset, we plan to remove the stage presets in v7. We thought at first it would be convenient, that people would make their own unofficial ones anyway, or it might help with "JavaScript fatigue". It seems to cause more of an issue: people continue to copy/paste configs without understanding what goes into a preset in the first place. 
 
-After all, seeing `"stage-0"` says nothing. My hope is that in making the decision to use proposal plugins explicit, people will have to learn what non-standard syntax they are opting into. More intentionality should lead to a better understanding of not just Babel but JavaScript the language and its development instead of just it's usage.
+After all, seeing `"stage-0"` says nothing. My hope is that in making the decision to use proposal plugins explicit, people will have to learn what non-standard syntax they are opting into. More intentionally, this should lead to a better understanding of not just Babel but of JavaScript as a language and its development instead of just its usage.
 
 ### Publishing Non-standard Syntax
 
 As a library author, publishing non-standard syntax is setting our users up for possible inconsistencies, refactoring, and breakage of their projects. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means we will inevitability have to change the library code. A "new" proposal doesn't mean the idea is fixed or certain but rather that we collectively want to explore the solution space.
 
-At least if we ship the compiled version, it will still work, and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it and will have to have the same configuration of Babel as us. This is in the same bucket as using TS/JSX/Flow: we wouldn't expect consumers to configure the same compiler environment just because we used them.
+At least if we ship the compiled version, it will still work, and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package needs to have a build step to use it and needs to have the same configuration of Babel as us. This is in the same bucket as using TS/JSX/Flow: we wouldn't expect consumers to configure the same compiler environment just because we used them.
 
 ### Conflating ESM and ES2015+
 
-When we write `import foo from "foo"` or `require("foo")` and `foo` doesn't have an `index.js`, it will resolve to the `main` field in the `package.json` of the module.
+When we write `import foo from "foo"` or `require("foo")` and `foo` doesn't have an `index.js`, it resolves to the `main` field in the `package.json` of the module.
 
-Some tools like Rollup/Webpack will also read from another field called `module` (previously `jsnext:main`). It uses this to instead resolve to the ESM file.
+Some tools like Rollup/webpack also read from another field called `module` (previously `jsnext:main`). It uses this to instead resolve to the ESM file.
 
 - An example with [`redux`](https://github.com/reactjs/redux)
 
@@ -149,7 +149,7 @@ Some tools like Rollup/Webpack will also read from another field called `module`
 
 This was introduced so that users could consume ES2015 modules (ESM).
 
-However, the sole intention of this field is ESM, not anything else. The [Rollup docs](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features) that specify the `module` field make it clear that it's not intended for future JavaScript syntax.
+However, the sole intention of this field is ESM, not anything else. The [Rollup docs](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features) specify that the `module` field makes it clear that it's not intended for future JavaScript syntax.
 
 Despite this warning, package authors invariably conflate the use of ES modules with the JavaScript language level they authored it in.
 
@@ -184,13 +184,13 @@ Having a `esnext` field may not be entirely helpful either. The "latest" version
 
 ### Dependencies May Not Publish ES2015+
 
-This effort will only be standard if it becomes straightforward to do as a library author. It will be hard to argue for the significance of this change if both new and popular libraries aren't able to ship the latest syntax.
+This effort will only be standard if it becomes straightforward to apply as a library author. It will be hard to argue for the significance of this change if both new and popular libraries aren't able to ship the latest syntax.
 
-Due to the complexity and tooling setup, it may be difficult for projects to publish ES2015+/ESM. This is probably the biggest issue to get right, and more documentation just isn't enough.
+Due to the complexity and tooling setup, it may be difficult for projects to publish ES2015+/ESM. This is probably the biggest issue to get right, and adding more documentation just isn't enough.
 
 For Babel, we may need to add some feature requests to `@babel/cli` to make this easier, and maybe make the `babel` package do this by default? Or we should integrate better with tools like @developit's [microbundle](https://github.com/developit/microbundle).
 
-And how do we deal with polyfills (this will be an upcoming post)? What would it look like for a library author not to have to think about polyfills (or the user).
+And how do we deal with polyfills (this will be an upcoming post)? What would it look like for a library author (or the user) to not to have to think about polyfills?
 
 With all that said, how does Babel help with all this?
 
@@ -198,7 +198,7 @@ With all that said, how does Babel help with all this?
 
 As we've discussed, compiling dependencies in Babel v6 can be pretty painful. Babel v7 will address some of these pain points. 
 
-One issue is around configuration lookup. Babel currently runs per file so when compiling a file, it tries to find the closest config ([`.babelrc`](https://babeljs.io/docs/en/next/babelrc)) to know what to compile against. It will keep looking up the directory tree if it doesn't find it in the current folder.
+One issue is around configuration lookup. Babel currently runs per file, so when compiling a file, it tries to find the closest config ([`.babelrc`](https://babeljs.io/docs/en/next/babelrc)) to know what to compile against. It keeps looking up the directory tree if it doesn't find it in the current folder.
 
 ```
 project
@@ -213,7 +213,7 @@ project
 We made a [few changes](https://github.com/babel/babel/pull/7358):
 
 - One is to stop lookup at the package boundary (stop when we find a `package.json`). This makes sure Babel won't try to load a config file outside the app, the most surprising being with it finds one in your home directory.
-- If we use a monorepo, we'll may want to have a `.babelrc` per-package that extends some other central config.
+- If we use a monorepo, we may want to have a `.babelrc` per-package that extends some other central config.
 - Babel itself is a monorepo, so instead we are using the new `babel.config.js` which allows us to resolve all files to that config (no more lookup).
 - We added an [`"overrides"`](https://github.com/babel/babel/pull/7091) option which allows us to basically create a new config for any set of paths.
 
@@ -249,7 +249,7 @@ module.exports = {
 
 We should shift our fixed view of publishing JavaScript to one that keeps up with the standard which pushes forward.
 
-My recommendation is that package authors should continue to publish ES5/CJS under `main` for backwards compat with current tooling and workflow but also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on like `main-es` (I don't believe `module` should be that key).
+My recommendation is that package authors should continue to publish ES5/CJS under `main` for backwards compat with current tooling and workflow but also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on like `main-es`. I don't believe `module` should be that key.
 
 > Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of a poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
 
@@ -257,11 +257,11 @@ Compiling dependencies isn't just something for one project/company to take adva
 
 Documentation needs to updated to mention the benefits of compiling `node_modules`, how to do so for the library authors, and how to consume it in bundlers/compilers.
 
-With Babel 7, consumers can more safely use `preset-env` and opt-in into running on `node_modules` with new config options like `overrides`.
+With Babel 7, consumers can more safely use `preset-env` and opt-in to running on `node_modules` with new config options like `overrides`.
 
 ## Let's Do This!
 
-Compiling JavaScript shouldn't be just about the specific ES2015/ES5 distinction, whether it's for our app or our dependencies! Hopefully this is an encouraging call to action re-starting conversations around making compiling dependencies more first class.
+Compiling JavaScript shouldn't be just about the specific ES2015/ES5 distinction, whether it's for our app or our dependencies! Hopefully this is an encouraging call to action re-starting conversations around making compiling dependencies more first-class.
 
 This post goes into some of the ways Babel should help with this effort, but we'll need everyone's help to change the ecosystem: more education, more opt-in published packages, and better tooling.
 

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -1,0 +1,224 @@
+---
+layout: post
+title:  "On Consuming (and Publishing) ES6+ Packages"
+author: Henry Zhu
+authorURL: https://twitter.com/left_pad
+date:   2018-06-25 12:00:00
+categories: announcements
+share_text: "On Consuming (and Publishing) ES6+ Packages"
+---
+
+How can we make compiling dependencies normal?
+
+<!--truncate-->
+
+<!-- I would probably add a TLDR; mention of what Dan wrote. Just a brief introduction to the topic. -->
+> Inspired by [Dan's tweet](https://twitter.com/dan_abramov/status/1009179550134296577)
+
+This is a pretty enabling feature request for the whole ecosystem, so I'm glad we've tried to make this easier in Babel v7 (I just realized this whole post is a good pitch for using it). Hopefully it can be made more standard moving forward (if we're collectively able to figure out some things I outline below).
+
+## Why
+
+Why is compiling your dependencies desirable in the first place (vs. just your own code)?
+
+We can ship less code to users, since JavaScript has a [cost](https://medium.com/dev-channel/the-cost-of-javascript-84009f51e99e).
+
+## Assumptions
+
+- You can ship to modern browsers (don't have to support IE) or are able to send multiple types of bundles (one way being [checking for script`type=module`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)).
+- And/or the dependencies actually publish ES6+ instead of ES5/ES3.
+
+## Backing up a Bit: Talking About `preset-env`
+
+If you think about it, the argument for why this would be helpful is the same for why we eventually introduced `@babel/preset-env`.
+
+Babel used to be `6to5`, since it only converted from ES6 to ES5. Back then, the browser support for ES6 was almost non-existent so the idea of a JS compiler was an amazing contribution to our ecosystem.
+
+I went through with implementing the preset even though there was so much complexity since it seemed to solve multiple issues for us. I didn't realize how much it would move us forward now that it's finally [surpassed `preset-es2015`](https://npm-stat.com/charts.html?package=babel-preset-es2015&package=babel-preset-env&from=2016-11-01&to=2018-06-22) which is a nice accomplishment.
+
+When I think about Babel's role not just in moving the language itself forward but helping us develop websites better, I saw that we would eventually want to move past only compiling to ES5. Creating `preset-env` helps us align with the browsers since if we only compiled to ES5, no one would ever run native code in the browsers.
+
+The real difference is realizing that there will _always_ be a sliding window of support: whether it's the JavaScript language that continues to move forward with new syntax, the browsers catching up with the standard, or the companies/projects themselves.
+
+- You (your supported environments)
+- Browsers (Chrome, Firefox, Edge, Safari)
+- TC39/ECMAScript Proposals (and Babel implementations)
+
+Thus the need isn't just for `6to5` to be renamed to Babel because it compiles to `7to5`, but for Babel to change the implicit assumption it only targets ES5. With `@babel/preset-env`, you are able to write the latest JavaScript and target whichever browser (environment) you want!
+
+But assuming people even know it exists or have starting using it at all, it's mainly for your **application** code.
+
+## Your Code
+
+You have control over your own code to be able to take advantage of preset-env: write in ES6+ and target ES6+ browsers.
+
+However, this isn't necessarily the case for your dependencies (you should take ownership for them though).
+
+## What Then?
+
+The next step is to start thinking, how do we actually make this happen?
+
+It sounds like it's as straightforward as running Babel over `node_modules` with the same configuration for your application.
+
+## Caveats
+
+### Using Non-Standard Syntax
+
+This is what Dan was warning about. There are many issues with *shipping* uncompiled proposal syntax.
+
+#### Using Proposals
+
+<blockquote class="twitter-tweet" data-lang="en"><p lang="und" dir="ltr"><a href="https://t.co/femUb4vgxh">pic.twitter.com/femUb4vgxh</a></p>&mdash; Rach Smith 🌈 (@rachsmithtweets) <a href="https://twitter.com/rachsmithtweets/status/892478598765887488?ref_src=twsrc%5Etfw">August 1, 2017</a></blockquote>
+
+<!-- added "simply" to emphasys like in the hyronically "just use" (if that's what you intended) -->
+First, we already recommend people be careful with *simply using* syntax less than Stage 3.
+
+But telling people not to use Stage X goes against the whole purpose of Babel in the first place. A big reason why proposals move forward or are shaped to be better is precisely because of the feedback the committee can get from real-world usage (whether in production or not) based on using it in Babel.
+
+So there is certainly a balance to be had here. We don't want to scare people away from using new syntax (that is a hard sell 😂), but we also don't want people to get the idea that "once it's in Babel, the syntax is official or immutable". Ideally people look into the purpose of a proposal and make the tradeoffs for their use case.
+
+One of the most common things people do is use the Stage 0 or Stage 2 presets. We plan to remove these Stage presets in v7 after much back and forth. I thought at first it would be convienent, that people would make their own unofficial ones anyway, or it might help with "JavaScript fatigue". I find now that it just causes more of an issue: people continue to copy paste configs and not understanding what goes into a preset in the first place. After all, seeing `"stage-0"` says nothing. My hope is that in actually making the decision explicit, people will have to learn what non-standard syntax they are opting into.
+
+#### Staging Process
+
+- The [TC39 staging process](https://tc39.github.io/process-document/) does not always move foward: there is the possibility for a proposal to move to any point in the process: even moving backwards from Stage 3 to Stage 2 as the case with Numeric Separators (`1_000`) or dropped entirely (`Object.observe()`, others you may have forgotten)
+- It can be hard to differentitate between the stages if you aren't involved: most people would advise that Stage 0-2 is unstable though.
+- Summary: Stage 0 has no criteria and is just an idea, Stage 1 is accepting that the problem is worth solving, Stage 2 is about describing a solution in spec text, Stage 3 means the specific solution is thought out, and Stage 4 means that it is ready for inclusion with tests, multiple browser implementations, and in-the-field experience.
+
+#### Publishing Non-standard Syntax
+
+So actually publishing it in a library may cause even more issues. Because a proposal on TC39 (even at Stage 3) has a possibility of changing, it means you will inevitability will have to change the code.
+
+At least if you ship the compiled version, it will still work and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it, and will have to have the same version of Babel as you. This is no different than using TS/JSX/Flow which you wouldn't publish either.
+
+TODO: Or a proposal might just stall because people are busy, etc. Decorators are a great example of this.
+
+### Conflating ESM and ES6+
+
+When you do `import foo from "foo"` or `require("foo")` and `foo` doesn't have an `index.js`, it will resolve to the `main` field in the `package.json` of the module.
+
+Some tools like Rollup/Webpack will also read from another field called `module` (previously `jsnext:main`). It uses this to instead resolve to the ESM file.
+
+- An example with [`redux`](https://github.com/reactjs/redux)
+
+```js
+// redux package.json
+{
+  ...
+  "main": "lib/redux.js", // ES5 + CJS
+  "module": "es/redux.js", // ES5 + ESM
+}
+```
+
+The reason this was introduced is so that users can consume ES2015 modules (ESM).
+
+However, the sole intention of this field is ESM not anything else. The [Rollup docs](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features) on this make it clear that it's not intended for future JavaScript syntax.
+
+What this means is that we may need another way to handle ES6+ even though some libraries may choose to do this anyway.
+
+A common suggestion is for libraries to start publishing ES2015 under another field like `es2015`, e.g. `"es2015": "es2015/redux.js"`.
+
+```js
+// @angular/core package.json
+{
+  "main": "./bundles/core.umd.js",
+  "module": "./fesm5/core.js",
+  "es2015": "./fesm2015/core.js",
+  "esm5": "./esm5/core.js",
+  "esm2015": "./esm2015/core.js",
+  "fesm5": "./fesm5/core.js",
+  "fesm2015": "./fesm2015/core.js",
+}
+```
+
+This works for ES2015 but the question next is what about ES2016? Are we supposed to create a new folder for each year and a new field in `package.json`? That also seems unsustainable later, and even produces even larger `node_modules` still.
+
+I feel like this is similar to how we had a babel preset for each year and ended up creating `preset-latest` which included all the yearly plugins (we removed that soon after in favor of `preset-env`).
+
+Having a field like `es-latest` or `esnext` may not be helpful either because we want the library versions to be fixed yet changing. And providing only the source may not always be helpful if you use non-standard syntax, TS, Flow, JSX, etc which might have different behavior based on compiler version. Maybe we need some changes on the `npm` side?
+
+One suggestion is to provide an ES5 version but also publish a version that includes the latest standard syntax so it can be compiled with `preset-env`.
+
+### Dependencies May Not Publish ES6+
+
+TODO:
+
+- Due to complexity and tooling, it may be difficult for projects to publish ES6/ESM without more setup. This is probably the biggest issue to get right. We should add some feature requests to `@babel/cli` to make this easier, and maybe make the `babel` package do this by default.
+
+<!-- jshcrowthe: Getting into the library dev scene I definitely felt the lack of good tooling/guides for publishing modules "correctly." Would be awesome if we could do something here -->
+
+- Tools like @developit's [microbundle](https://github.com/developit/microbundle) may help a lot with this.
+- How do we deal with polyfills? Mention `preset-env` + polyfills
+
+<!-- jshcrowthe: As you said above, polyfills are application specific, based on the target environment. Would love it if, as a library dev, didn't have to worry about these at all and these were handled by application tooling. -->
+
+### Compiler Complexity
+
+Every compiler has bugs, although the risk is lower if there are so many users and sufficient tests. We should just be aware that compiling dependencies does increase the surface area of potential bugs, but I don't believe that should deter us from making this a common practice.
+
+- Babel v6 assumed everything that it compiled was a module and thus in strict mode (one could argue this is actually a good thing). Thus if you tried to run Babel on all your `node_modules` and it encountered something that was a `script` like a jQuery plugin it might cause a lot of issues. This is changed in v7 so that it won't always auto inject the `"use strict"` directive unless it actually is a module.
+- React Native has always compiled `node_modules` by default and has probably learned a lot from issues like ^.
+- `preset-env` could have it's own bugs because we use `compat-table` vs. test262.
+- Browsers themselves can have issues with running native ES6+ code vs. ES5.
+- Question of how do we determine what is "supported": https://github.com/babel/babel-preset-env/issues/54 example of edge case.
+
+### Help with Babel v7 Config
+
+It can be pretty painful to compile `node_modules` in Babel v6. The reason is both that we never thought of it as something we wanted as well as getting issue reports that people would actually accidently do it making the build slower.
+
+One issue (which we have fixed in v7) is around config lookup. Babel currently runs per file so when compiling a file, it tries to find the closest config to know what to compile against. If it doesn't find it in the same directory, it keeps looking up directories (this is why if you don't specify a config but have one in your home directory it might try to load that instead).
+
+```
+project
+└── .babelrc // closest config for a.js
+└── a.js
+└── node_modules
+    └── package
+        └── .babelrc // closest config for b.js
+        └── b.js
+```
+
+We made a [few changes](https://github.com/babel/babel/pull/7358):
+
+- One is to stop lookup at the package boundary (stop when you find a `package.json`). This makes sure Babel won't try to load a config file outside.
+- If you use a monorepo, you'll may want to have a `.babelrc` per-package that extends some other central config.
+- Babel itself is a monorepo, so instead we are using the new `babel.config.js` which allows you to resolve all files to that config (no more lookup).
+- We added an [`"overrides"`](https://github.com/babel/babel/pull/7091) option which allows you to basically create a new config for any set of paths.
+
+This allows you to have a single config for your whole app: maybe you want to compile your server JavaScript code differently than the client code as well as compile something in `node_modules`.
+
+```js
+// babel.config.js
+module.exports = {
+  presets: [
+    ['env', { 
+      targets: { node: 'current' },
+    }],
+  ],
+  overrides: [{
+    test: "./client",
+    presets: [
+      ['env', { 
+        targets: { browsers: ["last 2 versions"] },
+      }],
+    ],
+  }, {
+    test: "./node_modules/",
+    presets: [
+      ['env', { 
+        targets: { browsers: ["last 2 versions"] },
+      }],
+    ],
+  }],
+}
+```
+
+### Let's Do This!
+
+Hopefully this is an encouraging call to action for looking into moving forward to make compiling dependencies more first class. It's not just about the specific ES6/ES5 distinction.
+
+Babel v7 should be out soon, this post goes into some of the ways it should help with this effort but we'll need everyone's help to change the ecosystem (more education, published packages that do this, and better tooling and sustainability).
+
+Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of the poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
+
+Potential recommendation: package authors should also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on (I don't believe `module` should be that key) but continue to publish ES5 under `main`. Consumers can use `preset-env` and opt-in into running on `node_modules`.

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -32,7 +32,7 @@ Why is compiling dependencies desirable in the first place (vs. our own code)?
 
 The argument for why compiling dependencies would be helpful is the same for why Babel [eventually](https://github.com/babel/babel/pull/3476) introduced [`@babel/preset-env`](https://babeljs.io/docs/en/next/babel-preset-env.html). We saw that developers would eventually want to move past only compiling to ES5. 
 
-Babel used to be [`6to5`](https://babeljs.io/blog/2017/10/05/babel-turns-three), since it only converted from ES2015 to ES5. Back then, the browser support for ES2015 was almost non-existent, so the idea of a JavaScript compiler was both novel and useful: we could write modern code and have it work for all of our users.
+Babel used to be [`6to5`](https://babeljs.io/blog/2017/10/05/babel-turns-three), since it only converted from ES2015 to ES5. Back then, the browser support for ES2015 was almost non-existent, so the idea of a JavaScript compiler was both novel and useful: we could write modern code, and have it work for all of our users.
 
 But what about the browser runtimes themselves? Because evergreen browsers will eventually catch up to the standard (and they have with ES2015), creating `preset-env` helps Babel and the community align with both the browsers and TC39 itself. If we only compiled to ES5, no one would ever run native code in the browsers.
 
@@ -43,7 +43,7 @@ The real difference is realizing that there will _always_ be a sliding window of
 - Babel (the abstraction layer)
 - TC39/ECMAScript Proposals (and Babel implementations)
 
-Thus the need isn't just for `6to5` to be renamed to Babel because it compiles to `7to5`, but for Babel to change the implicit assumption it only targets ES5. With `@babel/preset-env`, we are able to write the latest JavaScript and target whichever browser (environment)!
+Thus, the need isn't just for `6to5` to be renamed to Babel because it compiles to `7to5`, but for Babel to change the implicit assumption it only targets ES5. With `@babel/preset-env`, we are able to write the latest JavaScript and target whichever browser (environment)!
 
 Using Babel and `preset-env` helps us keep up with that constantly changing sliding window. However, even if we use it, it's currently used for *our application code* and not what our code depends upon.
 
@@ -61,14 +61,14 @@ Is it as straightforward as just running Babel over `node_modules`?
 
 Although it shouldn't deter us from making this a common practice, we should be aware that compiling dependencies does increase the surface area of issues and complexity.
 
-- Compilers are no different than other programs and has bugs. 
-- `preset-env` itself could have because we use [`compat-table`](https://kangax.github.io/compat-table/es6/) for our data vs. [test262](https://github.com/tc39/test262) (the official test suite).
+- Compilers are no different than other programs and have bugs. 
+- `preset-env` itself could have bugs because we use [`compat-table`](https://kangax.github.io/compat-table/es6/) for our data vs. [test262](https://github.com/tc39/test262) (the official test suite).
 - Browsers themselves can have issues with running native ES2015+ code vs. ES5.
 - There is still a question of determining what is "supported": https://github.com/babel/babel-preset-env/issues/54 is an example of an edge case.
 
 #### Specific Issues in v6
 
-Running a `script` as a `module` will either cause a `SyntaxError`, new runtime erorrs, or unexpected behavior due to the differences in semantics.
+Running a `script` as a `module` will either cause a `SyntaxError`, new runtime errors, or unexpected behavior due to the differences in semantics.
 
 Babel v6 viewed every file as a `module` and thus in ["strict mode"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode).
 
@@ -94,9 +94,9 @@ An example of an issue is how [`this` gets converted to `undefined`](https://git
 })(undefined.jQuery);
 ```
 
-This was [changed in v7](https://github.com/babel/babel/pull/6280) so that it won't auto inject the `"use strict"` directive unless it actually is a `module`.
+This was [changed in v7](https://github.com/babel/babel/pull/6280) so that it won't auto inject the `"use strict"` directive unless it is a `module`.
 
-It was also not in Babel's original scope to compile dependencies: we actually got issue reports that people would accidently do it, making the build slower. So there may be a lot of defaults and documentation in the tooling that purposely not allow compiling `node_modules`.
+It was also not in Babel's original scope to compile dependencies: we actually got issue reports that people would accidently do it, making the build slower. There is a lot of defaults and documentation in the tooling that purposely disable compiling `node_modules`.
 
 ### Using Non-Standard Syntax
 
@@ -120,15 +120,15 @@ There is certainly a balance to be had here: we don't want to scare people away 
 
 #### Removing the Stage Presets in v7
 
-Even though one of the most common things people do is use the Stage 0 preset, we plan to remove the stage presets in v7. We thought at first it would be convienent, that people would make their own unofficial ones anyway, or it might help with "JavaScript fatigue". It seems to cause more of an issue: people continue to copy/paste configs with out understanding what goes into a preset in the first place. 
+Even though one of the most common things people do is use the Stage 0 preset, we plan to remove the stage presets in v7. We thought at first it would be convenient, that people would make their own unofficial ones anyway, or it might help with "JavaScript fatigue". It seems to cause more of an issue: people continue to copy/paste configs without understanding what goes into a preset in the first place. 
 
-After all, seeing `"stage-0"` says nothing. My hope is that in making the decision to use proposal plugins explicit, people will have to learn what non-standard syntax they are opting into. More intentionality should lead to a better understanding of not just Babel but JavaScript the language and it's development instead of just it's usage.
+After all, seeing `"stage-0"` says nothing. My hope is that in making the decision to use proposal plugins explicit, people will have to learn what non-standard syntax they are opting into. More intentionality should lead to a better understanding of not just Babel but JavaScript the language and its development instead of just it's usage.
 
 ### Publishing Non-standard Syntax
 
-As a library author, publishing non-standard syntax is setting our users up for possible inconsistencies, refactoring, and breakage of their projects. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means we will inevitability have to change the library code. A "new" proposal doesn't mean the idea is fixed or certain but rather that we collectively want explore the solution space.
+As a library author, publishing non-standard syntax is setting our users up for possible inconsistencies, refactoring, and breakage of their projects. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means we will inevitability have to change the library code. A "new" proposal doesn't mean the idea is fixed or certain but rather that we collectively want to explore the solution space.
 
-At least if we ship the compiled version, it will still work and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it, and will have to have the same configuration of Babel as us. This is in the same bucket as using TS/JSX/Flow: we wouldn't expect consumers to configure the same compiler environment just because we used them.
+At least if we ship the compiled version, it will still work, and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it and will have to have the same configuration of Babel as us. This is in the same bucket as using TS/JSX/Flow: we wouldn't expect consumers to configure the same compiler environment just because we used them.
 
 ### Conflating ESM and ES2015+
 
@@ -184,7 +184,7 @@ Having a `esnext` field may not be entirely helpful either. The "latest" version
 
 ### Dependencies May Not Publish ES2015+
 
-This effort will only be standard if it becomes straightfoward to do as a library author. It will be hard to argue for the significance of this change if both new and popular libraries aren't able to ship the latest syntax.
+This effort will only be standard if it becomes straightforward to do as a library author. It will be hard to argue for the significance of this change if both new and popular libraries aren't able to ship the latest syntax.
 
 Due to the complexity and tooling setup, it may be difficult for projects to publish ES2015+/ESM. This is probably the biggest issue to get right, and more documentation just isn't enough.
 
@@ -253,7 +253,7 @@ My recommendation is that package authors should continue to publish ES5/CJS und
 
 > Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of a poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
 
-Compiling dependencies isn't just something for one project/company to take advantage of: it requires a push by the whole community to move forward. Even though this effort will be natural, it might require some sort of standardization: we can implement a set of criteria for how librarys can opt-in to publishing ES2015+ and verify this via CI/tooling/npm itself.
+Compiling dependencies isn't just something for one project/company to take advantage of: it requires a push by the whole community to move forward. Even though this effort will be natural, it might require some sort of standardization: we can implement a set of criteria for how libraries can opt-in to publishing ES2015+ and verify this via CI/tooling/npm itself.
 
 Documentation needs to updated to mention the benefits of compiling `node_modules`, how to do so for the library authors, and how to consume it in bundlers/compilers.
 
@@ -261,9 +261,9 @@ With Babel 7, consumers can more safely use `preset-env` and opt-in into running
 
 ## Let's Do This!
 
-Compiling JavScript shouldn't be just about the specific ES2015/ES5 distinction, whether it's for our app or our dependencies! Hopefully this is an encouraging call to action re-starting conversations around making compiling dependencies more first class.
+Compiling JavaScript shouldn't be just about the specific ES2015/ES5 distinction, whether it's for our app or our dependencies! Hopefully this is an encouraging call to action re-starting conversations around making compiling dependencies more first class.
 
-This post goes into some of the ways Babel should help with this effort but we'll need everyone's help to change the ecosystem: more education, more opt-in published packages, and better tooling.
+This post goes into some of the ways Babel should help with this effort, but we'll need everyone's help to change the ecosystem: more education, more opt-in published packages, and better tooling.
 
 Let's take advantage of ES2015+ not just in our own code, but our dependencies.
 

--- a/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
+++ b/website/blog/2018-06-25-on-consuming-and-publishing-es6+-packages.md
@@ -126,7 +126,7 @@ After all, seeing `"stage-0"` says nothing. My hope is that in making the decisi
 
 ### Publishing Non-standard Syntax
 
-As a library author, publishing non-standard syntax is setting our users up for possible inconsistencies, refactoring, and breakage of their projects. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means we will inevitability have to change the library code.
+As a library author, publishing non-standard syntax is setting our users up for possible inconsistencies, refactoring, and breakage of their projects. Because a TC39 proposal (even at Stage 3) has a possibility of changing, it means we will inevitability have to change the library code. A "new" proposal doesn't mean the idea is fixed or certain but rather that we collectively want explore the solution space.
 
 At least if we ship the compiled version, it will still work and the library maintainer can change the output so that it works the same as before. Shipping the uncompiled version means that anyone consuming a package will necessarily have to have a build step to use it, and will have to have the same configuration of Babel as us. This is in the same bucket as using TS/JSX/Flow: we wouldn't expect consumers to configure the same compiler environment just because we used them.
 
@@ -245,7 +245,9 @@ module.exports = {
 }
 ```
 
-## Recommendation to Discuss
+## Recommendations to Discuss
+
+We should shift our fixed view of publishing JavaScript to one that keeps up with the standard which pushes forward.
 
 My recommendation is that package authors should continue to publish ES5/CJS under `main` for backwards compat with current tooling and workflow but also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on like `main-es` (I don't believe `module` should be that key).
 
@@ -259,9 +261,15 @@ With Babel 7, consumers can more safely use `preset-env` and opt-in into running
 
 ## Let's Do This!
 
-Hopefully this is an encouraging call to action for looking into moving forward to make compiling dependencies more first class. It's not just about the specific ES2015/ES5 distinction.
+Compiling JavScript shouldn't be just about the specific ES2015/ES5 distinction, whether it's for our app or our dependencies! Hopefully this is an encouraging call to action re-starting conversations around making compiling dependencies more first class.
 
-Babel v7 should be out soon. This post goes into some of the ways it should help with this effort but we'll need everyone's help to change the ecosystem: more education, published packages that do this, and better tooling and sustainability.
+This post goes into some of the ways Babel should help with this effort but we'll need everyone's help to change the ecosystem: more education, more opt-in published packages, and better tooling.
+
+Let's take advantage of ES2015+ not just in our own code, but our dependencies.
+
+---
+
+If you appreciated this article and the work that we do on Babel, please consider partnering with us and supporting my [Patreon](https://www.patreon.com/henryzhu) and Babel's [Open Collective](https://opencollective.com/babel) to continue to invest in the JavaScript ecosystem that we all use.
 
 > Thanks to the [many](https://twitter.com/left_pad/status/1010280464840617984) folks who offered to review this post including [@chrisdarroch](https://twitter.com/chrisdarroch), [@existentialism](https://twitter.com/existentialism), [@betaorbust](https://twitter.com/betaorbust), [@_developit](https://twitter.com/_developit), [@jdalton](https://twitter.com/jdalton), [@bonsaistudio](https://twitter.com/bonsaistudio).
 

--- a/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
+++ b/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
@@ -251,15 +251,11 @@ module.exports = {
 
 We should shift our fixed view of publishing JavaScript to one that keeps up with the latest standard.
 
-For package authors.
-
 We should continue to publish ES5/CJS under `main` for backwards compatibility with current tooling but also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on like `main-es`. (I don't believe `module` should be that key since it was intended only for JS Modules).
 
 > Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of the poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
 
 Compiling dependencies isn't just something for one project/company to take advantage of: it requires a push by the whole community to move forward. Even though this effort will be natural, it might require some sort of standardization: we can implement a set of criteria for how libraries can opt-in to publishing ES2015+ and verify this via CI/tooling/npm itself.
-
-For tool authors/everyone.
 
 Documentation needs to updated to mention the benefits of compiling `node_modules`, how to do so for the library authors, and how to consume it in bundlers/compilers.
 
@@ -272,12 +268,6 @@ Compiling JavaScript shouldn't be just about the specific ES2015/ES5 distinction
 This post goes into some of the ways Babel should help with this effort, but we'll need everyone's help to change the ecosystem: more education, more opt-in published packages, and better tooling.
 
 ---
-
-Maybe dependencies will become a first-class citizen for compliation. But have we thought about the future of our dependencies and their sustainability?
-
-In the case of Babel, it's grown to be a fundamental part of the JavaScript ecosystem with the help of some volunteers and only more so the past year.
-
-Please consider partnering with us by getting involved and/or supporting my [Patreon](https://www.patreon.com/henryzhu) and Babel's [Open Collective](https://opencollective.com/babel).
 
 > Thanks to the [many](https://twitter.com/left_pad/status/1010280464840617984) folks who offered to review this post including [@chrisdarroch](https://twitter.com/chrisdarroch), [@existentialism](https://twitter.com/existentialism), [@mathias](https://twitter.com/mathias), [@betaorbust](https://twitter.com/betaorbust), [@_developit](https://twitter.com/_developit), [@jdalton](https://twitter.com/jdalton), [@bonsaistudio](https://twitter.com/bonsaistudio).
 

--- a/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
+++ b/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
@@ -29,8 +29,6 @@ Why is compiling dependencies (as opposed to just compiling our own code) desira
 - To have the freedom to make the tradeoffs of where code is able to run (vs. the library).
 - To ship less code to users, since JavaScript has a [cost](https://medium.com/dev-channel/the-cost-of-javascript-84009f51e99e).
 
-> If you only support evergreen, latest browsers then you may not need to compile your own code let alone dependencies!
-
 ## The Ephemeral JavaScript Runtime
 
 The argument for why compiling dependencies would be helpful is the same for why Babel [eventually](https://github.com/babel/babel/pull/3476) introduced [`@babel/preset-env`](https://babeljs.io/docs/en/next/babel-preset-env.html). We saw that developers would eventually want to move past only compiling to ES5. 
@@ -58,18 +56,19 @@ This isn't necessarily the case for our dependencies; in order to get the same b
 
 Is it as straightforward as just running Babel over `node_modules`?
 
-## The Current Complexities in Compiling Dependencies
+## Current Complexities in Compiling Dependencies
 
 ### Compiler Complexity
 
-Although it shouldn't deter us from making this a common practice, we should be aware that compiling dependencies does increase the surface area of issues and complexity.
+Although it shouldn't deter us from making this possible, we should be aware that compiling dependencies does increase the surface area of issues and complexity, especially for Babel itself.
 
+- Not every dependency needs to be compiled, and compiling more files does mean a slower build.
 - Compilers are no different than other programs and have bugs. 
 - `preset-env` itself could have bugs because we use [`compat-table`](https://kangax.github.io/compat-table/es6/) for our data vs. [Test262](https://github.com/tc39/test262) (the official test suite).
 - Browsers themselves can have issues with running native ES2015+ code vs. ES5.
 - There is still a question of determining what is "supported": see [babel/babel-preset-env#54](https://github.com/babel/babel-preset-env/issues/54) for an example of an edge case. Does it pass the test just because it parses or has partial support?
 
-#### Specific Issues in v6
+#### Specific Issues in Babel v6
 
 Running a `script` as a `module` either causes a `SyntaxError`, new runtime errors, or unexpected behavior due to the [differences in semantics](https://developers.google.com/web/fundamentals/primers/modules#intro) between classic scripts and modules.
 
@@ -215,7 +214,7 @@ project
 
 We made a [few changes](https://github.com/babel/babel/pull/7358):
 
-- One is to stop lookup at the package boundary (stop when we find a `package.json`). This makes sure Babel won't try to load a config file outside the app, the most surprising being with it finds one in your home directory.
+- One is to stop lookup at the package boundary (stop when we find a `package.json`). This makes sure Babel won't try to load a config file outside the app, the most surprising being when it finds one in the home directory.
 - If we use a monorepo, we may want to have a `.babelrc` per-package that extends some other central config.
 - Babel itself is a monorepo, so instead we are using the new `babel.config.js` which allows us to resolve all files to that config (no more lookup).
 - We added an [`"overrides"`](https://github.com/babel/babel/pull/7091) option which allows us to basically create a new config for any set of paths.
@@ -256,7 +255,7 @@ For package authors.
 
 We should continue to publish ES5/CJS under `main` for backwards compatibility with current tooling but also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on like `main-es`. (I don't believe `module` should be that key since it was intended only for JS Modules).
 
-> Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of a poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
+> Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of the poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
 
 Compiling dependencies isn't just something for one project/company to take advantage of: it requires a push by the whole community to move forward. Even though this effort will be natural, it might require some sort of standardization: we can implement a set of criteria for how libraries can opt-in to publishing ES2015+ and verify this via CI/tooling/npm itself.
 
@@ -272,13 +271,11 @@ Compiling JavaScript shouldn't be just about the specific ES2015/ES5 distinction
 
 This post goes into some of the ways Babel should help with this effort, but we'll need everyone's help to change the ecosystem: more education, more opt-in published packages, and better tooling.
 
-Let's take advantage of ES2015+ not just in our own code, but our dependencies.
-
 ---
 
 Maybe dependencies will become a first-class citizen for compliation. But have we thought about the future of our dependencies and their sustainability?
 
-In the case of Babel, it's grown to be a fundamental part of the JavaScript ecosystem with the help of some volunteers.
+In the case of Babel, it's grown to be a fundamental part of the JavaScript ecosystem with the help of some volunteers and only more so the past year.
 
 Please consider partnering with us by getting involved and/or supporting my [Patreon](https://www.patreon.com/henryzhu) and Babel's [Open Collective](https://opencollective.com/babel).
 

--- a/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
+++ b/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
@@ -8,17 +8,17 @@ categories: announcements
 share_text: "On Consuming (and Publishing) ES2015+ Packages"
 ---
 
-For those of us that need to support older browsers, we run a compiler like Babel over application code. But that's not all of the code that we ship to browsers, there's also the code in our `node_modules`.
+For those of us that need to support older browsers, we run a compiler like Babel over application code. But that's not all of the code that we ship to browsers; there's also the code in our `node_modules`.
 
 Can we make compiling our dependencies not just possible, but normal?
 
 <!--truncate-->
 
-The ability to compile dependencies is an enabling feature request for the whole ecosystem. Starting with some of the changes we made in Babel v7, we hope to see it standardized moving forward.
+The ability to compile dependencies is an enabling feature request for the whole ecosystem. Starting with some of the changes we made in Babel v7 to make selective dependency compilation possible, we hope to see it standardized moving forward.
 
 ## Assumptions
 
-- We will ship to modern browsers that support ES2015+ [natively](https://kangax.github.io/compat-table/es6/) (don't have to support IE) or are able to send multiple kinds of bundles (i.e. [by using `<script type="module">` and `<script nomodule>`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)).
+- We ship to modern browsers that support ES2015+ [natively](https://kangax.github.io/compat-table/es6/) (don't have to support IE) or are able to send multiple kinds of bundles (i.e. [by using `<script type="module">` and `<script nomodule>`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) or ).
 - Our dependencies actually publish ES2015+ instead of the current baseline of ES5/ES3.
 - The future baseline shouldn't be fixed at ES2015, but is a changing target.
 
@@ -62,8 +62,8 @@ Is it as straightforward as just running Babel over `node_modules`?
 
 Although it shouldn't deter us from making this possible, we should be aware that compiling dependencies does increase the surface area of issues and complexity, especially for Babel itself.
 
-- Not every dependency needs to be compiled, and compiling more files does mean a slower build.
 - Compilers are no different than other programs and have bugs. 
+- Not every dependency needs to be compiled, and compiling more files does mean a slower build.
 - `preset-env` itself could have bugs because we use [`compat-table`](https://kangax.github.io/compat-table/es6/) for our data vs. [Test262](https://github.com/tc39/test262) (the official test suite).
 - Browsers themselves can have issues with running native ES2015+ code vs. ES5.
 - There is still a question of determining what is "supported": see [babel/babel-preset-env#54](https://github.com/babel/babel-preset-env/issues/54) for an example of an edge case. Does it pass the test just because it parses or has partial support?

--- a/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
+++ b/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
@@ -8,7 +8,9 @@ categories: announcements
 share_text: "On Consuming (and Publishing) ES2015+ Packages"
 ---
 
-How can we make compiling our dependencies not just possible, but normal?
+For those of us that need to support older browsers, we run a compiler like Babel over application code. But that's not all of the code that we ship to browsers, there's also the code in our `node_modules`.
+
+Can we make compiling our dependencies not just possible, but normal?
 
 <!--truncate-->
 
@@ -16,7 +18,6 @@ The ability to compile dependencies is an enabling feature request for the whole
 
 ## Assumptions
 
-- We believe compiling our own app code is useful due to supporting older browsers.
 - We will ship to modern browsers that support ES2015+ [natively](https://kangax.github.io/compat-table/es6/) (don't have to support IE) or are able to send multiple kinds of bundles (i.e. [by using `<script type="module">` and `<script nomodule>`](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)).
 - Our dependencies actually publish ES2015+ instead of the current baseline of ES5/ES3.
 - The future baseline shouldn't be fixed at ES2015, but is a changing target.
@@ -27,6 +28,8 @@ Why is compiling dependencies (as opposed to just compiling our own code) desira
 
 - To have the freedom to make the tradeoffs of where code is able to run (vs. the library).
 - To ship less code to users, since JavaScript has a [cost](https://medium.com/dev-channel/the-cost-of-javascript-84009f51e99e).
+
+> If you only support evergreen, latest browsers then you may not need to compile your own code let alone dependencies!
 
 ## The Ephemeral JavaScript Runtime
 
@@ -64,7 +67,7 @@ Although it shouldn't deter us from making this a common practice, we should be 
 - Compilers are no different than other programs and have bugs. 
 - `preset-env` itself could have bugs because we use [`compat-table`](https://kangax.github.io/compat-table/es6/) for our data vs. [Test262](https://github.com/tc39/test262) (the official test suite).
 - Browsers themselves can have issues with running native ES2015+ code vs. ES5.
-- There is still a question of determining what is "supported": https://github.com/babel/babel-preset-env/issues/54 is an example of an edge case.
+- There is still a question of determining what is "supported": see [babel/babel-preset-env#54](https://github.com/babel/babel-preset-env/issues/54) for an example of an edge case. Does it pass the test just because it parses or has partial support?
 
 #### Specific Issues in v6
 
@@ -247,21 +250,25 @@ module.exports = {
 
 ## Recommendations to Discuss
 
-We should shift our fixed view of publishing JavaScript to one that keeps up with the standard which pushes forward.
+We should shift our fixed view of publishing JavaScript to one that keeps up with the latest standard.
 
-My recommendation is that package authors should continue to publish ES5/CJS under `main` for backwards compat with current tooling and workflow but also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on like `main-es`. I don't believe `module` should be that key since it was intended only for JS Modules.
+For package authors.
+
+We should continue to publish ES5/CJS under `main` for backwards compatibility with current tooling but also publish a version compiled down to latest syntax (no experimental proposals) under a new key we can standardize on like `main-es`. (I don't believe `module` should be that key since it was intended only for JS Modules).
 
 > Maybe we should decide on another key in `package.json`, maybe `"es"`? Reminds me of a poll I made for [babel-preset-latest](https://twitter.com/left_pad/status/758429846594850816).
 
 Compiling dependencies isn't just something for one project/company to take advantage of: it requires a push by the whole community to move forward. Even though this effort will be natural, it might require some sort of standardization: we can implement a set of criteria for how libraries can opt-in to publishing ES2015+ and verify this via CI/tooling/npm itself.
 
+For tool authors/everyone.
+
 Documentation needs to updated to mention the benefits of compiling `node_modules`, how to do so for the library authors, and how to consume it in bundlers/compilers.
 
-With Babel 7, consumers can more safely use `preset-env` and opt-in to running on `node_modules` with new config options like `overrides`.
+And with Babel 7, consumers can more safely use `preset-env` and opt-in to running on `node_modules` with new config options like `overrides`.
 
 ## Let's Do This!
 
-Compiling JavaScript shouldn't be just about the specific ES2015/ES5 distinction, whether it's for our app or our dependencies! Hopefully this is an encouraging call to action re-starting conversations around making compiling dependencies more first-class.
+Compiling JavaScript shouldn't be just about the specific ES2015/ES5 distinction, whether it's for our app or our dependencies! Hopefully this is an encouraging call to action re-starting conversations around using ES2015+ published dependencies more first-class.
 
 This post goes into some of the ways Babel should help with this effort, but we'll need everyone's help to change the ecosystem: more education, more opt-in published packages, and better tooling.
 
@@ -269,8 +276,12 @@ Let's take advantage of ES2015+ not just in our own code, but our dependencies.
 
 ---
 
-If you appreciated this article and the work that we do on Babel, please consider partnering with us and supporting my [Patreon](https://www.patreon.com/henryzhu) and Babel's [Open Collective](https://opencollective.com/babel) to continue to invest in the JavaScript ecosystem that we all use.
+Maybe dependencies will become a first-class citizen for compliation. But have we thought about the future of our dependencies and their sustainability?
 
-> Thanks to the [many](https://twitter.com/left_pad/status/1010280464840617984) folks who offered to review this post including [@chrisdarroch](https://twitter.com/chrisdarroch), [@existentialism](https://twitter.com/existentialism), [@betaorbust](https://twitter.com/betaorbust), [@_developit](https://twitter.com/_developit), [@jdalton](https://twitter.com/jdalton), [@bonsaistudio](https://twitter.com/bonsaistudio).
+In the case of Babel, it's grown to be a fundamental part of the JavaScript ecosystem with the help of some volunteers.
+
+Please consider partnering with us by getting involved and/or supporting my [Patreon](https://www.patreon.com/henryzhu) and Babel's [Open Collective](https://opencollective.com/babel).
+
+> Thanks to the [many](https://twitter.com/left_pad/status/1010280464840617984) folks who offered to review this post including [@chrisdarroch](https://twitter.com/chrisdarroch), [@existentialism](https://twitter.com/existentialism), [@mathias](https://twitter.com/mathias), [@betaorbust](https://twitter.com/betaorbust), [@_developit](https://twitter.com/_developit), [@jdalton](https://twitter.com/jdalton), [@bonsaistudio](https://twitter.com/bonsaistudio).
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
Rendered: https://deploy-preview-1705--babel.netlify.com/blog/2018/06/26/on-consuming-and-publishing-es2015+-packages

Purpose: bring up a discussion on how library authors should publish ES6+ and ESM as well as how this is dealt on the consumer side (whether or not you need to compile deps)

- [x] I will move this to https://github.com/babel/website eventually
- [x] Should I move the headings around (maybe a different order is better)? This could probably be better organized
- [x] Am I missing something?
- [x] Should I split the post up, it's getting long?
- [x] Check if I repeated myself too much in between sections
- [x] Anything better with a visual? (either code, picture, etc)
- [x] Pitch v7 release/post, mention patreon/oc?
- [x] mention creating a standard for publishing (latest syntax, ESM) for lib authors to use, create a way to validate, npm should promote, tooling should use.