### PR TITLE
feat(repl): avoid browser autocompletion in plugin search

### DIFF
--- a/js/repl/ExternalPluginsSearchBox.js
+++ b/js/repl/ExternalPluginsSearchBox.js
@@ -23,6 +23,10 @@ export class SearchBox extends React.PureComponent<Props> {
         ref={this.props.inputRef}
         type="text"
         value={this.props.currentRefinement}
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
       />
     );
   }


### PR DESCRIPTION
My browser otherwise interprets this input as a contacts form (it would be better as type=search and in a form, but didn't want to mess with the styling now)


(this is how it used to look)
<img width="616" alt="screen shot 2018-08-29 at 11 35 25 redacted" src="https://user-images.githubusercontent.com/6270048/44798614-f25a4a80-ab7f-11e8-87c7-4bafe0ad4ec1.png">
