### PR TITLE
Remove outdated reference to Makefile from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ cd website
 $ yarn && yarn bootstrap
 ```
 
-* Just run `npm start` next time (check the Makefile and the package.json).
+- Just run `npm start` next time (check the package.json for scripts).
 
 ### Contributing to the website
 


### PR DESCRIPTION
Doesn't look like there's a Makefile anymore, so this line is out of date (probably?)