### PR TITLE
Add trivago post

### DIFF
--- a/website/blog/2018-07-16-announcing-babels-new-partnership-with-trivago.md
+++ b/website/blog/2018-07-16-announcing-babels-new-partnership-with-trivago.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title:  "Announcing Babel's New Partnership with trivago!"
+author: Henry Zhu
+authorURL: https://twitter.com/left_pad
+date:   2018-07-16 12:00:00
+categories: announcements
+share_text: "Announcing Babel's New Partnership with trivago!"
+---
+
+We are happy to announce a new partnership with [trivago](https://www.trivago.com/), the hotel search website.
+
+<!--truncate-->
+
+They've committed to fund our community with $2,000 per month, for a total of $24,000 per year.
+
+trivago is famous for their TV ads ("Hotel? trivago!") but also recognized for their substantial financial support for the [Webpack](https://webpack.js.org/) community. They have a track record of supporting Open Source communities without interfering with their work so we were very excited when they got in touch to offer their support for Babel.
+
+Just as it is for many projects and companies all over the world, [Babel](https://babeljs.io/) is a key technology for trivago’s applications. It enables high productivity from using the modern JavaScript language while still shipping compatible code for their users running older browsers like IE11. Internally, they utilize around a dozen custom Babel plugins and their own JavaScript framework, [Melody](https://melody.js.org) also heavily relies on Babel to do its magic.
+
+In addition to those immediate benefits, Babel has a very concrete impact on the future of the ECMAScript specification and the shape of the language itself due to its unique place in the ecosystem for implementing proposals in the TC39 process as early as Stage 0.
+
+This new partnership with trivago brings us one step closer toward reaching our goal of having full-time maintainers working on Babel, but we're still not there yet and will continue to try to find additional partners that want to help us reach a sustainable level of funding. We also desire to have the capacity to spend more time on programs like [RGSoC](https://twitter.com/left_pad/status/988019997023920128) and mentoring new contributors/companies to get involved.
+
+If you're working at a company that is using Babel, consider advocating a partnership with us to your supervisor. Webpack recently spoke to [Patrick Gotthardt](https://twitter.com/pgotthardt), our contact at trivago, about [their experience](https://medium.com/webpack/trivago-sponsors-webpack-for-second-year-bfe6ca2f0702) with investing in their community and he shared a lot of good reasons for why they're doing it at such a large scale.
+
+As a community, we need the funding not just to maintain Babel in its current state but to support our efforts in working with TC39, the ECMA committee responsible for defining the future of the JavaScript language and the JavaScript package ecosystem. This includes both attending the bi-monthly meetings and just helping to implement all the new proposals and work towards bringing them to a stable, well-thought out state. This is a community effort that is mostly being done by a couple of volunteers: with the help of the ecosystem of companies that use the tool we can make the future of JavaScript amazing.
+
+We hope that the new partnership with trivago ($24,000) as well as our already existing partnerships with Adobe ($12,000), Facebook ($10,000), the AMP Project ($9,600), Coinbase/Webflow ($5,500) and many other companies will encourage even more [companies who rely on Babel](https://babeljs.io/users) to also form a partnership with our community and to help us reach our [goals](https://opencollective.com/babel) of funding more full time developers not just to support the project itself but the community and language at large.
+
+Please join us in moving JavaScript forward!

--- a/website/blog/2018-07-16-announcing-babels-new-partnership-with-trivago.md
+++ b/website/blog/2018-07-16-announcing-babels-new-partnership-with-trivago.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Announcing Babel's New Partnership with trivago!"
 author: Henry Zhu
 authorURL: https://twitter.com/left_pad
-date:   2018-07-16 12:00:00
+date:   2018-07-16 12:30:00
 categories: announcements
 share_text: "Announcing Babel's New Partnership with trivago!"
 ---
@@ -12,9 +12,9 @@ We are happy to announce a new partnership with [trivago](https://www.trivago.co
 
 <!--truncate-->
 
-They've committed to fund our community with $2,000 per month, for a total of $24,000 per year.
+They've committed to fund our community with $2,000 per month, for a total of $24,000 per year!
 
-trivago is famous for their TV ads ("Hotel? trivago!") but also recognized for their substantial financial support for the [Webpack](https://webpack.js.org/) community. They have a track record of supporting Open Source communities without interfering with their work so we were very excited when they got in touch to offer their support for Babel.
+trivago is famous for their TV ads ("Hotel? trivago!") but also recognized for their substantial financial support for the [Webpack](https://webpack.js.org/) community. They have a [track record of supporting Open Source communities](https://tech.trivago.com/opensource/) without interfering with their work so we were very excited when they got in touch to offer their support for Babel.
 
 Just as it is for many projects and companies all over the world, [Babel](https://babeljs.io/) is a key technology for trivago’s applications. It enables high productivity from using the modern JavaScript language while still shipping compatible code for their users running older browsers like IE11. Internally, they utilize around a dozen custom Babel plugins and their own JavaScript framework, [Melody](https://melody.js.org) also heavily relies on Babel to do its magic.
 


### PR DESCRIPTION
> https://deploy-preview-1727--babel.netlify.com/blog/2018/07/16/announcing-babels-new-partnership-with-trivago