### PR TITLE
Fix "WordPress" spelling in the 7.0.0 release post

### DIFF
--- a/website/blog/2018-08-27-7.0.0.md
+++ b/website/blog/2018-08-27-7.0.0.md
@@ -16,7 +16,7 @@ After almost 2 years, 4k commits, over 50 pre-releases, and a lot of help we are
 
 ## It's Happening! 🎉
 
-Software is never going to be perfect but we're ready to ship something that's already been used in production for some time now! [`@babel/core`](https://www.npmjs.com/package/@babel/core) is already at 5.1 mil downloads/month because of its usage in tools like [Next.js 6](https://zeit.co/blog/next6), [vue-cli 3.0](https://medium.com/the-vue-point/vue-cli-3-0-is-here-c42bebe28fbb), [React Native 0.56](https://facebook.github.io/react-native/blog/2018/07/04/releasing-react-native-056), and even [Wordpress's frontend](https://github.com/Automattic/wp-calypso) 🙂!
+Software is never going to be perfect but we're ready to ship something that's already been used in production for some time now! [`@babel/core`](https://www.npmjs.com/package/@babel/core) is already at 5.1 mil downloads/month because of its usage in tools like [Next.js 6](https://zeit.co/blog/next6), [vue-cli 3.0](https://medium.com/the-vue-point/vue-cli-3-0-is-here-c42bebe28fbb), [React Native 0.56](https://facebook.github.io/react-native/blog/2018/07/04/releasing-react-native-056), and even [WordPress.com's frontend](https://github.com/Automattic/wp-calypso) 🙂!
 
 ## Babel's Role
 


### PR DESCRIPTION
Makes the "P" in "WordPress" capital and changes "WordPress" to "WordPress.com", which is a more precise description of the Calypso frontend: it's part of the commercial service rather than the open source WordPress software itself.