### PR TITLE
so that preset-env will run on v7

### DIFF
--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -77,9 +77,7 @@ export default function compile(code: string, config: CompileConfig): Return {
       };
     }
 
-    const options = {
-      // not a valid option in v7
-      onPresetBuild: Babel.version[0] === "6" ? onPresetBuild: undefined,
+    const options: { [string]: any } = {
       targets,
       forceAllTransforms,
       shippedProposals,
@@ -87,6 +85,11 @@ export default function compile(code: string, config: CompileConfig): Return {
       spec,
       loose,
     };
+    
+    // not a valid option in v7: preset-env-standalone added extra fields not in preset-env
+    if (Babel.version[0] === "6") {
+      options.onPresetBuild = onPresetBuild;
+    }
 
     config.presets.push(["env", options]);
   }

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -78,7 +78,8 @@ export default function compile(code: string, config: CompileConfig): Return {
     }
 
     const options = {
-      onPresetBuild,
+      // not a valid option in v7
+      onPresetBuild: Babel.version[0] === "6" ? onPresetBuild: undefined,
       targets,
       forceAllTransforms,
       shippedProposals,


### PR DESCRIPTION
Not the best but then it will run. The `onPresetBuild` option seems to be for debug info.

The one in https://github.com/yavorsky/babel-preset-env-standalone/blob/6287394270fdfbc8241f3816748cfffc704a3cc6/src/index.js#L189-L214 added a bunch of extra stuff to v6 that isn't in v7 (the one in the monorepo).