### PR TITLE
Move export-namespace-from to experimental

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -64,7 +64,6 @@ These plugins apply transformations to your code.
 
 - [async-generator-functions](plugin-proposal-async-generator-functions.md)
 - [dotall-regex](plugin-transform-dotall-regex.md)
-- [export-namespace-from](plugin-proposal-export-namespace-from.md)
 - [object-rest-spread](plugin-proposal-object-rest-spread.md)
 - [optional-catch-binding](plugin-proposal-optional-catch-binding.md)
 - [unicode-property-regex](plugin-proposal-unicode-property-regex.md)
@@ -82,6 +81,7 @@ These plugins apply transformations to your code.
 - [decorators](plugin-proposal-decorators.md)
 - [do-expressions](plugin-proposal-do-expressions.md)
 - [export-default-from](plugin-proposal-export-default-from.md)
+- [export-namespace-from](plugin-proposal-export-namespace-from.md)
 - [function-bind](plugin-proposal-function-bind.md)
 - [function-sent](plugin-proposal-function-sent.md)
 - [logical-assignment-operators](plugin-proposal-logical-assignment-operators.md)
@@ -167,7 +167,7 @@ Your `.babelrc`:
 If the plugin is on npm, you can pass in the name of the plugin and babel will check that it's installed in `node_modules`
 
 ```json
-{ 
+{
   "plugins": ["babel-plugin-myPlugin"]
 }
 ```


### PR DESCRIPTION
### Summary

The [es2018 section of the plugins page](https://babeljs.io/docs/en/next/plugins#es2018) currently contains a link to [`babel-plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/next/babel-plugin-proposal-export-namespace-from). Since this is stage one, and doesn't appear to be in the [`babel-preset-env`'s package.json](https://github.com/babel/babel/blob/master/packages/babel-preset-env/package.json), I've moved it under "experimental", alongside `babel-plugin-proposal-export-default-from`.

Apologies if there's anything missing from this PR, and thanks everyone for all your work on babel and its docs!