### PR TITLE
Blog: Removing Babel's Stage Presets

### DIFF
--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -78,24 +78,15 @@ Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your reminder that binding with :: is just an experimental proposal at stage 0 and might never become a part of JS. Don&#39;t call it &quot;ES7&quot;.</p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/785082176610115584?ref_src=twsrc%5Etfw">October 9, 2016</a></blockquote>
 
-It's completely understandable that this happens without realizing it, but continuing to do so sets different expectations for how the language progresses. It's nothing to feel guilty about, we learn as a community and [remind](https://twitter.com/dan_abramov/status/785082176610115584) one another of how JavaScript works.
+It's completely understandable that this happens without realizing it, but continuing to do so sets different expectations for how the language progresses. It's nothing to feel guilty about, we learn as a community and remind one another of how JavaScript works.
 
-[Jay Phelps](https://twitter.com/_jayphelps/status/779770321003962369) wrote a nice [article](https://medium.com/@jayphelps/please-stop-referring-to-proposed-javascript-features-as-es7-cad29f9dcc4b) about the subject. He explains it would be best to call them by the "Stage" they are currently at: "Stage 2 Decorators", or just simply the "Decorators Proposal".
+[Jay Phelps](https://twitter.com/_jayphelps/status/779770321003962369) wrote a nice [article](https://medium.com/@jayphelps/please-stop-referring-to-proposed-javascript-features-as-es7-cad29f9dcc4b) about this subject. He explains it would be best to call them by the "Stage" they are currently at: "Stage 2 Decorators", or just simply the "Decorators Proposal".
 
 The reasoning is that saying "ES7 Decorators" assumes that Decorators is expected to be in ES7. I mentioned this in my [last post regarding compiling node_modules](https://babeljs.io/blog/2018/06/26/on-consuming-and-publishing-es2015+-packages#staging-process), but being in a particular Stage doesn't guarantee much: a proposal can stall, move backward, or get removed entirely.
 
 We wanted to highlight this fact when we decided to [change the names](https://babeljs.io/docs/en/next/v7-migration#switch-to-proposal-for-tc39-proposals-blog-2017-12-27-nearing-the-70-releasehtml-renames-proposal) of the proposal plugins from `@babel/plugin-transform-` to `@babel/plugin-proposal-`.
 
 What are we to do here? It does feel like part of our responsibility to make speaking about these proposals clear.
-
-### Semver is Hard for Compilers
-
-TODO: https://twitter.com/sebmck/status/685870041347305472, https://github.com/babel/babel/pull/3225 (rollup, flow, typescript, what about other compilers)
-
-### Ecosystem Maintenance Burden
-
-TODO: We push all other tools in a negative way, burdensome even for us! Can mention all the tooling that needs to be updated along the way and the lack of help. https://twitter.com/mjackson/status/619580016473456641, http://jshint.com/blog/new-lang-features/
-
 
 ### Back and Forth
 
@@ -159,6 +150,10 @@ Also, you are free to make your own preset that contains the same plugins and up
 TODO: Refer to previous [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) about configuring proposal plugins to not have default behaviors if in-flux.
 
 We are trying to better position ourselves in the JavaScript ecosystem: being part of the TC39 process and being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users.
+
+### Ecosystem Maintenance Burden
+
+TODO: We push all other tools in a negative way, burdensome even for us! Can mention all the tooling that needs to be updated along the way and the lack of help. https://twitter.com/mjackson/status/619580016473456641, http://jshint.com/blog/new-lang-features/
 
 ---
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -64,24 +64,24 @@ We probably wouldn't be where we are if not for the wide adoption of compilers s
 
 Babel became a one-time setup for people, never to be thought of again. It became the underlying infrastructure, hidden behind other tools until there was a `SyntaxError`, dependency issues, or integration issues. Simply use `stage-0`.
 
-This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, even in production environments. However, it also meant that many companies, tools, and people would encounter some trouble if a proposal changed in a significant way (or even get dropped altogether).
+This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, even in production environments. However, it also meant that many companies, tools, and people would encounter some trouble if a proposal changed in a significant way (or even got dropped altogether).
 
 ### Back and Forth
 
 Over the years, we've raised many issues to discuss what to do with the Stage presets in [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770). I even wrote in an older post about Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
 
-But we found that keeping the Stage presets would lead to issues even for Babel itself:
+However, we found that keeping the Stage presets would lead to issues even for Babel itself:
 
 - It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It would be unclear for people to know exactly what `stage-0` meant, and few people would look at its `package.json` or source.
 - Removing a proposal plugin in Stage 3 (once it moves to Stage 4) is actually a breaking change. This issue is exacerbated when you are trying to use `@babel/preset-env` to not compile a natively supported proposal.
 
 ### "ES7 Decorators"
 
-Part of the issue is precisely around naming things, and as we hear often, naming things is hard.
+Part of the issue is precisely around naming things, and as we often here, naming things is hard.
 
 There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. When people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
 
-Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say "ES7 Decorators" and find that it's become the accustomed name for it.
+Thereforce, it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say "ES7 Decorators" and find that it's become the accustomed name for it.
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your reminder that binding with :: is just an experimental proposal at stage 0 and might never become a part of JS. Don&#39;t call it &quot;ES7&quot;.</p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/785082176610115584?ref_src=twsrc%5Etfw">October 9, 2016</a></blockquote>
 
@@ -172,7 +172,9 @@ This is something that we'd like to continue to do moving forward as another ind
 
 A language's "syntax budget" doesn't just apply to the complexity of the language itself but can extend down to the tooling. Each new syntax addition brings new [burden](http://jshint.com/blog/new-lang-features/) to the maintainers of other JavaScript projects.
 
-Once new syntax is proposed, many things need updating: parsers (`babylon`), syntax highlighting (`language-babel`), linters (`babel-eslint`), test frameworks (jest/ava), formatters (`prettier`), code coverage (`instanbul`), minifiers (`babel-minify`), and more.  There have been many issues brought up on projects like `acorn`, `eslint`, `jshint`, `typescript`, and others to support Stage 0 proposals because they were in Babel. There aren't many projects that would adhere to a policy that required them to support any proposal since that would be extremely demanding to maintain. In many ways, it's surprising we even attempt to handle it in Babel itself given the constant updates and churn.
+Once new syntax is proposed, many things need updating: parsers (`babylon`), syntax highlighting (`language-babel`), linters (`babel-eslint`), test frameworks (jest/ava), formatters (`prettier`), code coverage (`instanbul`), minifiers (`babel-minify`), and more.
+
+There have been many issues brought up on projects like `acorn`, `eslint`, `jshint`, `typescript`, and others to support Stage 0 proposals because they were in Babel. There aren't many projects that would adhere to a policy that required them to support any proposal since that would be extremely demanding to maintain. In many ways, it's surprising we even attempt to handle it in Babel itself given the constant updates and churn.
 
 Who is doing that work, and is it our responsibility to make sure everything works? Every one of those projects (mostly volunteers) is lacking in help in almost every aspect, and yet we continually get complaints about this across the board. How are we, as a community, to take responsibility for dealing with our infrastructure (not dissimilar to open source as a whole)?
 
@@ -184,7 +186,7 @@ The purpose of this project is to act as a part of the TC39 process: being a res
 
 ---
 
-If you appreciate this post and the work we're doing on Babel, you can support me on [Patreon](https://www.patreon.com/henryzhu), ask your company to sponsor us on [Open Collective](https://opencollective.com/babel), or better yet get involved with Babel as part of your job/work. We'd appreciate the collective ownership.
+If you appreciate this post and the work we're doing on Babel, you can support me on [Patreon](https://www.patreon.com/henryzhu), ask your company to sponsor us on [Open Collective](https://opencollective.com/babel), or better yet get your company involved with Babel as part of your work. We'd appreciate the collective ownership.
 
 With thanks to all the [reviewers](https://github.com/babel/website/pull/1735)!
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -74,7 +74,7 @@ Part of issue is precisely around naming things, and as we hear a lot, naming th
 
 There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. When people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
 
-Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say something like "ES7 Decorators" and find it become the established name for it.
+Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say something like "ES7 Decorators" and find that it's become the established name for it.
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your reminder that binding with :: is just an experimental proposal at stage 0 and might never become a part of JS. Don&#39;t call it &quot;ES7&quot;.</p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/785082176610115584?ref_src=twsrc%5Etfw">October 9, 2016</a></blockquote>
 
@@ -99,49 +99,48 @@ TODO: We push all other tools in a negative way, burdensome even for us! Can men
 
 ### Back and Forth
 
-We've had many issues to talk about what to do with the Stage presets over the years: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770)
+Over the years, we've had many issues raised in our repo about what to do with the Stage presets: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770)
 
-I even wrote an older post about the release of 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
+I even wrote in an older post about the release of 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
 
-Having the Stage presets in place lead to some issues for Babel itself:
+Ultimately, we decided that keeping the Stage presets would lead to some issues for Babel itself:
 
-- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to be able to know what exactly "stage-0" meant, and few people would look at the `package.json` or source.
-- Removing a plugin in Stage 3 is actually a breaking change. This issue is exacerbated when you are trying to use preset-env to not compile a natively supported proposal.
+- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to know exactly what "stage-0" meant, and few people would look at its `package.json` or source.
+- Removing a plugin in Stage 3 is actually a breaking change. This issue is exacerbated when you are trying to use `@babel/preset-env` to not compile a natively supported proposal.
 
 ### BabelScript
 
-[TC39](https://tc39.github.io/process-document/) strongly recommends caution with anyone using Stage 2 proposals or below and may feel pressure from the community to keep the implementation as is instead of making better or necessary changes for fear of breaking existing code or fragmentation (ex: using a different symbol like `#` for decorators instead of `@`). 
+[TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertant pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (ex: using a different symbol like `#` for decorators instead of `@`). 
 
-People joke that developers that use Babel are using "BabelScript" instead of JavaScript, that somehow once a Babel plugin is made for it, it must be "fixed" or in the language already (not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) they ask whether there's a Babel plugin for it already.
+People joke that developers that use Babel are using "BabelScript" instead of JavaScript, that somehow once a Babel plugin is made for it, it must be "fixed" or in the language already (not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) they immediately ask whether there's a Babel plugin for it.
 
 Having presets for proposals so early in the process may imply to people that these proposals are guaranteed to move forward or have a stable implementation.
 
 ### Setting Expectations
 
-But after it became normal for people to write in ES6 thanks to compilers, it was natural for developers to want to try out even newer "features". The way this worked in Babel was to use the `stage` flag in previous versions or the `stage-x` presets.
+After compilers like Babel made it normal for people to write ES2015, it was natural for developers to want to try out even newer and more experimental "features". The way this worked in Babel was to use the `stage` flag in previous versions or the `stage-x` presets.
 
-Being the most convenient way of opting into any new feature, it quickly became the default for people when configuring Babel (even though in Babel v6 it moved to not doing anything by default which there was a lot of complaints about).
+Being the most convenient way of opting into any new feature, it quickly became the default for people when configuring Babel (even though in Babel v6 it moved to not doing anything by default, which caused lots of complaints).
 
-It became common to see `"stage-0"` show up in libraries, boilerplates, talks, tweets, and slides.
+It became common to see `"stage-0"` being used in libraries, boilerplates, talks, tweets, and slides.
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">&quot;Just say no&quot; to `babel?stage=0` in production.</p>&mdash; Ryan Florence (@ryanflorence) <a href="https://twitter.com/ryanflorence/status/627154904302288897?ref_src=twsrc%5Etfw">July 31, 2015</a></blockquote>
 
-There was a lot of good discussion even years ago, 
-but it wasn't the easiest thing to navigate: we wouldn't want to penalize users that understood the tradeoffs by putting `console.warn`'s when using it, and not having the option at all seemed unreasonable at the time. 
+There was a lot of good discussion even years ago, but it wasn't the easiest thing to navigate: we wouldn't want to penalize users that understood the tradeoffs by putting `console.warn`'s when using it, and not having the option at all seemed unreasonable at the time.
 
-Blindly opting in to Stage 0 (whether we had it by default) or people choosing to do so seems dangerous, but also never using any proposals maybe overly cautious and doesn't work with the strengths of using Babel. Ideally everyone is able to make an informed decision on the kinds of features that seem reasonable to them and use them wisely, whether they are at Stage 0 or not. [Mike Pennisi](https://twitter.com/jugglinmike) wrote a great [post](https://bocoup.com/blog/javascript-developers-watch-your-language) about these concerns.
+Blindly opting into Stage 0 (whether we had it by default) or people choosing to do so seems dangerous, but also never using any proposals is overly cautious. Ideally, everyone should able to make an informed decision about the kinds of features that seem reasonable to them and use them wisely, regardless of what stage they are in. [Mike Pennisi](https://twitter.com/jugglinmike) wrote a great [post](https://bocoup.com/blog/javascript-developers-watch-your-language) about these concerns.
 
-It isn't our intention to threaten, rush, or force specific things into the ecosystem or JavaScript but faithfully maintain the implementation/discussions around new ideas so that they have been tested.
+It isn't our intention to threaten, rush, or force specific things into the ecosystem or JavaScript but to faithfully maintain the implementation/discussions around new ideas.
 
 ## Hesitations
 
-Why not remove it earlier? Stage presets have been part of Babel for years and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. And it seemed better to have officially maintained presets.
+Why not remove it earlier? Stage presets have been part of Babel for years and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. We also thought it was better to have officially maintained presets, since someone would (and will) inevitably create them.
 
-We're trying to determine the right level of feedback: if it's only the committee that decides what goes in the language it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or alright to use in production without consequence then we have another issue. We all want to move forward and to proceed with intention: not rushing but not being too cautious. Babel can be the right place to do that experimentation but knowing where the boundaries are is necessary.
+We're trying to determine the right level of feedback: if it's only the committee that decides what goes into the language,  it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or ok to use in production without consequence, then we have other issues. We all want to move forward and proceed with intention: not rushing, but not being too cautious. Babel is the right place to do that experimentation but knowing where the boundaries are is necessary.
 
-In the end, it actually makes more sense to remove the presets because it means that users have to explicitly opt-in to using new proposals. This would be considered a "feature" since it means someone would have to make the decision to use each proposal, which is reasonable for any proposal since they all have varying levels of instability, usefulness, complexity.
+In the end, it actually makes more sense to remove the presets because it means that users have to explicitly opt-in to using new proposals. This would be considered a "feature" since it means someone would have to make an explicit decision to use each proposal, which is reasonable for any proposal since they all have varying levels of instability, usefulness, and complexity.
 
-We do have some expectation of initial backlash but it does feel like removing the Stage presets is a better decision for us all in the long run.
+We fully expect some initial backlash from this, but ultimately feel like removing the Stage presets is a better decision for us all in the long run.
 
 TODO: mention stuff like https://news.ycombinator.com/item?id=11371906, https://www.reddit.com/r/javascript/comments/4c8isx/babel_6_useless_by_default_a_lesson_in_how_not_to/
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -159,8 +159,6 @@ We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want
 
 As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to accomplish it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
-## The Future
-
 ### Proposal Implementations in Babel
 
 [James DiGioia](https://twitter.com/JamesDiGioia) wrote a [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) recently about the changes to using the pipeline operator (`|>`).
@@ -178,12 +176,18 @@ Before we would simply add the proposal plugin to the config and that was it. No
 }
 ```
 
+This is something that we'd like to continue to do moving forward as another indication that these proposals are open to change and feedback from all of us. The removal of the Stage presets makes this even easier as before we had to pass down these options even if you didn't use the syntax.
+
 ### Ecosystem Maintenance Burden
 
-TODO: Each new syntax provides affordances to the language, but it brings new burdens for all of our tooling. Can mention all the tooling that needs to be updated along the way and the lack of help. https://twitter.com/mjackson/status/619580016473456641, http://jshint.com/blog/new-lang-features/
+A language's "syntax budget" doesn't just apply to the complexity of the language itslef but can extend down to the tooling. Each new syntax can brings [new burdens](http://jshint.com/blog/new-lang-features/) for the maintainers of other JavaScript projects.
 
-### Purpose
+Once a new syntax is "added" many things need updating: parsers (`babylon`), syntax highlighting (`language-babel`), linters (`babel-eslint`), test frameworks (jest/ava), formatters (`prettier`), code coverage (`instanbul`), minifiers (`babel-minify`), and more.  There have been many issues brought up on projects like `acorn`, `eslint`, `jshint`, `typescript`, and others to support Stage 0 proposals because they were in Babel. There aren't many projects that would adhere to a policy that required them to support any proposal since that would be extremely demanding to maintain. In many ways, it's surprising we even attempt to handle it in Babel itself given the constant updates and churn.
 
-TODO: We are trying to better position ourselves in the JavaScript ecosystem: being part of the TC39 process and being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users.
+Who is doing that work, and is it our responsibility to make sure everything works? Every one of those projects (mostly volunteers) is lacking in help in almost every aspect, and yet we continouly get complaints about this across the board. How are we to as a community take responsibility for dealing with these changes (same with open source as a whole)?
+
+### The Future
+
+The purpose of this project is to act as a part of the TC39 process: being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users while also supporting older versions of JavaScript. We hope this post sheds more light on how we are trying as best we can to better align this project in the JavaScript ecosystem.
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -155,7 +155,7 @@ We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want
 
 As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please. In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to list and add the current Stage plugins? Or maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
-### Proposal Lock In
+### Preventing Proposal Lock In
 
 [James DiGioia](https://twitter.com/JamesDiGioia) wrote a [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) recently about the changes to using the pipeline operator (`|>`).
 
@@ -185,5 +185,11 @@ Who is doing that work, and is it our responsibility to make sure everything wor
 ### The Future
 
 The purpose of this project is to act as a part of the TC39 process: being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users while also supporting older versions of JavaScript. We hope this post sheds more light on how we are trying, as best we can, to better align this project in the JavaScript ecosystem.
+
+---
+
+If you appreciate this post and the work we're doing on Babel, you can support me on [Patreon](https://www.patreon.com/henryzhu), ask your company to sponsor us on [Open Collective](https://opencollective.com/babel), or better yet get involved with Babel as part of your job/work. We'd appreciate the collective ownership.
+
+With thanks to all the reviewers (too many to list)!
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -70,7 +70,7 @@ This was awesome to see in some ways, as it meant that these ideas were being te
 
 ### "ES7 Decorators"
 
-Part of issue is precisely around naming things, and as we hear often, naming things is hard.
+Part of the issue is precisely around naming things, and as we hear often, naming things is hard.
 
 There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. When people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
 
@@ -153,7 +153,7 @@ But removing previous defaults or removing the Stage presets doesn't mean we don
 
 > For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
 
-The TL;DR is that we're removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. But if you use your another preset or a toolchain (e.g. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
+The TL;DR is that we're removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. But if you use another preset or a toolchain (e.g. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
 
 We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with a message saying how to migrate.
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -20,7 +20,7 @@ A Babel preset is a shareable list of plugins.
 
 The [official Babel Stage presets](https://babeljs.io/docs/en/next/presets) tracked the [TC39 Staging process](https://tc39.github.io/process-document/) for new [syntax proposals](https://github.com/tc39/proposals) in JavaScript.
 
-Each preset (ex. stage-3, stage-2, etc.) included all the plugins for that particular stage and the ones above it (ex. stage-2 included stage-3, etc).
+Each preset (ex. `stage-3`, `stage-2`, etc.) included all the plugins for that particular stage and the ones above it. For example, `stage-2` included `stage-3`, and so on.
 
 ---
 
@@ -30,7 +30,7 @@ We actually [added](https://github.com/babel/babel/pull/2649) the Stage presets 
 
 These are some older examples from Babel v6.
 
-Common to see this in a config: 
+It’s common to see this in a config: 
 
 ```js
 {
@@ -60,7 +60,7 @@ Looking back, it worked really well! (Maybe too well?)
 
 ### Too Good a Job?
 
-Languages like [CoffeeScript](https://coffeescript.org/) and tooling like [Traceur](https://github.com/google/traceur-compiler) helped establish the idea that compiling JavaScript wasn't crazy. Babel made it even easier to both use new/future syntax and integrate with existing tooling. The expectations changed from skepticism and worry to completely embracing the experimental.
+Languages like [CoffeeScript](https://coffeescript.org/) and tooling like [Traceur](https://github.com/google/traceur-compiler) helped establish the idea of compiling JavaScript. Babel made it even easier to both use new/future syntax and integrate with existing tooling. The expectations changed from skepticism and worry to completely embracing the experimental.
 
 We probably wouldn't be where we are at if not for the wide adoption of compilers such as Babel: it accelerated the usage (and teaching) of ES2015 to a much larger audience. The growth of React further fueled usage as its JSX syntax, class properties, and object rest/spread led to people knowing a bit more about these syntax proposals.
 
@@ -70,7 +70,7 @@ This was awesome to see in some ways, as it meant that these ideas were being te
 
 ### "ES7 Decorators"
 
-Part of issue is precisely around naming things, and as we hear a lot, naming things is hard.
+Part of issue is precisely around naming things, and as we hear often, naming things is hard.
 
 There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. When people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
 
@@ -78,7 +78,7 @@ Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your reminder that binding with :: is just an experimental proposal at stage 0 and might never become a part of JS. Don&#39;t call it &quot;ES7&quot;.</p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/785082176610115584?ref_src=twsrc%5Etfw">October 9, 2016</a></blockquote>
 
-It's completely understandable that this happens without realizing it, but continuing to do so sets different expectations for how the language progresses. It's nothing to feel guilty about, we learn as a community and remind one another of how JavaScript works.
+It's completely understandable that this happens without realizing it, but continuing to do so sets different expectations for how the language progresses. It's nothing to feel guilty about — we learn as a community and remind one another of how JavaScript works.
 
 [Jay Phelps](https://twitter.com/_jayphelps/status/779770321003962369) wrote a nice [article](https://medium.com/@jayphelps/please-stop-referring-to-proposed-javascript-features-as-es7-cad29f9dcc4b) about this subject. He explains it would be best to call them by the "Stage" they are currently at: "Stage 2 Decorators", or just simply the "Decorators Proposal".
 
@@ -92,24 +92,24 @@ What are we to do here? It does feel like part of our responsibility to make spe
 
 Over the years, we've had many issues raised in our repo about what to do with the Stage presets: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770)
 
-I even wrote in an older post about the release of 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
+I even wrote in an older post about the release of Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
 
 Ultimately, we decided that keeping the Stage presets would lead to some issues for Babel itself:
 
-- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to know exactly what "stage-0" meant, and few people would look at its `package.json` or source.
+- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to know exactly what `stage-0` meant, and few people would look at its `package.json` or source.
 - Removing a plugin in Stage 3 is actually a breaking change. This issue is exacerbated when you are trying to use `@babel/preset-env` to not compile a natively supported proposal.
 
 ### BabelScript
 
-[TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertant pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (ex: using a different symbol like `#` for decorators instead of `@`). 
+[TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertant pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (for example, using a different symbol like `#` for decorators instead of `@`). 
 
-People joke that developers that use Babel are using "BabelScript" instead of JavaScript, that somehow once a Babel plugin is made for it, it must be "fixed" or in the language already (not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) they immediately ask whether there's a Babel plugin for it.
+People joke that developers that use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) is whether there's a Babel plugin for it.
 
 Having presets for proposals so early in the process may imply to people that these proposals are guaranteed to move forward or have a stable implementation.
 
 ### Setting Expectations
 
-After compilers like Babel made it normal for people to write ES2015, it was natural for developers to want to try out even newer and more experimental "features". The way this worked in Babel was to use the `stage` flag in previous versions or the `stage-x` presets.
+After compilers like Babel made it common practice for people to write ES2015, it was natural for developers to want to try out even newer and more experimental "features". The way this worked in Babel was to use the `stage` flag in previous versions or the `stage-x` presets.
 
 Being the most convenient way of opting into any new feature, it quickly became the default for people when configuring Babel (even though in Babel v6 it moved to not doing anything by default, which caused lots of complaints).
 
@@ -117,9 +117,9 @@ It became common to see `"stage-0"` being used in libraries, boilerplates, talks
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">&quot;Just say no&quot; to `babel?stage=0` in production.</p>&mdash; Ryan Florence (@ryanflorence) <a href="https://twitter.com/ryanflorence/status/627154904302288897?ref_src=twsrc%5Etfw">July 31, 2015</a></blockquote>
 
-There was a lot of good discussion even years ago, but it wasn't the easiest thing to navigate: we wouldn't want to penalize users that understood the tradeoffs by putting `console.warn`'s when using it, and not having the option at all seemed unreasonable at the time.
+There was a lot of good discussion even years ago, but it wasn't the easiest thing to navigate: we wouldn't want to penalize users that understood the tradeoffs by putting `console.warn`s when using it, and not having the option at all seemed unreasonable at the time.
 
-Blindly opting into Stage 0 (whether we had it by default) or people choosing to do so seems dangerous, but also never using any proposals is overly cautious. Ideally, everyone should able to make an informed decision about the kinds of features that seem reasonable to them and use them wisely, regardless of what stage they are in. [Mike Pennisi](https://twitter.com/jugglinmike) wrote a great [post](https://bocoup.com/blog/javascript-developers-watch-your-language) about these concerns.
+Blindly opting into Stage 0 (whether we had it by default) or people choosing to do so seems dangerous, but also never using any proposals is overly cautious. Ideally, everyone should able to make an informed decision about the kinds of features that seem reasonable to them and use them wisely, regardless of what stage they are in. [Mike Pennisi](https://twitter.com/jugglinmike) wrote [a great post](https://bocoup.com/blog/javascript-developers-watch-your-language) about these concerns.
 
 It isn't our intention to threaten, rush, or force specific things into the ecosystem or JavaScript but to faithfully maintain the implementation/discussions around new ideas.
 
@@ -145,7 +145,7 @@ In the end, it actually makes more sense to remove the presets because it means 
 
 We fully expect some initial backlash from this, but ultimately feel like removing the Stage presets is a better decision for us all in the long run.
 
-And this project is no stranger to community uproar 🙂, as Babel 6 was a "controverisal" release for many. There were plently of posts right after and even [recently](https://news.ycombinator.com/item?id=11371906) that speak about how difficult it was to use.
+And this project is no stranger to community uproar 🙂, as Babel 6 was a "controversial" release for many. There were plently of posts right after and even [recently](https://news.ycombinator.com/item?id=11371906) that speak about how difficult it was to use.
 
 But removing previous defaults or removing the Stage presets doesn't mean we don't care about ease of use, new users, or documentation. We try with what we can to keep the project stable, document what we know, and provide tooling to make things better.
 
@@ -155,9 +155,9 @@ But removing previous defaults or removing the Stage presets doesn't mean we don
 
 The TL;DR is that we removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. But if you use your another preset or a toolchain (i.e. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
 
-We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with how to migrate.
+We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with a message saying how to migrate.
 
-As as alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you setup plugins interactively or update `babel-upgrade` itself to accomplsih it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
+As as alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you setup plugins interactively or update `babel-upgrade` itself to accomplish it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
 ## The Future
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -26,11 +26,9 @@ Each preset (ex. `stage-3`, `stage-2`, etc.) included all the plugins for that p
 
 This allowed users who wanted to use experimental syntax to simply add the preset, instead of needing to configure/install each individual plugin.
 
-We actually [added](https://github.com/babel/babel/pull/2649) the Stage presets shortly after Babel's v6 release (it was previously a config flag in v5).
+We actually [added](https://github.com/babel/babel/pull/2649) the Stage presets shortly after Babel's v6 release (it was previously a config flag in v5). Shown below is an older example from Babel v6.
 
-These are some older examples from Babel v6.
-
-It’s common to see this in a config: 
+It was common to see this in a config: 
 
 ```js
 {
@@ -70,14 +68,12 @@ This was awesome to see in some ways, as it meant that these ideas were being te
 
 ### Back and Forth
 
-Over the years, we've had many issues raised in our repo about what to do with the Stage presets: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770)
+Over the years, we've raised many issues to discuss what to do with the Stage presets: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770). I even wrote in an older post about Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
 
-I even wrote in an older post about the release of Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
+But we found that keeping the Stage presets would lead to issues even for Babel itself:
 
-Ultimately, we decided that keeping the Stage presets would lead to some issues for Babel itself:
-
-- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to know exactly what `stage-0` meant, and few people would look at its `package.json` or source.
-- Removing a plugin in Stage 3 is actually a breaking change. This issue is exacerbated when you are trying to use `@babel/preset-env` to not compile a natively supported proposal.
+- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It would be unclear for people to know exactly what `stage-0` meant, and few people would look at its `package.json` or source.
+- Removing a proposal plugin in Stage 3 (once it moves to Stage 4) is actually a breaking change. This issue is exacerbated when you are trying to use `@babel/preset-env` to not compile a natively supported proposal.
 
 ### "ES7 Decorators"
 
@@ -85,7 +81,7 @@ Part of the issue is precisely around naming things, and as we hear often, namin
 
 There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. When people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
 
-Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say something like "ES7 Decorators" and find that it's become the established name for it.
+Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say "ES7 Decorators" and find that it's become the accustomed name for it.
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your reminder that binding with :: is just an experimental proposal at stage 0 and might never become a part of JS. Don&#39;t call it &quot;ES7&quot;.</p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/785082176610115584?ref_src=twsrc%5Etfw">October 9, 2016</a></blockquote>
 
@@ -99,11 +95,11 @@ We wanted to highlight this fact when we decided to [change the names](https://b
 
 ### BabelScript
 
-[TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertent pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (for example, using a different symbol like `#` for decorators instead of `@`). 
-
-People joke that developers who use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first question that people think of when they see a new syntax or idea (Stage "-1") is whether there's a Babel plugin for it.
-
 Having presets for proposals so early in the process may imply to people that these proposals are guaranteed to move forward or have a stable implementation.
+
+[TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertent pressure from the community to keep the implementation as-is instead of improving it for fear of breaking existing code or ecosystem fragmentation (e.g. using a different symbol like `#` instead of `@` for decorators). 
+
+People joke that developers who use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first thought for people when they see a new syntax/idea (Stage "-1") is whether there a Babel plugin for it.
 
 ### Setting Expectations
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -36,7 +36,7 @@ It was common to see this in a config:
 }
 ```
 
-Original source of the package: [babel-preset-stage-0](https://unpkg.com/babel-preset-stage-0@6.0.14/index.js)
+The original source of [babel-preset-stage-0](https://unpkg.com/babel-preset-stage-0@6.0.14/index.js):
 
 ```js
 module.exports = {
@@ -62,13 +62,13 @@ Languages like [CoffeeScript](https://coffeescript.org/) and tooling like [Trace
 
 We probably wouldn't be where we are if not for the wide adoption of compilers such as Babel: it accelerated the usage (and teaching) of ES2015 to a much larger audience. The growth of React further fueled usage as its JSX syntax, class properties, and object rest/spread led to people knowing a bit more about these syntax proposals.
 
-Babel became a one-time setup for people, never to be thought of again. It became underlying infrastructure, hidden behind other tooling until there was a `SyntaxError`, dependency issues, or integration issues. Simply use `stage-0`.
+Babel became a one-time setup for people, never to be thought of again. It became the underlying infrastructure, hidden behind other tools until there was a `SyntaxError`, dependency issues, or integration issues. Simply use `stage-0`.
 
 This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, even in production environments. However, it also meant that many companies, tools, and people would encounter some trouble if a proposal changed in a significant way (or even get dropped altogether).
 
 ### Back and Forth
 
-Over the years, we've raised many issues to discuss what to do with the Stage presets: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770). I even wrote in an older post about Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
+Over the years, we've raised many issues to discuss what to do with the Stage presets in [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770). I even wrote in an older post about Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
 
 But we found that keeping the Stage presets would lead to issues even for Babel itself:
 
@@ -111,7 +111,7 @@ It became common to see `"stage-0"` being used in libraries, boilerplates, talks
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">&quot;Just say no&quot; to `babel?stage=0` in production.</p>&mdash; Ryan Florence (@ryanflorence) <a href="https://twitter.com/ryanflorence/status/627154904302288897?ref_src=twsrc%5Etfw">July 31, 2015</a></blockquote>
 
-There was a lot of good discussion even years ago, but it wasn't the easiest thing to navigate: we wouldn't want to penalize users who understood the tradeoffs by putting `console.warn`s when using it, and not having the option at all seemed unreasonable at the time.
+There was a lot of good discussions even years ago, but it wasn't the easiest thing to navigate: we wouldn't want to penalize users who understood the tradeoffs by putting `console.warn`s when using it, and not having the option at all seemed unreasonable at the time.
 
 Blindly opting into Stage 0 (whether we had it by default) or people choosing to do so seems dangerous, but also never using any proposals is overly cautious. Ideally, everyone should able to make an informed decision about the kinds of features that seem reasonable to them and use them wisely, regardless of what stage they are in. [Mike Pennisi](https://twitter.com/jugglinmike) wrote [a great post](https://bocoup.com/blog/javascript-developers-watch-your-language) about these concerns.
 
@@ -131,7 +131,7 @@ In the end, people would still have to look up what proposals are at what Stage 
 
 ### Why Now?
 
-Why not remove it earlier? Stage presets have been part of Babel for years, and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. We also thought it was better to have officially maintained presets, since someone would (and will) inevitably create them.
+Why not remove it earlier? Stage presets have been part of Babel for years, and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. Earlier, we thought it was better to officially maintain the presets since someone else would (and will) inevitably create them.
 
 We're trying to determine the right level of feedback: if it's only the committee that decides what goes into the language,  it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or ok to use in production without consequence, then we'll have other issues. We all want to move forward and proceed with intention: not rushing, but not being too cautious. Babel is the right place to do that experimentation but knowing where the boundaries are is necessary.
 
@@ -149,13 +149,13 @@ We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want
 
 As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please. In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to list and add the current Stage plugins? Or maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
-### Preventing Proposal Lock In
+### Preventing Proposal Lock-In
 
 [James DiGioia](https://twitter.com/JamesDiGioia) wrote a [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) recently about the changes to using the pipeline operator (`|>`).
 
-The main point there is that the proposal itself is in flux and has a few options to explore. Because we'd like to implement all three of the current possibilities as Babel plugins for both spec feedback and user feedback, we believed the way the plugin is used should change as well. This a relatively new approach for TC39 and Babel!
+The main point in the post is that the proposal itself is in flux and has a few options to explore. Because we'd like to implement all three of the current possibilities as Babel plugins for both spec feedback and user feedback, we believed the way the plugin is used should change as well. This a relatively new approach for TC39 and Babel!
 
-Before, we would add the proposal plugin to the config and that was it. Now, we remove the default behavior and ask users to opt in to a flag that shows which proposal is chosen, and make it clear that there isn't a fixed (or even favored) option at the moment.
+Previously, we would add the proposal plugin to the config and that was it. Now, we remove the default behavior and ask users to opt into a flag that shows which proposal is chosen, and make it clear that there isn't a fixed (or even favored) option at the moment.
 
 ```diff
 {

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -10,7 +10,7 @@ share_text: "Removing Babel's Stage Presets"
 
 Moving forward with v7, we've decided it's best to stop publishing the Stage presets in Babel (e.g. `@babel/preset-stage-0`).
 
-We didn't make this decision lightly and wanted bring show some context regarding TC39, new proposals, and Babel.
+We didn't make this decision lightly and wanted to show the context behind the interplay between TC39, Babel, and the community.
 
 <!--truncate-->
 
@@ -62,7 +62,7 @@ Looking back, it worked really well! (Maybe too well?)
 
 Languages like [CoffeeScript](https://coffeescript.org/) and tooling like [Traceur](https://github.com/google/traceur-compiler) helped establish the idea of compiling JavaScript. Babel made it even easier to both use new/future syntax and integrate with existing tooling. The expectations changed from skepticism and worry to completely embracing the experimental.
 
-We probably wouldn't be where we are at if not for the wide adoption of compilers such as Babel: it accelerated the usage (and teaching) of ES2015 to a much larger audience. The growth of React further fueled usage as its JSX syntax, class properties, and object rest/spread led to people knowing a bit more about these syntax proposals.
+We probably wouldn't be where we are if not for the wide adoption of compilers such as Babel: it accelerated the usage (and teaching) of ES2015 to a much larger audience. The growth of React further fueled usage as its JSX syntax, class properties, and object rest/spread led to people knowing a bit more about these syntax proposals.
 
 Babel became a one-time setup for people, never to be thought of again. It became underlying infrastructure, hidden behind other tooling until there was a `SyntaxError`, dependency issues, or integration issues. Simply use `stage-0`.
 
@@ -103,7 +103,7 @@ Ultimately, we decided that keeping the Stage presets would lead to some issues 
 
 [TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertant pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (for example, using a different symbol like `#` for decorators instead of `@`). 
 
-People joke that developers that use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) is whether there's a Babel plugin for it.
+People joke that developers who use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) is whether there's a Babel plugin for it.
 
 Having presets for proposals so early in the process may imply to people that these proposals are guaranteed to move forward or have a stable implementation.
 
@@ -117,7 +117,7 @@ It became common to see `"stage-0"` being used in libraries, boilerplates, talks
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">&quot;Just say no&quot; to `babel?stage=0` in production.</p>&mdash; Ryan Florence (@ryanflorence) <a href="https://twitter.com/ryanflorence/status/627154904302288897?ref_src=twsrc%5Etfw">July 31, 2015</a></blockquote>
 
-There was a lot of good discussion even years ago, but it wasn't the easiest thing to navigate: we wouldn't want to penalize users that understood the tradeoffs by putting `console.warn`s when using it, and not having the option at all seemed unreasonable at the time.
+There was a lot of good discussion even years ago, but it wasn't the easiest thing to navigate: we wouldn't want to penalize users who understood the tradeoffs by putting `console.warn`s when using it, and not having the option at all seemed unreasonable at the time.
 
 Blindly opting into Stage 0 (whether we had it by default) or people choosing to do so seems dangerous, but also never using any proposals is overly cautious. Ideally, everyone should able to make an informed decision about the kinds of features that seem reasonable to them and use them wisely, regardless of what stage they are in. [Mike Pennisi](https://twitter.com/jugglinmike) wrote [a great post](https://bocoup.com/blog/javascript-developers-watch-your-language) about these concerns.
 
@@ -127,19 +127,19 @@ It isn't our intention to threaten, rush, or force specific things into the ecos
 
 ### Other Considerations
 
-We also could of tried to:
+We also could have tried to:
 
 - [Rename the presets](https://github.com/babel/babel/issues/4914) to better signify the stability level (doesn't solve the versioning problem)
 - Better versioning strategies: independently version the presets and update them immediately when needed, maybe use `0.x`
-- Warn/Error for old out of date versions of presets.
+- Warn/Error for old out-of-date versions of presets
 
 The the end, people would still have to look up what proposals are at what Stage to know which ones to use if we kept the Stages in.
 
 ### Why Now?
 
-Why not remove it earlier? Stage presets have been part of Babel for years and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. We also thought it was better to have officially maintained presets, since someone would (and will) inevitably create them.
+Why not remove it earlier? Stage presets have been part of Babel for years, and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. We also thought it was better to have officially maintained presets, since someone would (and will) inevitably create them.
 
-We're trying to determine the right level of feedback: if it's only the committee that decides what goes into the language,  it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or ok to use in production without consequence, then we have other issues. We all want to move forward and proceed with intention: not rushing, but not being too cautious. Babel is the right place to do that experimentation but knowing where the boundaries are is necessary.
+We're trying to determine the right level of feedback: if it's only the committee that decides what goes into the language,  it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or ok to use in production without consequence, then we'll have other issues. We all want to move forward and proceed with intention: not rushing, but not being too cautious. Babel is the right place to do that experimentation but knowing where the boundaries are is necessary.
 
 In the end, it actually makes more sense to remove the presets because it means that users have to explicitly opt-in to using new proposals. This would be considered a "feature" since it means someone would have to make an explicit decision to use each proposal, which is reasonable for any proposal since they all have varying levels of instability, usefulness, and complexity.
 
@@ -153,21 +153,21 @@ But removing previous defaults or removing the Stage presets doesn't mean we don
 
 > For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
 
-The TL;DR is that we removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. But if you use your another preset or a toolchain (i.e. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
+The TL;DR is that we're removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. But if you use your another preset or a toolchain (e.g. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
 
 We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with a message saying how to migrate.
 
-As as alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you setup plugins interactively or update `babel-upgrade` itself to accomplish it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
+As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to accomplish it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
 ## The Future
 
 ### Proposal Implementations in Babel
 
-[Josh Justice](https://twitter.com/CodingItWrong) wrote a [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) recently about the changes to using the pipeline operator (`|>`).
+[James DiGioia](https://twitter.com/JamesDiGioia) wrote a [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) recently about the changes to using the pipeline operator (`|>`).
 
-The main point there is that the proposal itself is in flux and has a few options to explore. Because we'd like to implement all three of the current possibilities as Babel plugins for both spec feedback and user feedback, we believed the way the plugin is used should change as well.
+The main point there is that the proposal itself is in flux and has a few options to explore. Because we'd like to implement all three of the current possibilities as Babel plugins for both spec feedback and user feedback, we believed the way the plugin is used should change as well. This a relatively new approach for 
 
-Before we would simply add the proposal plugin to the config and that was it. Now we would remove the default behavior and ask users to opt-in to a flag that shows which proposal is chosen, and makes it clear that there isn't a fixed or even favored option at the moment.
+Before we would simply add the proposal plugin to the config and that was it. Now we would remove the default behavior and ask users to opt in to a flag that shows which proposal is chosen, and makes it clear that there isn't a fixed or even favored option at the moment.
 
 ```diff
 {

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -125,6 +125,18 @@ It isn't our intention to threaten, rush, or force specific things into the ecos
 
 ## Hesitations
 
+### Other Considerations
+
+We also could of tried to:
+
+- [Rename the presets](https://github.com/babel/babel/issues/4914) to better signify the stability level (doesn't solve the versioning problem)
+- Better versioning strategies: independently version the presets and update them immediately when needed, maybe use `0.x`
+- Warn/Error for old out of date versions of presets.
+
+The the end, people would still have to look up what proposals are at what Stage to know which ones to use if we kept the Stages in.
+
+### Why Now?
+
 Why not remove it earlier? Stage presets have been part of Babel for years and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. We also thought it was better to have officially maintained presets, since someone would (and will) inevitably create them.
 
 We're trying to determine the right level of feedback: if it's only the committee that decides what goes into the language,  it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or ok to use in production without consequence, then we have other issues. We all want to move forward and proceed with intention: not rushing, but not being too cautious. Babel is the right place to do that experimentation but knowing where the boundaries are is necessary.
@@ -133,7 +145,9 @@ In the end, it actually makes more sense to remove the presets because it means 
 
 We fully expect some initial backlash from this, but ultimately feel like removing the Stage presets is a better decision for us all in the long run.
 
-TODO: mention stuff like https://news.ycombinator.com/item?id=11371906, https://www.reddit.com/r/javascript/comments/4c8isx/babel_6_useless_by_default_a_lesson_in_how_not_to/
+And this project is no stranger to community uproar 🙂, as Babel 6 was a "controverisal" release for many. There were plently of posts right after and even [recently](https://news.ycombinator.com/item?id=11371906) that speak about how difficult it was to use.
+
+But removing previous defaults or removing the Stage presets doesn't mean we don't care about ease of use, new users, or documentation. We try with what we can to keep the project stable, document what we know, and provide tooling to make things better.
 
 ## Migrating
 
@@ -143,31 +157,33 @@ We deprecated the Stage presets in v7 as of `7.0.0-beta.52`, so if you don't wan
 
 For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) which you can run with `npx babel-upgrade`.
 
-Also, you are free to make your own preset that contains the same plugins and upgrade them as you please.
+As as alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you setup plugins interactively or update `babel-upgrade` itself to accomplsih it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
 ## The Future
 
-TODO: Refer to previous [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) about configuring proposal plugins to not have default behaviors if in-flux.
+### Proposal Implementations in Babel
 
-We are trying to better position ourselves in the JavaScript ecosystem: being part of the TC39 process and being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users.
+[Josh Justice](https://twitter.com/CodingItWrong) wrote a [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) recently about the changes to using the pipeline operator (`|>`).
+
+The main point there is that the proposal itself is in flux and has a few options to explore. Because we'd like to implement all three of the current possibilities as Babel plugins for both spec feedback and user feedback, we believed the way the plugin is used should change as well.
+
+Before we would simply add the proposal plugin to the config and that was it. Now we would remove the default behavior and ask users to opt-in to a flag that shows which proposal is chosen, and makes it clear that there isn't a fixed or even favored option at the moment.
+
+```diff
+{
+  "plugins": [
+-   "@babel/plugin-proposal-pipeline-operator"
++   ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }]
+  ]
+}
+```
 
 ### Ecosystem Maintenance Burden
 
-TODO: We push all other tools in a negative way, burdensome even for us! Can mention all the tooling that needs to be updated along the way and the lack of help. https://twitter.com/mjackson/status/619580016473456641, http://jshint.com/blog/new-lang-features/
+TODO: Each new syntax provides affordances to the language, but it brings new burdens for all of our tooling. Can mention all the tooling that needs to be updated along the way and the lack of help. https://twitter.com/mjackson/status/619580016473456641, http://jshint.com/blog/new-lang-features/
 
----
+### Purpose
 
-TODO: considerations/alternatives/workarounds?
-
-> `babel-init`?
-> Rely on other higher level tools like create-react-app
-> Tool to convert your current config into a shareable preset
-> `babel-upgrade`
-
-There are a lot of other ways to tackle this issue as well, and maybe we can use them if it makes more sense in the future.
-
-- Versioning strategies: Independently version the presets and update them immediately when needed
-- [Rename the presets](https://github.com/babel/babel/issues/4914)
-- Keep them but warn/error when out of date?
+TODO: We are trying to better position ourselves in the JavaScript ecosystem: being part of the TC39 process and being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users.
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -151,11 +151,11 @@ But removing previous defaults or removing the Stage presets doesn't mean we don
 
 ## Migrating
 
-TL;DR is that removing the Stage presets so that at some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. If you use your own preset or a toolchain (i.e. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
+> For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
 
-We deprecated the Stage presets in v7 as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with how to migrate.
+The TL;DR is that we removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. But if you use your another preset or a toolchain (i.e. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
 
-For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) which you can run with `npx babel-upgrade`.
+We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with how to migrate.
 
 As as alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you setup plugins interactively or update `babel-upgrade` itself to accomplsih it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -101,7 +101,7 @@ Ultimately, we decided that keeping the Stage presets would lead to some issues 
 
 ### BabelScript
 
-[TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertant pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (for example, using a different symbol like `#` for decorators instead of `@`). 
+[TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertent pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (for example, using a different symbol like `#` for decorators instead of `@`). 
 
 People joke that developers who use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) is whether there's a Babel plugin for it.
 
@@ -133,7 +133,7 @@ We also could have tried to:
 - Better versioning strategies: independently version the presets and update them immediately when needed, maybe use `0.x`
 - Warn/Error for old out-of-date versions of presets
 
-The the end, people would still have to look up what proposals are at what Stage to know which ones to use if we kept the Stages in.
+In the end, people would still have to look up what proposals are at what Stage to know which ones to use if we kept the Stages in.
 
 ### Why Now?
 
@@ -141,31 +141,27 @@ Why not remove it earlier? Stage presets have been part of Babel for years, and 
 
 We're trying to determine the right level of feedback: if it's only the committee that decides what goes into the language,  it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or ok to use in production without consequence, then we'll have other issues. We all want to move forward and proceed with intention: not rushing, but not being too cautious. Babel is the right place to do that experimentation but knowing where the boundaries are is necessary.
 
-In the end, it actually makes more sense to remove the presets because it means that users have to explicitly opt-in to using new proposals. This would be considered a "feature" since it means someone would have to make an explicit decision to use each proposal, which is reasonable for any proposal since they all have varying levels of instability, usefulness, and complexity.
+Removing the presets would be considered a "feature" since it means someone would have to make an explicit decision to use each proposal, which is reasonable for any proposal since they all have varying levels of instability, usefulness, and complexity.
 
-We fully expect some initial backlash from this, but ultimately feel like removing the Stage presets is a better decision for us all in the long run.
-
-And this project is no stranger to community uproar 🙂, as Babel 6 was a "controversial" release for many. There were plently of posts right after and even [recently](https://news.ycombinator.com/item?id=11371906) that speak about how difficult it was to use.
-
-But removing previous defaults or removing the Stage presets doesn't mean we don't care about ease of use, new users, or documentation. We try with what we can to keep the project stable, document what we know, and provide tooling to make things better.
+We fully expect some initial [backlash](https://news.ycombinator.com/item?id=11371906) from this, but ultimately feel that removing the Stage presets is a better decision for us all in the long run. But removing previous defaults or removing the Stage presets doesn't mean we don't care about ease of use, new users, or documentation. We work with what we can to keep the project stable, document what we know, and provide tooling to make things better.
 
 ## Migrating
 
 > For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
 
-The TL;DR is that we're removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. But if you use another preset or a toolchain (e.g. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
+The TL;DR is that we're removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. If you use another preset or a toolchain, (e.g. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
 
 We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with a message saying how to migrate.
 
-As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please (someone make a tool that automatically creates a preset from your config). In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to accomplish it. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
+As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please. In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to list and add the current Stage plugins? Or maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
-### Proposal Implementations in Babel
+### Proposal Lock In
 
 [James DiGioia](https://twitter.com/JamesDiGioia) wrote a [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) recently about the changes to using the pipeline operator (`|>`).
 
-The main point there is that the proposal itself is in flux and has a few options to explore. Because we'd like to implement all three of the current possibilities as Babel plugins for both spec feedback and user feedback, we believed the way the plugin is used should change as well. This a relatively new approach for 
+The main point there is that the proposal itself is in flux and has a few options to explore. Because we'd like to implement all three of the current possibilities as Babel plugins for both spec feedback and user feedback, we believed the way the plugin is used should change as well. This a relatively new approach for TC39 and Babel!
 
-Before we would simply add the proposal plugin to the config and that was it. Now we would remove the default behavior and ask users to opt in to a flag that shows which proposal is chosen, and makes it clear that there isn't a fixed or even favored option at the moment.
+Before, we would add the proposal plugin to the config and that was it. Now, we remove the default behavior and ask users to opt in to a flag that shows which proposal is chosen, and make it clear that there isn't a fixed (or even favored) option at the moment.
 
 ```diff
 {
@@ -180,14 +176,14 @@ This is something that we'd like to continue to do moving forward as another ind
 
 ### Ecosystem Maintenance Burden
 
-A language's "syntax budget" doesn't just apply to the complexity of the language itslef but can extend down to the tooling. Each new syntax can brings [new burdens](http://jshint.com/blog/new-lang-features/) for the maintainers of other JavaScript projects.
+A language's "syntax budget" doesn't just apply to the complexity of the language itself but can extend down to the tooling. Each new syntax addition brings new [burden](http://jshint.com/blog/new-lang-features/) to the maintainers of other JavaScript projects.
 
-Once a new syntax is "added" many things need updating: parsers (`babylon`), syntax highlighting (`language-babel`), linters (`babel-eslint`), test frameworks (jest/ava), formatters (`prettier`), code coverage (`instanbul`), minifiers (`babel-minify`), and more.  There have been many issues brought up on projects like `acorn`, `eslint`, `jshint`, `typescript`, and others to support Stage 0 proposals because they were in Babel. There aren't many projects that would adhere to a policy that required them to support any proposal since that would be extremely demanding to maintain. In many ways, it's surprising we even attempt to handle it in Babel itself given the constant updates and churn.
+Once new syntax is proposed, many things need updating: parsers (`babylon`), syntax highlighting (`language-babel`), linters (`babel-eslint`), test frameworks (jest/ava), formatters (`prettier`), code coverage (`instanbul`), minifiers (`babel-minify`), and more.  There have been many issues brought up on projects like `acorn`, `eslint`, `jshint`, `typescript`, and others to support Stage 0 proposals because they were in Babel. There aren't many projects that would adhere to a policy that required them to support any proposal since that would be extremely demanding to maintain. In many ways, it's surprising we even attempt to handle it in Babel itself given the constant updates and churn.
 
-Who is doing that work, and is it our responsibility to make sure everything works? Every one of those projects (mostly volunteers) is lacking in help in almost every aspect, and yet we continouly get complaints about this across the board. How are we to as a community take responsibility for dealing with these changes (same with open source as a whole)?
+Who is doing that work, and is it our responsibility to make sure everything works? Every one of those projects (mostly volunteers) is lacking in help in almost every aspect, and yet we continually get complaints about this across the board. How are we, as a community, to take responsibility for dealing with these changes (same with open source as a whole)?
 
 ### The Future
 
-The purpose of this project is to act as a part of the TC39 process: being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users while also supporting older versions of JavaScript. We hope this post sheds more light on how we are trying as best we can to better align this project in the JavaScript ecosystem.
+The purpose of this project is to act as a part of the TC39 process: being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users while also supporting older versions of JavaScript. We hope this post sheds more light on how we are trying, as best we can, to better align this project in the JavaScript ecosystem.
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -54,37 +54,37 @@ module.exports = {
 
 ## Problems
 
-These presets were a convenient way use what we all wanted: the new, shiny, "yet-to-be-determined" future of JavaScript.
+These presets were a convenient way to use what we all wanted: the new, shiny, "yet-to-be-determined" future of JavaScript.
 
 Looking back, it worked really well! (Maybe too well?)
 
 ### Too Good a Job?
 
-With new languages like [CoffeeScript](https://coffeescript.org/) and new tooling like [Traceur](https://github.com/google/traceur-compiler) it set the expectation that compiling JavaScript wasn't something to laugh at. And Babel made it that much easier to integrate with existing tooling and to use future syntax. The expectations were changed from skepticism and worry to completely embracing the experimental.
+Languages like [CoffeeScript](https://coffeescript.org/) and tooling like [Traceur](https://github.com/google/traceur-compiler) helped establish the idea that compiling JavaScript wasn't crazy. Babel made it even easier to both use new/future syntax and integrate with existing tooling. The expectations changed from skepticism and worry to completely embracing the experimental.
 
-We probably wouldn't be where we're at if not for the wide adoption of compilers such as Babel: it brought ES2015 to many more people, earlier both in terms of teaching and usage. With the growth of React and it's optional JSX syntax along side class properties and object rest/spread led to people knowing a bit more about these syntax proposals.
+We probably wouldn't be where we are at if not for the wide adoption of compilers such as Babel: it accelerated the usage (and teaching) of ES2015 to a much larger audience. The growth of React further fueled usage as its JSX syntax, class properties, and object rest/spread led to people knowing a bit more about these syntax proposals.
 
 Babel became a one-time setup for people, never to be thought of again. It became underlying infrastructure, hidden behind other tooling until there was a `SyntaxError`, dependency issues, or integration issues. Simply use `stage-0`.
 
-This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, especially in production. However, it meant that many companies, tools, people would be in some trouble if a proposal happened to drop or changed in a significant way.
+This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, even in production environments. However, it also meant that many companies, tools, and people would encounter some trouble if a proposal happened to change in a significant way (or even get dropped altogether).
 
 ### "ES7 Decorators"
 
 Part of issue is precisely around naming things, and as we hear a lot, naming things is hard.
 
-There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. So when people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
+There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. When people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
 
-Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say something like "ES7 Decorators" and find that it is a common occurrence.
+Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say something like "ES7 Decorators" and find it become the established name for it.
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your reminder that binding with :: is just an experimental proposal at stage 0 and might never become a part of JS. Don&#39;t call it &quot;ES7&quot;.</p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/785082176610115584?ref_src=twsrc%5Etfw">October 9, 2016</a></blockquote>
 
-It's completely understandable that this happens and not realize it, but continuing to do so sets different expectations on how the language progresses. Nothing to feel guilty about, we learn as a community and [remind](https://twitter.com/dan_abramov/status/785082176610115584) one another of how JavaScript works.
+It's completely understandable that this happens without realizing it, but continuing to do so sets different expectations for how the language progresses. It's nothing to feel guilty about, we learn as a community and [remind](https://twitter.com/dan_abramov/status/785082176610115584) one another of how JavaScript works.
 
-[Jay Phelps](https://twitter.com/_jayphelps/status/779770321003962369) wrote a nice [article](https://medium.com/@jayphelps/please-stop-referring-to-proposed-javascript-features-as-es7-cad29f9dcc4b) about the subject explaining it would be best to call them by the "Stage" they are currently at: "Stage 2 Decorators", or simply as the "Decorators Proposal".
+[Jay Phelps](https://twitter.com/_jayphelps/status/779770321003962369) wrote a nice [article](https://medium.com/@jayphelps/please-stop-referring-to-proposed-javascript-features-as-es7-cad29f9dcc4b) about the subject. He explains it would be best to call them by the "Stage" they are currently at: "Stage 2 Decorators", or just simply the "Decorators Proposal".
 
-The reasoning is that saying "ES7 Decorators" assumes that Decorators is expected to be in ES7. I mentioned this in my [last post regarding compiling node_modules](https://babeljs.io/blog/2018/06/26/on-consuming-and-publishing-es2015+-packages#staging-process), but being in a Stage doesn't guarantee much if proposals stall, move backward, or get removed entirely.
+The reasoning is that saying "ES7 Decorators" assumes that Decorators is expected to be in ES7. I mentioned this in my [last post regarding compiling node_modules](https://babeljs.io/blog/2018/06/26/on-consuming-and-publishing-es2015+-packages#staging-process), but being in a particular Stage doesn't guarantee much: a proposal can stall, move backward, or get removed entirely.
 
-This is the reasoning behind [changing the names](https://babeljs.io/docs/en/next/v7-migration#switch-to-proposal-for-tc39-proposals-blog-2017-12-27-nearing-the-70-releasehtml-renames-proposal) of the proposal plugins to be `@babel/plugin-proposal-` instead of `@babel/plugin-transform-`.
+We wanted to highlight this fact when we decided to [change the names](https://babeljs.io/docs/en/next/v7-migration#switch-to-proposal-for-tc39-proposals-blog-2017-12-27-nearing-the-70-releasehtml-renames-proposal) of the proposal plugins from `@babel/plugin-transform-` to `@babel/plugin-proposal-`.
 
 What are we to do here? It does feel like part of our responsibility to make speaking about these proposals clear.
 

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -66,7 +66,18 @@ We probably wouldn't be where we are if not for the wide adoption of compilers s
 
 Babel became a one-time setup for people, never to be thought of again. It became underlying infrastructure, hidden behind other tooling until there was a `SyntaxError`, dependency issues, or integration issues. Simply use `stage-0`.
 
-This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, even in production environments. However, it also meant that many companies, tools, and people would encounter some trouble if a proposal happened to change in a significant way (or even get dropped altogether).
+This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, even in production environments. However, it also meant that many companies, tools, and people would encounter some trouble if a proposal changed in a significant way (or even get dropped altogether).
+
+### Back and Forth
+
+Over the years, we've had many issues raised in our repo about what to do with the Stage presets: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770)
+
+I even wrote in an older post about the release of Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
+
+Ultimately, we decided that keeping the Stage presets would lead to some issues for Babel itself:
+
+- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to know exactly what `stage-0` meant, and few people would look at its `package.json` or source.
+- Removing a plugin in Stage 3 is actually a breaking change. This issue is exacerbated when you are trying to use `@babel/preset-env` to not compile a natively supported proposal.
 
 ### "ES7 Decorators"
 
@@ -86,24 +97,11 @@ The reasoning is that saying "ES7 Decorators" assumes that Decorators is expecte
 
 We wanted to highlight this fact when we decided to [change the names](https://babeljs.io/docs/en/next/v7-migration#switch-to-proposal-for-tc39-proposals-blog-2017-12-27-nearing-the-70-releasehtml-renames-proposal) of the proposal plugins from `@babel/plugin-transform-` to `@babel/plugin-proposal-`.
 
-What are we to do here? It does feel like part of our responsibility to make speaking about these proposals clear.
-
-### Back and Forth
-
-Over the years, we've had many issues raised in our repo about what to do with the Stage presets: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770)
-
-I even wrote in an older post about the release of Babel 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
-
-Ultimately, we decided that keeping the Stage presets would lead to some issues for Babel itself:
-
-- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to know exactly what `stage-0` meant, and few people would look at its `package.json` or source.
-- Removing a plugin in Stage 3 is actually a breaking change. This issue is exacerbated when you are trying to use `@babel/preset-env` to not compile a natively supported proposal.
-
 ### BabelScript
 
 [TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertent pressure from the community to keep the implementation as-is instead of improving/changing it for fear of breaking existing code or fragmentation (for example, using a different symbol like `#` for decorators instead of `@`). 
 
-People joke that developers who use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) is whether there's a Babel plugin for it.
+People joke that developers who use Babel are using "BabelScript" instead of JavaScript, implying that somehow once a Babel plugin is made for a certain feature, that must mean it’s "fixed" or officially part of the language already (which is not true). For some, the first question that people think of when they see a new syntax or idea (Stage "-1") is whether there's a Babel plugin for it.
 
 Having presets for proposals so early in the process may imply to people that these proposals are guaranteed to move forward or have a stable implementation.
 
@@ -180,7 +178,9 @@ A language's "syntax budget" doesn't just apply to the complexity of the languag
 
 Once new syntax is proposed, many things need updating: parsers (`babylon`), syntax highlighting (`language-babel`), linters (`babel-eslint`), test frameworks (jest/ava), formatters (`prettier`), code coverage (`instanbul`), minifiers (`babel-minify`), and more.  There have been many issues brought up on projects like `acorn`, `eslint`, `jshint`, `typescript`, and others to support Stage 0 proposals because they were in Babel. There aren't many projects that would adhere to a policy that required them to support any proposal since that would be extremely demanding to maintain. In many ways, it's surprising we even attempt to handle it in Babel itself given the constant updates and churn.
 
-Who is doing that work, and is it our responsibility to make sure everything works? Every one of those projects (mostly volunteers) is lacking in help in almost every aspect, and yet we continually get complaints about this across the board. How are we, as a community, to take responsibility for dealing with these changes (same with open source as a whole)?
+Who is doing that work, and is it our responsibility to make sure everything works? Every one of those projects (mostly volunteers) is lacking in help in almost every aspect, and yet we continually get complaints about this across the board. How are we, as a community, to take responsibility for dealing with our infrastructure (not dissimilar to open source as a whole)?
+
+Babel has taken on the unusual burden of supporting these experimental features; at the same time, it's reasonable that other projects take a more conservative policy. If you'd like to see new language features supported across the ecosystem, [contribute to TC39](https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md) and this project to bring these proposals to Stage 4.
 
 ### The Future
 
@@ -190,6 +190,6 @@ The purpose of this project is to act as a part of the TC39 process: being a res
 
 If you appreciate this post and the work we're doing on Babel, you can support me on [Patreon](https://www.patreon.com/henryzhu), ask your company to sponsor us on [Open Collective](https://opencollective.com/babel), or better yet get involved with Babel as part of your job/work. We'd appreciate the collective ownership.
 
-With thanks to all the reviewers (too many to list)!
+With thanks to all the [reviewers](https://github.com/babel/website/pull/1735)!
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -1,0 +1,179 @@
+---
+layout: post
+title:  "Removing Babel's Stage Presets"
+author: Henry Zhu
+authorURL: https://twitter.com/left_pad
+date:   2018-07-27 12:00:00
+categories: announcements
+share_text: "Removing Babel's Stage Presets"
+---
+
+Moving forward with v7, we've decided it's best to stop publishing the Stage presets in Babel (e.g. `@babel/preset-stage-0`).
+
+We didn't make this decision lightly and wanted bring show some context regarding TC39, new proposals, and Babel.
+
+<!--truncate-->
+
+## Some History
+
+A Babel preset is a shareable list of plugins.
+
+The [official Babel Stage presets](https://babeljs.io/docs/en/next/presets) tracked the [TC39 Staging process](https://tc39.github.io/process-document/) for new [syntax proposals](https://github.com/tc39/proposals) in JavaScript.
+
+Each preset (ex. stage-3, stage-2, etc.) included all the plugins for that particular stage and the ones above it (ex. stage-2 included stage-3, etc).
+
+---
+
+This allowed users who wanted to use experimental syntax to simply add the preset, instead of needing to configure/install each individual plugin.
+
+We actually [added](https://github.com/babel/babel/pull/2649) the Stage presets shortly after Babel's v6 release (it was previously a config flag in v5).
+
+These are some older examples from Babel v6.
+
+Common to see this in a config: 
+
+```js
+{
+  "presets": ["es2015", "react", "stage-0"]
+}
+```
+
+Original source of the package: [babel-preset-stage-0](https://unpkg.com/babel-preset-stage-0@6.0.14/index.js)
+
+```js
+module.exports = {
+  presets: [
+    require("babel-preset-stage-1")
+  ],
+  plugins: [
+    require("babel-plugin-transform-do-expressions"),
+    require("babel-plugin-transform-function-bind")
+  ]
+};
+```
+
+## Problems
+
+These presets were a convenient way use what we all wanted: the new, shiny, "yet-to-be-determined" future of JavaScript.
+
+Looking back, it worked really well! (Maybe too well?)
+
+### Too Good a Job?
+
+With new languages like [CoffeeScript](https://coffeescript.org/) and new tooling like [Traceur](https://github.com/google/traceur-compiler) it set the expectation that compiling JavaScript wasn't something to laugh at. And Babel made it that much easier to integrate with existing tooling and to use future syntax. The expectations were changed from skepticism and worry to completely embracing the experimental.
+
+We probably wouldn't be where we're at if not for the wide adoption of compilers such as Babel: it brought ES2015 to many more people, earlier both in terms of teaching and usage. With the growth of React and it's optional JSX syntax along side class properties and object rest/spread led to people knowing a bit more about these syntax proposals.
+
+Babel became a one-time setup for people, never to be thought of again. It became underlying infrastructure, hidden behind other tooling until there was a `SyntaxError`, dependency issues, or integration issues. Simply use `stage-0`.
+
+This was awesome to see in some ways, as it meant that these ideas were being tested in the wild, especially in production. However, it meant that many companies, tools, people would be in some trouble if a proposal happened to drop or changed in a significant way.
+
+### "ES7 Decorators"
+
+Part of issue is precisely around naming things, and as we hear a lot, naming things is hard.
+
+There were a lot of names for ES6 itself: Harmony, ES Next, ES6, ES2015. So when people hear about new ideas it makes sense to just pick the latest number and attach the name to it.
+
+Thus it's easy to [search](https://twitter.com/search?q=es7%20class%20properties&src=typd) [around](https://twitter.com/search?q=es7%20decorators&src=typd) for tweets/blog posts/talks that say something like "ES7 Decorators" and find that it is a common occurrence.
+
+<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your reminder that binding with :: is just an experimental proposal at stage 0 and might never become a part of JS. Don&#39;t call it &quot;ES7&quot;.</p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/785082176610115584?ref_src=twsrc%5Etfw">October 9, 2016</a></blockquote>
+
+It's completely understandable that this happens and not realize it, but continuing to do so sets different expectations on how the language progresses. Nothing to feel guilty about, we learn as a community and [remind](https://twitter.com/dan_abramov/status/785082176610115584) one another of how JavaScript works.
+
+[Jay Phelps](https://twitter.com/_jayphelps/status/779770321003962369) wrote a nice [article](https://medium.com/@jayphelps/please-stop-referring-to-proposed-javascript-features-as-es7-cad29f9dcc4b) about the subject explaining it would be best to call them by the "Stage" they are currently at: "Stage 2 Decorators", or simply as the "Decorators Proposal".
+
+The reasoning is that saying "ES7 Decorators" assumes that Decorators is expected to be in ES7. I mentioned this in my [last post regarding compiling node_modules](https://babeljs.io/blog/2018/06/26/on-consuming-and-publishing-es2015+-packages#staging-process), but being in a Stage doesn't guarantee much if proposals stall, move backward, or get removed entirely.
+
+This is the reasoning behind [changing the names](https://babeljs.io/docs/en/next/v7-migration#switch-to-proposal-for-tc39-proposals-blog-2017-12-27-nearing-the-70-releasehtml-renames-proposal) of the proposal plugins to be `@babel/plugin-proposal-` instead of `@babel/plugin-transform-`.
+
+What are we to do here? It does feel like part of our responsibility to make speaking about these proposals clear.
+
+### Semver is Hard for Compilers
+
+TODO: https://twitter.com/sebmck/status/685870041347305472, https://github.com/babel/babel/pull/3225 (rollup, flow, typescript, what about other compilers)
+
+### Ecosystem Maintenance Burden
+
+TODO: We push all other tools in a negative way, burdensome even for us! Can mention all the tooling that needs to be updated along the way and the lack of help. https://twitter.com/mjackson/status/619580016473456641, http://jshint.com/blog/new-lang-features/
+
+
+### Back and Forth
+
+We've had many issues to talk about what to do with the Stage presets over the years: [#4914](https://github.com/babel/babel/issues/4914), [#4955](https://github.com/babel/babel/issues/4955), [#7770](https://github.com/babel/babel/issues/7770)
+
+I even wrote an older post about the release of 7.0 that said we *weren't* [removing them](https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release) 😅.
+
+Having the Stage presets in place lead to some issues for Babel itself:
+
+- It was a common issue to ask something like: ["What presets(s) are needed to use async functions?"](https://github.com/babel/babel/issues/2948). It was difficult for people to be able to know what exactly "stage-0" meant, and few people would look at the `package.json` or source.
+- Removing a plugin in Stage 3 is actually a breaking change. This issue is exacerbated when you are trying to use preset-env to not compile a natively supported proposal.
+
+### BabelScript
+
+[TC39](https://tc39.github.io/process-document/) strongly recommends caution with anyone using Stage 2 proposals or below and may feel pressure from the community to keep the implementation as is instead of making better or necessary changes for fear of breaking existing code or fragmentation (ex: using a different symbol like `#` for decorators instead of `@`). 
+
+People joke that developers that use Babel are using "BabelScript" instead of JavaScript, that somehow once a Babel plugin is made for it, it must be "fixed" or in the language already (not true). For some, the first question that people think of when they see a new syntax or idea (Stage -1 😂) they ask whether there's a Babel plugin for it already.
+
+Having presets for proposals so early in the process may imply to people that these proposals are guaranteed to move forward or have a stable implementation.
+
+### Setting Expectations
+
+But after it became normal for people to write in ES6 thanks to compilers, it was natural for developers to want to try out even newer "features". The way this worked in Babel was to use the `stage` flag in previous versions or the `stage-x` presets.
+
+Being the most convenient way of opting into any new feature, it quickly became the default for people when configuring Babel (even though in Babel v6 it moved to not doing anything by default which there was a lot of complaints about).
+
+It became common to see `"stage-0"` show up in libraries, boilerplates, talks, tweets, and slides.
+
+<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">&quot;Just say no&quot; to `babel?stage=0` in production.</p>&mdash; Ryan Florence (@ryanflorence) <a href="https://twitter.com/ryanflorence/status/627154904302288897?ref_src=twsrc%5Etfw">July 31, 2015</a></blockquote>
+
+There was a lot of good discussion even years ago, 
+but it wasn't the easiest thing to navigate: we wouldn't want to penalize users that understood the tradeoffs by putting `console.warn`'s when using it, and not having the option at all seemed unreasonable at the time. 
+
+Blindly opting in to Stage 0 (whether we had it by default) or people choosing to do so seems dangerous, but also never using any proposals maybe overly cautious and doesn't work with the strengths of using Babel. Ideally everyone is able to make an informed decision on the kinds of features that seem reasonable to them and use them wisely, whether they are at Stage 0 or not. [Mike Pennisi](https://twitter.com/jugglinmike) wrote a great [post](https://bocoup.com/blog/javascript-developers-watch-your-language) about these concerns.
+
+It isn't our intention to threaten, rush, or force specific things into the ecosystem or JavaScript but faithfully maintain the implementation/discussions around new ideas so that they have been tested.
+
+## Hesitations
+
+Why not remove it earlier? Stage presets have been part of Babel for years and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. And it seemed better to have officially maintained presets.
+
+We're trying to determine the right level of feedback: if it's only the committee that decides what goes in the language it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or alright to use in production without consequence then we have another issue. We all want to move forward and to proceed with intention: not rushing but not being too cautious. Babel can be the right place to do that experimentation but knowing where the boundaries are is necessary.
+
+In the end, it actually makes more sense to remove the presets because it means that users have to explicitly opt-in to using new proposals. This would be considered a "feature" since it means someone would have to make the decision to use each proposal, which is reasonable for any proposal since they all have varying levels of instability, usefulness, complexity.
+
+We do have some expectation of initial backlash but it does feel like removing the Stage presets is a better decision for us all in the long run.
+
+TODO: mention stuff like https://news.ycombinator.com/item?id=11371906, https://www.reddit.com/r/javascript/comments/4c8isx/babel_6_useless_by_default_a_lesson_in_how_not_to/
+
+## Migrating
+
+TL;DR is that removing the Stage presets so that at some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. If you use your own preset or a toolchain (i.e. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
+
+We deprecated the Stage presets in v7 as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with how to migrate.
+
+For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) which you can run with `npx babel-upgrade`.
+
+Also, you are free to make your own preset that contains the same plugins and upgrade them as you please.
+
+## The Future
+
+TODO: Refer to previous [post](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) about configuring proposal plugins to not have default behaviors if in-flux.
+
+We are trying to better position ourselves in the JavaScript ecosystem: being part of the TC39 process and being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users.
+
+---
+
+TODO: considerations/alternatives/workarounds?
+
+> `babel-init`?
+> Rely on other higher level tools like create-react-app
+> Tool to convert your current config into a shareable preset
+> `babel-upgrade`
+
+There are a lot of other ways to tackle this issue as well, and maybe we can use them if it makes more sense in the future.
+
+- Versioning strategies: Independently version the presets and update them immediately when needed
+- [Rename the presets](https://github.com/babel/babel/issues/4914)
+- Keep them but warn/error when out of date?
+
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/website/blog/2018-07-27-removing-babels-stage-presets.md
+++ b/website/blog/2018-07-27-removing-babels-stage-presets.md
@@ -95,7 +95,7 @@ We wanted to highlight this fact when we decided to [change the names](https://b
 
 ### BabelScript
 
-Having presets for proposals so early in the process may imply to people that these proposals are guaranteed to move forward or have a stable implementation.
+Having presets for proposals so early in the process may imply that these proposals are guaranteed to move forward or have a stable implementation.
 
 [TC39](https://tc39.github.io/process-document/) urges caution when using Stage 2-or below proposals, as it might result in inadvertent pressure from the community to keep the implementation as-is instead of improving it for fear of breaking existing code or ecosystem fragmentation (e.g. using a different symbol like `#` instead of `@` for decorators). 
 
@@ -131,13 +131,13 @@ In the end, people would still have to look up what proposals are at what Stage 
 
 ### Why Now?
 
-Why not remove it earlier? Stage presets have been part of Babel for years, and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. Earlier, we thought it was better to officially maintain the presets since someone else would (and will) inevitably create them.
+Why not remove it earlier? The Stage presets have been part of Babel for years, and there were concerns with adding more "complexity" to using Babel. A lot of tooling, documentation, articles, and knowledge were around the Stage presets. Earlier, we thought it was better to officially maintain the presets since someone else would (and will) inevitably create them.
 
 We're trying to determine the right level of feedback: if it's only the committee that decides what goes into the language,  it may lead to well-specified features that are not needed, but if the community expects that in-progress, experimental proposals are considered stable or ok to use in production without consequence, then we'll have other issues. We all want to move forward and proceed with intention: not rushing, but not being too cautious. Babel is the right place to do that experimentation but knowing where the boundaries are is necessary.
 
 Removing the presets would be considered a "feature" since it means someone would have to make an explicit decision to use each proposal, which is reasonable for any proposal since they all have varying levels of instability, usefulness, and complexity.
 
-We fully expect some initial [backlash](https://news.ycombinator.com/item?id=11371906) from this, but ultimately feel that removing the Stage presets is a better decision for us all in the long run. But removing previous defaults or removing the Stage presets doesn't mean we don't care about ease of use, new users, or documentation. We work with what we can to keep the project stable, document what we know, and provide tooling to make things better.
+We fully expect some initial [backlash](https://news.ycombinator.com/item?id=11371906) from this, but ultimately feel that removing the Stage presets is a better decision for us all in the long run. However, removing previous defaults or removing the Stage presets doesn't mean we don't care about ease of use, new users, or documentation. We work with what we can to keep the project stable, provide tooling to make things better, and document what we know.
 
 ## Migrating
 
@@ -145,9 +145,9 @@ We fully expect some initial [backlash](https://news.ycombinator.com/item?id=113
 
 The TL;DR is that we're removing the Stage presets. At some level, people will have to opt-in and know what kinds of proposals are being used instead of assuming what people should use, especially given the unstable nature of some of these proposals. If you use another preset or a toolchain, (e.g. [create-react-app](https://github.com/facebook/create-react-app)) it's possible this change doesn't affect you directly.
 
-We have deprecated the Stage presets as of `7.0.0-beta.52`, so if you don't want to change your config now we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with a message saying how to migrate.
+We have deprecated the Stage presets as of `7.0.0-beta.52`. If you don't want to change your config now, we would suggest you *pin* the versions to `beta.54` until you can upgrade; after `beta.54` we will throw an error with a message saying how to migrate. And check that all your versions are the same while in prerelease.
 
-As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please. In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to list and add the current Stage plugins? Or maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
+As an alternative, you are free to make your own preset that contains the same plugins and upgrade them as you please. In the future, we may want to work on a `babel-init` that can help you set up plugins interactively or update `babel-upgrade` itself to list and add the current Stage plugins. Maybe Babel should stay as a low-level tool and rely on other higher-level/framework tools like `create-react-app` to handle these choices for people.
 
 ### Preventing Proposal Lock-In
 
@@ -182,7 +182,7 @@ Babel has taken on the unusual burden of supporting these experimental features;
 
 ### The Future
 
-The purpose of this project is to act as a part of the TC39 process: being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users while also supporting older versions of JavaScript. We hope this post sheds more light on how we are trying, as best we can, to better align this project in the JavaScript ecosystem.
+The purpose of this project is to act as a part of the TC39 process: being a resource for both implementing newer (Stage 0-2) proposals and receiving feedback from users while also supporting older versions of JavaScript. We hope this post sheds more light on how we are trying, as best we can, to better align this project in the JavaScript ecosystem. We will be releasing a RC for v7 soon!
 
 ---
 


### PR DESCRIPTION
## Rendered: https://deploy-preview-1735--babel.netlify.com/blog/2018/07/27/removing-babels-stage-presets

Gotta set a deadline (tomorrow?) otherwise I'll spend forever on this!

The purpose of this is to explain the decision to remove the Stage presets but also to give context into why and the history of not just TC39/Babel but the community and it's relationship with the process if that makes sense and where we are at today. Ideally we'd have some more takeaways regarding getting involved in the project.

Also this makes me think maybe I should rename the title.. (prepare for backlash)