### PR TITLE
Hide docs version on repl page

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -126,7 +126,7 @@ const siteConfig = {
   scripts: [
     "https://unpkg.com/clipboard@2.0.0/dist/clipboard.min.js",
     "/js/code-blocks-buttons.js",
-    "/scripts/hide-footer.js"
+    "/scripts/repl-page-hacks.js",
   ],
   // stylesheets: [ "" ],
   // translationRecruitingLink: "https://crowdin.com/project/",

--- a/website/static/css/hide-footer.css
+++ b/website/static/css/hide-footer.css
@@ -1,3 +1,0 @@
-.hide-footer {
-  display: none;
-}

--- a/website/static/css/repl-page-hacks.css
+++ b/website/static/css/repl-page-hacks.css
@@ -1,0 +1,4 @@
+body[data-repl] footer,
+body[data-repl] header a[href="/versions"] {
+  display: none;
+}

--- a/website/static/scripts/repl-page-hacks.js
+++ b/website/static/scripts/repl-page-hacks.js
@@ -1,11 +1,8 @@
 (function() {
   document.addEventListener("DOMContentLoaded", function() {
     const pathname = window.document.location.pathname;
-    const footer = document.getElementById("footer");
     if (pathname.indexOf("/repl") != -1) {
-      footer.setAttribute("class", "nav-footer hide-footer");
-    } else {
-      footer.setAttribute("class", "nav-footer");
+      document.body.setAttribute("data-repl", "");
     }
   });
 })();


### PR DESCRIPTION
The version number at the top of the repl page confused me, because I thought it referred to the version for the currently running repl, and I couldn't find a way to change it to `master` (because whenever you go to the repl page, it changes back to 6.x). I talked to @hzoo and he said it's the docs version (a docusaurus feature).

Since we already had some code that was hiding the docusaurus footer on the repl page, I repurposed it a bit and used the same pattern to also hide the docs version link when on the repl page.