### PR TITLE
`targets.browser` => `targets.browsers`

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -149,7 +149,7 @@ If you want to compile against the current node version, you can specify `"node"
 
 If you want to compile against the [technology preview](https://developer.apple.com/safari/technology-preview/) version of Safari, you can specify `"safari": "tp"`.
 
-#### `targets.browser`
+#### `targets.browsers`
 
 `string | Array<string>`.
 


### PR DESCRIPTION
Seems this is a typo