### PR TITLE
Add missing parenthesis to template doc

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -55,7 +55,7 @@ import template from "@babel/template";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-const fn = template`
+const fn = template(`
   var IMPORT_NAME = require('${"my-module"}');
 `);
 

--- a/docs/template.md
+++ b/docs/template.md
@@ -55,9 +55,9 @@ import template from "@babel/template";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-const fn = template(`
+const fn = template`
   var IMPORT_NAME = require('${"my-module"}');
-`);
+`;
 
 const ast = fn({
   IMPORT_NAME: t.identifier("myModule");


### PR DESCRIPTION
There was a parenthesis missing in the template doc when calling the `template` function.