### PR TITLE
Trim unnecessary backquote in code example

### DIFF
--- a/docs/v7-migration.md
+++ b/docs/v7-migration.md
@@ -302,7 +302,7 @@ We have separated out Babel's helpers from it's "polyfilling" behavior in runtim
 
 ```sh
 # install the runtime as a dependency
-npm install @babel/runtime`
+npm install @babel/runtime
 # install the plugin as a devDependency
 npm install @babel/plugin-transform-runtime --save-dev
 ```


### PR DESCRIPTION
I found an easy mistake in "[Upgrade to Babel 7](https://babeljs.io/docs/en/v7-migration#only-helpers)".
It's a trivial fix, so please check it when you have time. 😉 

### Screenshot

![image](https://user-images.githubusercontent.com/473530/45065634-4c658d80-b0f5-11e8-82cb-cfb523b66689.png)
