### PR TITLE
Move `docUrl`, `pageUrl`, and `DEFAULT_LANGUAGE` to siteConfig

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -1,16 +1,6 @@
 const React = require("react");
 
 class Footer extends React.Component {
-  docUrl(doc, language = "en") {
-    const baseUrl = this.props.config.baseUrl;
-    return baseUrl + "docs/" + (language ? language + "/" : "") + doc;
-  }
-
-  pageUrl(doc, language = "en") {
-    const baseUrl = this.props.config.baseUrl;
-    return baseUrl + (language ? language + "/" : "") + doc;
-  }
-
   render() {
     return (
       <footer className="nav-footer" id="footer">
@@ -27,13 +17,23 @@ class Footer extends React.Component {
           </a>
           <div>
             <h5>Docs</h5>
-            <a href={this.docUrl("learn.html", this.props.language)}>
+            <a
+              href={this.props.config.getDocUrl(
+                "learn.html",
+                this.props.language
+              )}
+            >
               Learn ES2015
             </a>
           </div>
           <div>
             <h5>Community</h5>
-            <a href={this.pageUrl("users.html", this.props.language)}>
+            <a
+              href={this.props.config.getPageUrl(
+                "users.html",
+                this.props.language
+              )}
+            >
               User Showcase
             </a>
             <a

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -2,14 +2,6 @@ const React = require("react");
 const translate = require("../../server/translate.js").translate;
 const siteConfig = require(process.cwd() + "/siteConfig.js");
 
-function docUrl(doc, language) {
-  return siteConfig.baseUrl + "docs/" + (language ? language + "/" : "") + doc;
-}
-
-function pageUrl(page, language) {
-  return siteConfig.baseUrl + (language ? language + "/" : "") + page;
-}
-
 class Button extends React.Component {
   render() {
     return (
@@ -25,8 +17,6 @@ class Button extends React.Component {
 Button.defaultProps = {
   target: "_self",
 };
-
-const DEFAULT_LANGUAGE = "en";
 
 const PromoSection = props => (
   <div className="section promoSection">
@@ -55,7 +45,7 @@ const MiniRepl = ({ language }) => {
         </div>
       </div>
       <div className="hero-repl__footer">
-        <a href={pageUrl("repl.html", language)}>
+        <a href={siteConfig.getPageUrl("repl.html", language)}>
           <translate>
             Check out our REPL to experiment more with Babel!
           </translate>
@@ -94,8 +84,7 @@ const MiniRepl = ({ language }) => {
 //   );
 // };
 
-const GetStarted = props => {
-  const language = props.language || "en";
+const GetStarted = ({ language }) => {
   return (
     <div
       className="blockElement twoByGridBlock get-started"
@@ -105,17 +94,22 @@ const GetStarted = props => {
 
       <p>
         We&apos;re currently just a small group of{" "}
-        <a href={pageUrl("team.html", language)}>volunteers</a> that spend their
-        free time maintaining this project. If Babel has benefited you in your
-        work, becoming a contributor might be a great way to give back.
+        <a href={siteConfig.getPageUrl("team.html", language)}>volunteers</a>{" "}
+        that spend their free time maintaining this project. If Babel has
+        benefited you in your work, becoming a contributor might be a great way
+        to give back.
       </p>
       <p>
         Learn more about Babel by reading the get started guide or watching
         talks about the concepts behind it.
       </p>
       <PromoSection>
-        <Button href={docUrl("index.html", language)}>Get Started</Button>
-        <Button href={pageUrl("videos.html", language)}>Videos</Button>
+        <Button href={siteConfig.getDocUrl("index.html", language)}>
+          Get Started
+        </Button>
+        <Button href={siteConfig.getPageUrl("videos.html", language)}>
+          Videos
+        </Button>
       </PromoSection>
     </div>
   );
@@ -194,8 +188,7 @@ const SponsorTier = props => {
   );
 };
 
-const OpenCollectiveSponsors = props => {
-  const language = props.language || "en";
+const OpenCollectiveSponsors = ({ language }) => {
   const ocButton = {
       title: "Become a sponsor",
       link: "https://opencollective.com/babel",
@@ -213,10 +206,13 @@ const OpenCollectiveSponsors = props => {
           <p>
             Babel is helping shape the future of the JavaScript language itself,
             being used at companies like Facebook, Google, Netflix, and{" "}
-            <a href={pageUrl("users.html", language)}>hundreds more</a>. Your
-            donation will help cover expenses like attending TC39 (the committee
-            that specifies JavaScript) meetings and will directly support the
-            core team developers to continue working on improving Babel.
+            <a href={siteConfig.getPageUrl("users.html", language)}>
+              hundreds more
+            </a>
+            . Your donation will help cover expenses like attending TC39 (the
+            committee that specifies JavaScript) meetings and will directly
+            support the core team developers to continue working on improving
+            Babel.
           </p>
           <PromoSection>
             <Button href="https://opencollective.com/babel" target="_blank">
@@ -282,8 +278,10 @@ const Hero = ({ language }) => (
         <span>
           <strong>Babel 7 is out!</strong> Please read our{" "}
           <a href="/blog/2018/08/27/7.0.0">announcement</a> and{" "}
-          <a href={docUrl("v7-migration", language)}>upgrade guide</a> for more
-          information.
+          <a href={siteConfig.getDocUrl("v7-migration", language)}>
+            upgrade guide
+          </a>{" "}
+          for more information.
         </span>
       </div>
 
@@ -293,20 +291,14 @@ const Hero = ({ language }) => (
 );
 
 const Index = ({ language }) => {
-  let lang = language;
-
-  if (!language || !language.length) {
-    lang = DEFAULT_LANGUAGE;
-  }
-
   return (
     <div>
-      <Hero language={lang} />
+      <Hero language={language} />
 
       <div className="mainContainer" style={{ padding: 0 }}>
         <HomeContainer>
-          <GetStarted language={lang} />
-          <WorkSponsors language={lang} />
+          <GetStarted language={language} />
+          <WorkSponsors language={language} />
         </HomeContainer>
         <OpenCollectiveSponsors />
       </div>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -83,6 +83,8 @@ toolsMD.forEach(tool => {
   tool.usage = loadMD(`${tool.path}/usage.md`);
 });
 
+const DEFAULT_LANGUAGE = "en";
+
 const GITHUB_URL = "https://github.com/babel/website";
 
 const siteConfig = {
@@ -92,6 +94,10 @@ const siteConfig = {
   tagline: "The compiler for next generation JavaScript",
   url: "https://babeljs.io",
   baseUrl: "/",
+  getDocUrl: (doc, language) =>
+    `${siteConfig.baseUrl}docs/${language || DEFAULT_LANGUAGE}/${doc}`,
+  getPageUrl: (page, language) =>
+    `${siteConfig.baseUrl}${language || DEFAULT_LANGUAGE}/${page}`,
   organizationName: "babel",
   projectName: "babel",
   repoUrl: "https://github.com/babel/babel",


### PR DESCRIPTION
Moved `docUrl`, `pageUrl`, and `DEFAULT_LANGUAGE` to `siteConfig`.

* Fix invalid footer links. In non-localized pages, `props.language` is an empty string, rather than `undefined`, causing default arguments not to be applied.

Closes #1715.