### PR TITLE
fix(repl): search on computed plugins

### DIFF
--- a/js/repl/ExternalPluginsModal.js
+++ b/js/repl/ExternalPluginsModal.js
@@ -99,7 +99,7 @@ export default class ExternalPluginsModal extends React.Component<
     const { onClose, plugins } = this.props;
     const { officialOnly } = this.state;
 
-    let filters = "keywords:babel-plugin";
+    let filters = "computedKeywords:babel-plugin";
 
     if (officialOnly) {
       filters += " AND owner.name:babel";


### PR DESCRIPTION
The plugins are not only those that have the keyword; but also those that start with it. 

see https://github.com/algolia/npm-search/commit/a8a52650cc857e4cfb558538fa5e86b743dc5d86 to the change that did this, 

I already did https://github.com/babel/website/pull/1623 and https://github.com/babel/website/pull/1622, but it seems like that was reverted?

cc @xtuc