### PR TITLE
Update ignore files section

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,7 +102,7 @@ npx babel src --out-file script-compiled.js
 Ignore spec and test files
 
 ```sh
-npx babel src --out-dir lib --ignore spec.js,test.js
+npx babel src --out-dir lib --ignore src/**/*.spec.js,src/**/*.test.js
 ```
 
 ### Copy files

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,7 +102,7 @@ npx babel src --out-file script-compiled.js
 Ignore spec and test files
 
 ```sh
-npx babel src --out-dir lib --ignore src/**/*.spec.js,src/**/*.test.js
+npx babel src --out-dir lib --ignore "src/**/*.spec.js","src/**/*.test.js"
 ```
 
 ### Copy files


### PR DESCRIPTION
With Babel 7 the `--ignore` flag needs proper patterns to match files. This updates the documentation to reflect that change.

There is some more information in this issue https://github.com/babel/babel/issues/8631.