### PR TITLE
Fix sidebar labels for scoped packages

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 ---
 id: babel-cli
 title: @babel/cli
-sidebar_label: babel-cli
+sidebar_label: cli
 ---
 
 Babel comes with a built-in CLI which can be used to compile files from the command line.

--- a/docs/code-frame.md
+++ b/docs/code-frame.md
@@ -1,7 +1,7 @@
 ---
 id: babel-code-frame
 title: @babel/code-frame
-sidebar_label: babel-code-frame
+sidebar_label: code-frame
 ---
 
 ## Install

--- a/docs/core.md
+++ b/docs/core.md
@@ -1,7 +1,7 @@
 ---
 id: babel-core
 title: @babel/core
-sidebar_label: babel-core
+sidebar_label: core
 ---
 
 ```javascript

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -1,7 +1,7 @@
 ---
 id: babel-generator
 title: @babel/generator
-sidebar_label: babel-generator
+sidebar_label: generator
 ---
 
 ## Install

--- a/docs/helper-annotate-as-pure.md
+++ b/docs/helper-annotate-as-pure.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-annotate-as-pure
 title: @babel/helper-annotate-as-pure
-sidebar_label: babel-helper-annotate-as-pure
+sidebar_label: helper-annotate-as-pure
 ---
 
 ```js

--- a/docs/helper-bindify-decorators.md
+++ b/docs/helper-bindify-decorators.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-bindify-decorators
 title: @babel/helper-bindify-decorators
-sidebar_label: babel-helper-bindify-decorators
+sidebar_label: helper-bindify-decorators
 ---
 
 ```js

--- a/docs/helper-builder-binary-assignment-operator-visitor.md
+++ b/docs/helper-builder-binary-assignment-operator-visitor.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-builder-binary-assignment-operator-visitor
 title: @babel/helper-builder-binary-assignment-operator-visitor
-sidebar_label: babel-helper-builder-binary-assignment-operator-visitor
+sidebar_label: helper-builder-binary-assignment-operator-visitor
 ---
 
 TODO

--- a/docs/helper-builder-react-jsx.md
+++ b/docs/helper-builder-react-jsx.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-builder-react-jsx
 title: @babel/helper-builder-react-jsx
-sidebar_label: babel-helper-builder-react-jsx
+sidebar_label: helper-builder-react-jsx
 ---
 
 ```javascript

--- a/docs/helper-call-delegate.md
+++ b/docs/helper-call-delegate.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-call-delegate
 title: @babel/helper-call-delegate
-sidebar_label: babel-helper-call-delegate
+sidebar_label: helper-call-delegate
 ---
 
 TODO

--- a/docs/helper-define-map.md
+++ b/docs/helper-define-map.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-define-map
 title: @babel/helper-define-map
-sidebar_label: babel-helper-define-map
+sidebar_label: helper-define-map
 ---
 
 TODO

--- a/docs/helper-explode-assignable-expression.md
+++ b/docs/helper-explode-assignable-expression.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-explode-assignable-expression
 title: @babel/helper-explode-assignable-expression
-sidebar_label: babel-helper-explode-assignable-expression
+sidebar_label: helper-explode-assignable-expression
 ---
 
 TODO

--- a/docs/helper-explode-class.md
+++ b/docs/helper-explode-class.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-explode-class
 title: @babel/helper-explode-class
-sidebar_label: babel-helper-explode-class
+sidebar_label: helper-explode-class
 ---
 
 TODO

--- a/docs/helper-fixtures.md
+++ b/docs/helper-fixtures.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-fixtures
 title: @babel/helper-fixtures
-sidebar_label: babel-helper-fixtures
+sidebar_label: helper-fixtures
 ---
 
 ## Usage

--- a/docs/helper-function-name.md
+++ b/docs/helper-function-name.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-function-name
 title: @babel/helper-function-name
-sidebar_label: babel-helper-function-name
+sidebar_label: helper-function-name
 ---
 
 TODO

--- a/docs/helper-get-function-arity.md
+++ b/docs/helper-get-function-arity.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-get-function-arity
 title: @babel/helper-get-function-arity
-sidebar_label: babel-helper-get-function-arity
+sidebar_label: helper-get-function-arity
 ---
 
 

--- a/docs/helper-hoist-variables.md
+++ b/docs/helper-hoist-variables.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-hoist-variables
 title: @babel/helper-hoist-variables
-sidebar_label: babel-helper-hoist-variables
+sidebar_label: helper-hoist-variables
 ---
 
 ```sh

--- a/docs/helper-member-expression-to-functions.md
+++ b/docs/helper-member-expression-to-functions.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-member-expression-to-functions
 title: @babel/helper-member-expression-to-functions
-sidebar_label: babel-helper-member-expression-to-functions
+sidebar_label: helper-member-expression-to-functions
 ---
 
 ## Usage

--- a/docs/helper-module-imports.md
+++ b/docs/helper-module-imports.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-module-imports
 title: @babel/helper-module-imports
-sidebar_label: babel-helper-module-imports
+sidebar_label: helper-module-imports
 ---
 
 ```sh

--- a/docs/helper-module-transforms.md
+++ b/docs/helper-module-transforms.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-module-transforms
 title: @babel/helper-module-transforms
-sidebar_label: babel-helper-module-transforms
+sidebar_label: helper-module-transforms
 ---
 
 TODO

--- a/docs/helper-optimise-call-expression.md
+++ b/docs/helper-optimise-call-expression.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-optimise-call-expression
 title: @babel/helper-optimise-call-expression
-sidebar_label: babel-helper-optimise-call-expression
+sidebar_label: helper-optimise-call-expression
 ---
 
 TODO

--- a/docs/helper-plugin-test-runner.md
+++ b/docs/helper-plugin-test-runner.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-plugin-test-runner
 title: @babel/helper-plugin-test-runner
-sidebar_label: babel-helper-plugin-test-runner
+sidebar_label: helper-plugin-test-runner
 ---
 
 ## Usage:

--- a/docs/helper-plugin-utils.md
+++ b/docs/helper-plugin-utils.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-plugin-utils
 title: @babel/helper-plugin-utils
-sidebar_label: babel-helper-plugin-utils
+sidebar_label: helper-plugin-utils
 ---
 
 

--- a/docs/helper-regex.md
+++ b/docs/helper-regex.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-regex
 title: @babel/helper-regex
-sidebar_label: babel-helper-regex
+sidebar_label: helper-regex
 ---
 
 TODO

--- a/docs/helper-remap-async-to-generator.md
+++ b/docs/helper-remap-async-to-generator.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-remap-async-to-generator
 title: @babel/helper-remap-async-to-generator
-sidebar_label: babel-helper-remap-async-to-generator
+sidebar_label: helper-remap-async-to-generator
 ---
 
 TODO

--- a/docs/helper-replace-supers.md
+++ b/docs/helper-replace-supers.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-replace-supers
 title: @babel/helper-replace-supers
-sidebar_label: babel-helper-replace-supers
+sidebar_label: helper-replace-supers
 ---
 
 TODO

--- a/docs/helper-simple-access.md
+++ b/docs/helper-simple-access.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-simple-access
 title: @babel/helper-simple-access
-sidebar_label: babel-helper-simple-access
+sidebar_label: helper-simple-access
 ---
 
 to a given variable, and there are cases like

--- a/docs/helper-split-export-declaration.md
+++ b/docs/helper-split-export-declaration.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-split-export-declaration
 title: @babel/helper-split-export-declaration
-sidebar_label: babel-helper-split-export-declaration
+sidebar_label: helper-split-export-declaration
 ---
 
 ```js

--- a/docs/helper-transform-fixture-test-runner.md
+++ b/docs/helper-transform-fixture-test-runner.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-transform-fixture-test-runner
 title: @babel/helper-transform-fixture-test-runner
-sidebar_label: babel-helper-transform-fixture-test-runner
+sidebar_label: helper-transform-fixture-test-runner
 ---
 
 ## Usage

--- a/docs/helper-wrap-function.md
+++ b/docs/helper-wrap-function.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helper-wrap-function
 title: @babel/helper-wrap-function
-sidebar_label: babel-helper-wrap-function
+sidebar_label: helper-wrap-function
 ---
 
 ## Example

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,7 +1,7 @@
 ---
 id: babel-helpers
 title: @babel/helpers
-sidebar_label: babel-helpers
+sidebar_label: helpers
 ---
 
 ## Install

--- a/docs/highlight.md
+++ b/docs/highlight.md
@@ -1,7 +1,7 @@
 ---
 id: babel-highlight
 title: @babel/highlight
-sidebar_label: babel-highlight
+sidebar_label: highlight
 ---
 
 ## Install

--- a/docs/node.md
+++ b/docs/node.md
@@ -1,7 +1,7 @@
 ---
 id: babel-node
 title: @babel/node
-sidebar_label: babel-node
+sidebar_label: node
 ---
 
 babel-node is a CLI that works exactly the same as the Node.js CLI, with the added benefit of compiling with Babel presets and plugins before running it.

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,7 +1,7 @@
 ---
 id: babel-parser
 title: @babel/parser
-sidebar_label: babel-parser
+sidebar_label: parser
 ---
 
 <p align="left">

--- a/docs/polyfill.md
+++ b/docs/polyfill.md
@@ -1,7 +1,7 @@
 ---
 id: babel-polyfill
 title: @babel/polyfill
-sidebar_label: babel-polyfill
+sidebar_label: polyfill
 ---
 
 Babel includes a [polyfill](https://en.wikipedia.org/wiki/Polyfill_(programming)) that includes a custom [regenerator runtime](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js) and [core-js](https://github.com/zloirock/core-js).

--- a/docs/register.md
+++ b/docs/register.md
@@ -1,7 +1,7 @@
 ---
 id: babel-register
 title: @babel/register
-sidebar_label: babel-register
+sidebar_label: register
 ---
 
 One of the ways you can use Babel is through the require hook. The require hook

--- a/docs/runtime-corejs2.md
+++ b/docs/runtime-corejs2.md
@@ -1,7 +1,7 @@
 ---
 id: babel-runtime-corejs2
 title: @babel/runtime-corejs2
-sidebar_label: babel-runtime-corejs2
+sidebar_label: runtime-corejs2
 ---
 
 `@babel/runtime-corejs2` is a library that contain's Babel modular runtime helpers and a version of `regenerator-runtime` as well as [`core-js`](https://github.com/zloirock/core-js).

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,7 +1,7 @@
 ---
 id: babel-runtime
 title: @babel/runtime
-sidebar_label: babel-runtime
+sidebar_label: runtime
 ---
 
 `@babel/runtime` is a library that contain's Babel modular runtime helpers and a version of `regenerator-runtime`.

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,7 +1,7 @@
 ---
 id: babel-standalone
 title: @babel/standalone
-sidebar_label: babel-standalone
+sidebar_label: standalone
 ---
 
 

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,7 +1,7 @@
 ---
 id: babel-template
 title: @babel/template
-sidebar_label: babel-template
+sidebar_label: template
 ---
 
 In computer science, this is known as an implementation of quasiquotes.

--- a/docs/traverse.md
+++ b/docs/traverse.md
@@ -1,7 +1,7 @@
 ---
 id: babel-traverse
 title: @babel/traverse
-sidebar_label: babel-traverse
+sidebar_label: traverse
 ---
 
 ## Install

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,7 +1,7 @@
 ---
 id: babel-types
 title: @babel/types
-sidebar_label: babel-types
+sidebar_label: types
 ---
 
 ## Install

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -4,414 +4,2343 @@
     "next": "Next",
     "previous": "Previous",
     "tagline": "The compiler for next generation JavaScript",
-    "babelconfigjs": "babel.config.js",
-    "babelrc": ".babelrc",
-    "caveats": "Caveats",
-    "babel-cli": "babel-cli",
-    "babel-code-frame": "babel-code-frame",
-    "config-files": "Config Files",
-    "configuration": "Configure Babel",
-    "core-packages": "Babel's core packages",
-    "babel-core": "babel-core",
-    "editors": "Editors",
-    "env": "env",
-    "faq": "FAQ",
-    "babel-generator": "babel-generator",
-    "gulp-babel-minify": "gulp-babel-minify",
-    "babel-helper-annotate-as-pure": "babel-helper-annotate-as-pure",
-    "babel-helper-bindify-decorators": "babel-helper-bindify-decorators",
-    "babel-helper-builder-binary-assignment-operator-visitor": "babel-helper-builder-binary-assignment-operator-visitor",
-    "babel-helper-builder-react-jsx": "babel-helper-builder-react-jsx",
-    "babel-helper-call-delegate": "babel-helper-call-delegate",
-    "babel-helper-define-map": "babel-helper-define-map",
-    "babel-helper-evaluate-path": "babel-helper-evaluate-path",
-    "babel-helper-explode-assignable-expression": "babel-helper-explode-assignable-expression",
-    "babel-helper-explode-class": "babel-helper-explode-class",
-    "babel-helper-fixtures": "babel-helper-fixtures",
-    "babel-helper-flip-expressions": "babel-helper-flip-expressions",
-    "babel-helper-function-name": "babel-helper-function-name",
-    "babel-helper-get-function-arity": "babel-helper-get-function-arity",
-    "babel-helper-hoist-variables": "babel-helper-hoist-variables",
-    "babel-helper-is-void-0": "babel-helper-is-void-0",
-    "babel-helper-mark-eval-scopes": "babel-helper-mark-eval-scopes",
-    "babel-helper-member-expression-to-functions": "babel-helper-member-expression-to-functions",
-    "babel-helper-module-imports": "babel-helper-module-imports",
-    "babel-helper-module-transforms": "babel-helper-module-transforms",
-    "babel-helper-optimise-call-expression": "babel-helper-optimise-call-expression",
-    "babel-helper-plugin-test-runner": "babel-helper-plugin-test-runner",
-    "babel-helper-plugin-utils": "babel-helper-plugin-utils",
-    "babel-helper-regex": "babel-helper-regex",
-    "babel-helper-remap-async-to-generator": "babel-helper-remap-async-to-generator",
-    "babel-helper-remove-or-void": "babel-helper-remove-or-void",
-    "babel-helper-replace-supers": "babel-helper-replace-supers",
-    "babel-helper-simple-access": "babel-helper-simple-access",
-    "babel-helper-split-export-declaration": "babel-helper-split-export-declaration",
-    "babel-helper-to-multiple-sequence-expressions": "babel-helper-to-multiple-sequence-expressions",
-    "babel-helper-transform-fixture-test-runner": "babel-helper-transform-fixture-test-runner",
-    "babel-helper-wrap-function": "babel-helper-wrap-function",
-    "babel-helpers": "babel-helpers",
-    "babel-highlight": "babel-highlight",
-    "index": "What is Babel?",
-    "learn": "Learn ES2015",
-    "babel-minify": "babel-minify",
-    "babel-node": "babel-node",
-    "options": "Options",
-    "babel-parser": "babel-parser",
-    "babel-plugin-external-helpers": "@babel/plugin-external-helpers",
-    "external-helpers": "external-helpers",
-    "babel-plugin-minify-builtins": "babel-plugin-minify-builtins",
-    "minify-builtins": "minify-builtins",
-    "babel-plugin-minify-constant-folding": "babel-plugin-minify-constant-folding",
-    "minify-constant-folding": "minify-constant-folding",
-    "babel-plugin-minify-dead-code-elimination": "babel-plugin-minify-dead-code-elimination",
-    "minify-dead-code-elimination": "minify-dead-code-elimination",
-    "babel-plugin-minify-flip-comparisons": "babel-plugin-minify-flip-comparisons",
-    "minify-flip-comparisons": "minify-flip-comparisons",
-    "babel-plugin-minify-guarded-expressions": "babel-plugin-minify-guarded-expressions",
-    "minify-guarded-expressions": "minify-guarded-expressions",
-    "babel-plugin-minify-infinity": "babel-plugin-minify-infinity",
-    "minify-infinity": "minify-infinity",
-    "babel-plugin-minify-mangle-names": "babel-plugin-minify-mangle-names",
-    "minify-mangle-names": "minify-mangle-names",
-    "babel-plugin-minify-numeric-literals": "babel-plugin-minify-numeric-literals",
-    "minify-numeric-literals": "minify-numeric-literals",
-    "babel-plugin-minify-replace": "babel-plugin-minify-replace",
-    "minify-replace": "minify-replace",
-    "babel-plugin-minify-simplify": "babel-plugin-minify-simplify",
-    "minify-simplify": "minify-simplify",
-    "babel-plugin-minify-type-constructors": "babel-plugin-minify-type-constructors",
-    "minify-type-constructors": "minify-type-constructors",
-    "babel-plugin-proposal-async-generator-functions": "@babel/plugin-proposal-async-generator-functions",
-    "proposal-async-generator-functions": "proposal-async-generator-functions",
-    "babel-plugin-proposal-class-properties": "@babel/plugin-proposal-class-properties",
-    "proposal-class-properties": "proposal-class-properties",
-    "babel-plugin-proposal-decorators": "@babel/plugin-proposal-decorators",
-    "proposal-decorators": "proposal-decorators",
-    "babel-plugin-proposal-do-expressions": "@babel/plugin-proposal-do-expressions",
-    "proposal-do-expressions": "proposal-do-expressions",
-    "babel-plugin-proposal-export-default-from": "@babel/plugin-proposal-export-default-from",
-    "proposal-export-default-from": "proposal-export-default-from",
-    "babel-plugin-proposal-export-namespace-from": "@babel/plugin-proposal-export-namespace-from",
-    "proposal-export-namespace-from": "proposal-export-namespace-from",
-    "babel-plugin-proposal-function-bind": "@babel/plugin-proposal-function-bind",
-    "proposal-function-bind": "proposal-function-bind",
-    "babel-plugin-proposal-function-sent": "@babel/plugin-proposal-function-sent",
-    "proposal-function-sent": "proposal-function-sent",
-    "babel-plugin-proposal-json-strings": "@babel/plugin-proposal-json-strings",
-    "proposal-json-strings": "proposal-json-strings",
-    "babel-plugin-proposal-logical-assignment-operators": "@babel/plugin-proposal-logical-assignment-operators",
-    "proposal-logical-assignment-operators": "proposal-logical-assignment-operators",
-    "babel-plugin-proposal-nullish-coalescing-operator": "@babel/plugin-proposal-nullish-coalescing-operator",
-    "proposal-nullish-coalescing-operator": "proposal-nullish-coalescing-operator",
-    "babel-plugin-proposal-numeric-separator": "@babel/plugin-proposal-numeric-separator",
-    "proposal-numeric-separator": "proposal-numeric-separator",
-    "babel-plugin-proposal-object-rest-spread": "@babel/plugin-proposal-object-rest-spread",
-    "proposal-object-rest-spread": "proposal-object-rest-spread",
-    "babel-plugin-proposal-optional-catch-binding": "@babel/plugin-proposal-optional-catch-binding",
-    "proposal-optional-catch-binding": "proposal-optional-catch-binding",
-    "babel-plugin-proposal-optional-chaining": "@babel/plugin-proposal-optional-chaining",
-    "proposal-optional-chaining": "proposal-optional-chaining",
-    "babel-plugin-proposal-pipeline-operator": "@babel/plugin-proposal-pipeline-operator",
-    "proposal-pipeline-operator": "proposal-pipeline-operator",
-    "babel-plugin-proposal-throw-expressions": "@babel/plugin-proposal-throw-expressions",
-    "proposal-throw-expressions": "proposal-throw-expressions",
-    "babel-plugin-proposal-unicode-property-regex": "@babel/plugin-proposal-unicode-property-regex",
-    "proposal-unicode-property-regex": "proposal-unicode-property-regex",
-    "babel-plugin-syntax-async-generators": "@babel/plugin-syntax-async-generators",
-    "syntax-async-generators": "syntax-async-generators",
-    "babel-plugin-syntax-bigint": "@babel/plugin-syntax-bigint",
-    "syntax-bigint": "syntax-bigint",
-    "babel-plugin-syntax-class-properties": "@babel/plugin-syntax-class-properties",
-    "syntax-class-properties": "syntax-class-properties",
-    "babel-plugin-syntax-decorators": "@babel/plugin-syntax-decorators",
-    "syntax-decorators": "syntax-decorators",
-    "babel-plugin-syntax-do-expressions": "@babel/plugin-syntax-do-expressions",
-    "syntax-do-expressions": "syntax-do-expressions",
-    "babel-plugin-syntax-dynamic-import": "@babel/plugin-syntax-dynamic-import",
-    "syntax-dynamic-import": "syntax-dynamic-import",
-    "babel-plugin-syntax-export-default-from": "@babel/plugin-syntax-export-default-from",
-    "syntax-export-default-from": "syntax-export-default-from",
-    "babel-plugin-syntax-export-namespace-from": "@babel/plugin-syntax-export-namespace-from",
-    "syntax-export-namespace-from": "syntax-export-namespace-from",
-    "babel-plugin-syntax-flow": "@babel/plugin-syntax-flow",
-    "syntax-flow": "syntax-flow",
-    "babel-plugin-syntax-function-bind": "@babel/plugin-syntax-function-bind",
-    "syntax-function-bind": "syntax-function-bind",
-    "babel-plugin-syntax-function-sent": "@babel/plugin-syntax-function-sent",
-    "syntax-function-sent": "syntax-function-sent",
-    "babel-plugin-syntax-import-meta": "@babel/plugin-syntax-import-meta",
-    "syntax-import-meta": "syntax-import-meta",
-    "babel-plugin-syntax-json-strings": "@babel/plugin-syntax-json-strings",
-    "syntax-json-strings": "syntax-json-strings",
-    "babel-plugin-syntax-jsx": "@babel/plugin-syntax-jsx",
-    "syntax-jsx": "syntax-jsx",
-    "babel-plugin-syntax-logical-assignment-operators": "@babel/plugin-syntax-logical-assignment-operators",
-    "syntax-logical-assignment-operators": "syntax-logical-assignment-operators",
-    "babel-plugin-syntax-nullish-coalescing-operator": "@babel/plugin-syntax-nullish-coalescing-operator",
-    "syntax-nullish-coalescing-operator": "syntax-nullish-coalescing-operator",
-    "babel-plugin-syntax-numeric-separator": "@babel/plugin-syntax-numeric-separator",
-    "syntax-numeric-separator": "syntax-numeric-separator",
-    "babel-plugin-syntax-object-rest-spread": "@babel/plugin-syntax-object-rest-spread",
-    "syntax-object-rest-spread": "syntax-object-rest-spread",
-    "babel-plugin-syntax-optional-catch-binding": "@babel/plugin-syntax-optional-catch-binding",
-    "syntax-optional-catch-binding": "syntax-optional-catch-binding",
-    "babel-plugin-syntax-optional-chaining": "@babel/plugin-syntax-optional-chaining",
-    "syntax-optional-chaining": "syntax-optional-chaining",
-    "babel-plugin-syntax-pipeline-operator": "@babel/plugin-syntax-pipeline-operator",
-    "syntax-pipeline-operator": "syntax-pipeline-operator",
-    "babel-plugin-syntax-throw-expressions": "@babel/plugin-syntax-throw-expressions",
-    "syntax-throw-expressions": "syntax-throw-expressions",
-    "babel-plugin-syntax-typescript": "@babel/plugin-syntax-typescript",
-    "syntax-typescript": "syntax-typescript",
-    "babel-plugin-transform-arrow-functions": "@babel/plugin-transform-arrow-functions",
-    "transform-arrow-functions": "transform-arrow-functions",
-    "babel-plugin-transform-async-to-generator": "@babel/plugin-transform-async-to-generator",
-    "transform-async-to-generator": "transform-async-to-generator",
-    "babel-plugin-transform-block-scoped-functions": "@babel/plugin-transform-block-scoped-functions",
-    "transform-block-scoped-functions": "transform-block-scoped-functions",
-    "babel-plugin-transform-block-scoping": "@babel/plugin-transform-block-scoping",
-    "transform-block-scoping": "transform-block-scoping",
-    "babel-plugin-transform-classes": "@babel/plugin-transform-classes",
-    "transform-classes": "transform-classes",
-    "babel-plugin-transform-computed-properties": "@babel/plugin-transform-computed-properties",
-    "transform-computed-properties": "transform-computed-properties",
-    "babel-plugin-transform-destructuring": "@babel/plugin-transform-destructuring",
-    "transform-destructuring": "transform-destructuring",
-    "babel-plugin-transform-dotall-regex": "@babel/plugin-transform-dotall-regex",
-    "transform-dotall-regex": "transform-dotall-regex",
-    "babel-plugin-transform-duplicate-keys": "@babel/plugin-transform-duplicate-keys",
-    "transform-duplicate-keys": "transform-duplicate-keys",
-    "babel-plugin-transform-exponentiation-operator": "@babel/plugin-transform-exponentiation-operator",
-    "transform-exponentiation-operator": "transform-exponentiation-operator",
-    "babel-plugin-transform-flow-comments": "@babel/plugin-transform-flow-comments",
-    "transform-flow-comments": "transform-flow-comments",
-    "babel-plugin-transform-flow-strip-types": "@babel/plugin-transform-flow-strip-types",
-    "transform-flow-strip-types": "transform-flow-strip-types",
-    "babel-plugin-transform-for-of": "@babel/plugin-transform-for-of",
-    "transform-for-of": "transform-for-of",
-    "babel-plugin-transform-function-name": "@babel/plugin-transform-function-name",
-    "transform-function-name": "transform-function-name",
-    "babel-plugin-transform-inline-consecutive-adds": "@babel/plugin-transform-inline-consecutive-adds",
-    "transform-inline-consecutive-adds": "transform-inline-consecutive-adds",
-    "babel-plugin-transform-inline-environment-variables": "babel-plugin-transform-inline-environment-variables",
-    "transform-inline-environment-variables": "transform-inline-environment-variables",
-    "babel-plugin-transform-instanceof": "@babel/plugin-transform-instanceof",
-    "transform-instanceof": "transform-instanceof",
-    "babel-plugin-transform-jscript": "@babel/plugin-transform-jscript",
-    "transform-jscript": "transform-jscript",
-    "babel-plugin-transform-literals": "@babel/plugin-transform-literals",
-    "transform-literals": "transform-literals",
-    "babel-plugin-transform-member-expression-literals": "babel-plugin-transform-member-expression-literals",
-    "transform-member-expression-literals": "transform-member-expression-literals",
-    "babel-plugin-transform-merge-sibling-variables": "babel-plugin-transform-merge-sibling-variables",
-    "transform-merge-sibling-variables": "transform-merge-sibling-variables",
-    "babel-plugin-transform-minify-booleans": "babel-plugin-transform-minify-booleans",
-    "transform-minify-booleans": "transform-minify-booleans",
-    "babel-plugin-transform-modules-amd": "@babel/plugin-transform-modules-amd",
-    "transform-modules-amd": "transform-modules-amd",
-    "babel-plugin-transform-modules-commonjs": "@babel/plugin-transform-modules-commonjs",
-    "transform-modules-commonjs": "transform-modules-commonjs",
-    "babel-plugin-transform-modules-systemjs": "@babel/plugin-transform-modules-systemjs",
-    "transform-modules-systemjs": "transform-modules-systemjs",
-    "babel-plugin-transform-modules-umd": "@babel/plugin-transform-modules-umd",
-    "transform-modules-umd": "transform-modules-umd",
-    "babel-plugin-transform-new-target": "@babel/plugin-transform-new-target",
-    "transform-new-target": "transform-new-target",
-    "babel-plugin-transform-node-env-inline": "babel-plugin-transform-node-env-inline",
-    "transform-node-env-inline": "transform-node-env-inline",
-    "babel-plugin-transform-object-assign": "@babel/plugin-transform-object-assign",
-    "transform-object-assign": "transform-object-assign",
-    "babel-plugin-transform-object-set-prototype-of-to-assign": "@babel/plugin-transform-object-set-prototype-of-to-assign",
-    "transform-object-set-prototype-of-to-assign": "transform-object-set-prototype-of-to-assign",
-    "babel-plugin-transform-object-super": "@babel/plugin-transform-object-super",
-    "transform-object-super": "transform-object-super",
-    "babel-plugin-transform-parameters": "@babel/plugin-transform-parameters",
-    "transform-parameters": "transform-parameters",
-    "babel-plugin-transform-property-literals": "babel-plugin-transform-property-literals",
-    "transform-property-literals": "transform-property-literals",
-    "babel-plugin-transform-property-mutators": "@babel/plugin-transform-property-mutators",
-    "transform-property-mutators": "transform-property-mutators",
-    "babel-plugin-transform-proto-to-assign": "@babel/plugin-transform-proto-to-assign",
-    "transform-proto-to-assign": "transform-proto-to-assign",
-    "babel-plugin-transform-react-constant-elements": "@babel/plugin-transform-react-constant-elements",
-    "transform-react-constant-elements": "transform-react-constant-elements",
-    "babel-plugin-transform-react-display-name": "@babel/plugin-transform-react-display-name",
-    "transform-react-display-name": "transform-react-display-name",
-    "babel-plugin-transform-react-inline-elements": "@babel/plugin-transform-react-inline-elements",
-    "transform-react-inline-elements": "transform-react-inline-elements",
-    "babel-plugin-transform-react-jsx-compat": "@babel/plugin-transform-react-jsx-compat",
-    "transform-react-jsx-compat": "transform-react-jsx-compat",
-    "babel-plugin-transform-react-jsx-self": "@babel/plugin-transform-react-jsx-self",
-    "transform-react-jsx-self": "transform-react-jsx-self",
-    "babel-plugin-transform-react-jsx-source": "@babel/plugin-transform-react-jsx-source",
-    "transform-react-jsx-source": "transform-react-jsx-source",
-    "babel-plugin-transform-react-jsx": "@babel/plugin-transform-react-jsx",
-    "transform-react-jsx": "transform-react-jsx",
-    "babel-plugin-transform-regenerator": "@babel/plugin-transform-regenerator",
-    "transform-regenerator": "transform-regenerator",
-    "babel-plugin-transform-regexp-constructors": "babel-plugin-transform-regexp-constructors",
-    "transform-regexp-constructors": "transform-regexp-constructors",
-    "babel-plugin-transform-remove-console": "babel-plugin-transform-remove-console",
-    "transform-remove-console": "transform-remove-console",
-    "babel-plugin-transform-remove-debugger": "babel-plugin-transform-remove-debugger",
-    "transform-remove-debugger": "transform-remove-debugger",
-    "babel-plugin-transform-remove-undefined": "babel-plugin-transform-remove-undefined",
-    "transform-remove-undefined": "transform-remove-undefined",
-    "babel-plugin-transform-reserved-words": "@babel/plugin-transform-reserved-words",
-    "transform-reserved-words": "transform-reserved-words",
-    "babel-plugin-transform-runtime": "@babel/plugin-transform-runtime",
-    "transform-runtime": "transform-runtime",
-    "babel-plugin-transform-shorthand-properties": "@babel/plugin-transform-shorthand-properties",
-    "transform-shorthand-properties": "transform-shorthand-properties",
-    "babel-plugin-transform-simplify-comparison-operators": "babel-plugin-transform-simplify-comparison-operators",
-    "transform-simplify-comparison-operators": "transform-simplify-comparison-operators",
-    "babel-plugin-transform-spread": "@babel/plugin-transform-spread",
-    "transform-spread": "transform-spread",
-    "babel-plugin-transform-sticky-regex": "@babel/plugin-transform-sticky-regex",
-    "transform-sticky-regex": "transform-sticky-regex",
-    "babel-plugin-transform-strict-mode": "@babel/plugin-transform-strict-mode",
-    "transform-strict-mode": "transform-strict-mode",
-    "babel-plugin-transform-template-literals": "@babel/plugin-transform-template-literals",
-    "transform-template-literals": "transform-template-literals",
-    "babel-plugin-transform-typeof-symbol": "@babel/plugin-transform-typeof-symbol",
-    "transform-typeof-symbol": "transform-typeof-symbol",
-    "babel-plugin-transform-typescript": "@babel/plugin-transform-typescript",
-    "transform-typescript": "transform-typescript",
-    "babel-plugin-transform-undefined-to-void": "babel-plugin-transform-undefined-to-void",
-    "transform-undefined-to-void": "transform-undefined-to-void",
-    "babel-plugin-transform-unicode-regex": "@babel/plugin-transform-unicode-regex",
-    "transform-unicode-regex": "transform-unicode-regex",
-    "plugins": "Plugins",
-    "babel-polyfill": "babel-polyfill",
-    "babel-preset-env-standalone": "@babel/preset-env-standalone",
-    "env-standalone": "env-standalone",
-    "babel-preset-env": "@babel/preset-env",
-    "babel-preset-es2015": "@babel/preset-es2015",
-    "es2015": "es2015",
-    "babel-preset-es2016": "@babel/preset-es2016",
-    "es2016": "es2016",
-    "babel-preset-es2017": "@babel/preset-es2017",
-    "es2017": "es2017",
-    "babel-preset-flow": "@babel/preset-flow",
-    "flow": "flow",
-    "babel-preset-minify": "babel-preset-minify",
-    "minify": "minify",
-    "babel-preset-react": "@babel/preset-react",
-    "react": "react",
-    "babel-preset-stage-0": "@babel/preset-stage-0",
-    "stage-0": "stage-0",
-    "babel-preset-stage-1": "@babel/preset-stage-1",
-    "stage-1": "stage-1",
-    "babel-preset-stage-2": "@babel/preset-stage-2",
-    "stage-2": "stage-2",
-    "babel-preset-stage-3": "@babel/preset-stage-3",
-    "stage-3": "stage-3",
-    "babel-preset-typescript": "@babel/preset-typescript",
-    "typescript": "typescript",
-    "presets": "Presets",
-    "babel-register": "babel-register",
-    "roadmap": "Babel Roadmap",
-    "Roadmap": "Roadmap",
-    "babel-runtime-corejs2": "babel-runtime-corejs2",
-    "babel-runtime": "babel-runtime",
-    "babel-standalone": "babel-standalone",
-    "babel-template": "babel-template",
-    "tools/ava/install": "tools/ava/install",
-    "tools/ava/usage": "tools/ava/usage",
-    "tools/babel_cli/install": "tools/babel_cli/install",
-    "tools/babel_cli/usage": "tools/babel_cli/usage",
-    "tools/babel_node_debug/install": "tools/babel_node_debug/install",
-    "tools/babel_node_debug/usage": "tools/babel_node_debug/usage",
-    "tools/babel_register/install": "tools/babel_register/install",
-    "tools/babel_register/usage": "tools/babel_register/usage",
-    "tools/broccoli/install": "tools/broccoli/install",
-    "tools/broccoli/usage": "tools/broccoli/usage",
-    "tools/browser/install": "tools/browser/install",
-    "tools/browser/usage": "tools/browser/usage",
-    "tools/browserify/install": "tools/browserify/install",
-    "tools/browserify/usage": "tools/browserify/usage",
-    "tools/brunch/install": "tools/brunch/install",
-    "tools/brunch/usage": "tools/brunch/usage",
-    "tools/connect/install": "tools/connect/install",
-    "tools/connect/usage": "tools/connect/usage",
-    "tools/dotnet/install": "tools/dotnet/install",
-    "tools/dotnet/usage": "tools/dotnet/usage",
-    "tools/duo/install": "tools/duo/install",
-    "tools/duo/usage": "tools/duo/usage",
-    "tools/ember/install": "tools/ember/install",
-    "tools/ember/usage": "tools/ember/usage",
-    "tools/fly/install": "tools/fly/install",
-    "tools/fly/usage": "tools/fly/usage",
-    "tools/gobble/install": "tools/gobble/install",
-    "tools/gobble/usage": "tools/gobble/usage",
-    "tools/grunt/install": "tools/grunt/install",
-    "tools/grunt/usage": "tools/grunt/usage",
-    "tools/gulp/install": "tools/gulp/install",
-    "tools/gulp/usage": "tools/gulp/usage",
-    "tools/jasmine/install": "tools/jasmine/install",
-    "tools/jasmine/usage": "tools/jasmine/usage",
-    "tools/jest/install": "tools/jest/install",
-    "tools/jest/usage": "tools/jest/usage",
-    "tools/jspm/install": "tools/jspm/install",
-    "tools/jspm/usage": "tools/jspm/usage",
-    "tools/karma/install": "tools/karma/install",
-    "tools/karma/usage": "tools/karma/usage",
-    "tools/lab/install": "tools/lab/install",
-    "tools/lab/usage": "tools/lab/usage",
-    "tools/make/install": "tools/make/install",
-    "tools/make/usage": "tools/make/usage",
-    "tools/metalsmith/install": "tools/metalsmith/install",
-    "tools/metalsmith/usage": "tools/metalsmith/usage",
-    "tools/meteor/install": "tools/meteor/install",
-    "tools/meteor/usage": "tools/meteor/usage",
-    "tools/mocha/install": "tools/mocha/install",
-    "tools/mocha/usage": "tools/mocha/usage",
-    "tools/msbuild/install": "tools/msbuild/install",
-    "tools/msbuild/usage": "tools/msbuild/usage",
-    "tools/node/install": "tools/node/install",
-    "tools/node/usage": "tools/node/usage",
-    "tools/nodemon/install": "tools/nodemon/install",
-    "tools/nodemon/usage": "tools/nodemon/usage",
-    "tools/pug/install": "tools/pug/install",
-    "tools/pug/usage": "tools/pug/usage",
-    "tools/rails/install": "tools/rails/install",
-    "tools/rails/usage": "tools/rails/usage",
-    "tools/requirejs/install": "tools/requirejs/install",
-    "tools/requirejs/usage": "tools/requirejs/usage",
-    "tools/rollup/install": "tools/rollup/install",
-    "tools/rollup/usage": "tools/rollup/usage",
-    "tools/ruby/install": "tools/ruby/install",
-    "tools/ruby/usage": "tools/ruby/usage",
-    "tools/sails/install": "tools/sails/install",
-    "tools/sails/usage": "tools/sails/usage",
-    "tools/setup": "tools/setup",
-    "tools/sprockets/install": "tools/sprockets/install",
-    "tools/sprockets/usage": "tools/sprockets/usage",
-    "tools/start/install": "tools/start/install",
-    "tools/start/usage": "tools/start/usage",
-    "tools/webpack/install": "tools/webpack/install",
-    "tools/webpack/usage": "tools/webpack/usage",
-    "tools/webpack2/install": "tools/webpack2/install",
-    "tools/webpack2/usage": "tools/webpack2/usage",
-    "tools/webstorm/install": "tools/webstorm/install",
-    "tools/webstorm/usage": "tools/webstorm/usage",
-    "babel-traverse": "babel-traverse",
-    "babel-types": "babel-types",
-    "usage": "Usage Guide",
-    "v7-migration-api": "Upgrade to Babel 7 (API)",
-    "v7-migration": "Upgrade to Babel 7",
-    "Docs": "Docs",
-    "Setup": "Setup",
-    "Try it out": "Try it out",
-    "Blog": "Blog",
-    "Donate": "Donate",
-    "Team": "Team",
-    "GitHub": "GitHub",
-    "Guides": "Guides",
-    "General": "General",
-    "Usage": "Usage",
-    "Presets": "Presets",
-    "Tooling": "Tooling"
+    "docs": {
+      "babelconfigjs": {
+        "title": "babel.config.js"
+      },
+      "babelrc": {
+        "title": ".babelrc"
+      },
+      "caveats": {
+        "title": "Caveats"
+      },
+      "babel-cli": {
+        "title": "@babel/cli",
+        "sidebar_label": "cli"
+      },
+      "babel-code-frame": {
+        "title": "@babel/code-frame",
+        "sidebar_label": "code-frame"
+      },
+      "config-files": {
+        "title": "Config Files"
+      },
+      "configuration": {
+        "title": "Configure Babel"
+      },
+      "core-packages": {
+        "title": "Babel's core packages"
+      },
+      "babel-core": {
+        "title": "@babel/core",
+        "sidebar_label": "core"
+      },
+      "editors": {
+        "title": "Editors"
+      },
+      "env": {
+        "title": "babel-preset-es2015 -> babel-preset-env"
+      },
+      "faq": {
+        "title": "FAQ"
+      },
+      "babel-generator": {
+        "title": "@babel/generator",
+        "sidebar_label": "generator"
+      },
+      "gulp-babel-minify": {
+        "title": "gulp-babel-minify",
+        "sidebar_label": "gulp-babel-minify"
+      },
+      "babel-helper-annotate-as-pure": {
+        "title": "@babel/helper-annotate-as-pure",
+        "sidebar_label": "helper-annotate-as-pure"
+      },
+      "babel-helper-bindify-decorators": {
+        "title": "@babel/helper-bindify-decorators",
+        "sidebar_label": "helper-bindify-decorators"
+      },
+      "babel-helper-builder-binary-assignment-operator-visitor": {
+        "title": "@babel/helper-builder-binary-assignment-operator-visitor",
+        "sidebar_label": "helper-builder-binary-assignment-operator-visitor"
+      },
+      "babel-helper-builder-react-jsx": {
+        "title": "@babel/helper-builder-react-jsx",
+        "sidebar_label": "helper-builder-react-jsx"
+      },
+      "babel-helper-call-delegate": {
+        "title": "@babel/helper-call-delegate",
+        "sidebar_label": "helper-call-delegate"
+      },
+      "babel-helper-define-map": {
+        "title": "@babel/helper-define-map",
+        "sidebar_label": "helper-define-map"
+      },
+      "babel-helper-evaluate-path": {
+        "title": "babel-helper-evaluate-path",
+        "sidebar_label": "babel-helper-evaluate-path"
+      },
+      "babel-helper-explode-assignable-expression": {
+        "title": "@babel/helper-explode-assignable-expression",
+        "sidebar_label": "helper-explode-assignable-expression"
+      },
+      "babel-helper-explode-class": {
+        "title": "@babel/helper-explode-class",
+        "sidebar_label": "helper-explode-class"
+      },
+      "babel-helper-fixtures": {
+        "title": "@babel/helper-fixtures",
+        "sidebar_label": "helper-fixtures"
+      },
+      "babel-helper-flip-expressions": {
+        "title": "babel-helper-flip-expressions",
+        "sidebar_label": "babel-helper-flip-expressions"
+      },
+      "babel-helper-function-name": {
+        "title": "@babel/helper-function-name",
+        "sidebar_label": "helper-function-name"
+      },
+      "babel-helper-get-function-arity": {
+        "title": "@babel/helper-get-function-arity",
+        "sidebar_label": "helper-get-function-arity"
+      },
+      "babel-helper-hoist-variables": {
+        "title": "@babel/helper-hoist-variables",
+        "sidebar_label": "helper-hoist-variables"
+      },
+      "babel-helper-is-void-0": {
+        "title": "babel-helper-is-void-0",
+        "sidebar_label": "babel-helper-is-void-0"
+      },
+      "babel-helper-mark-eval-scopes": {
+        "title": "babel-helper-mark-eval-scopes",
+        "sidebar_label": "babel-helper-mark-eval-scopes"
+      },
+      "babel-helper-member-expression-to-functions": {
+        "title": "@babel/helper-member-expression-to-functions",
+        "sidebar_label": "helper-member-expression-to-functions"
+      },
+      "babel-helper-module-imports": {
+        "title": "@babel/helper-module-imports",
+        "sidebar_label": "helper-module-imports"
+      },
+      "babel-helper-module-transforms": {
+        "title": "@babel/helper-module-transforms",
+        "sidebar_label": "helper-module-transforms"
+      },
+      "babel-helper-optimise-call-expression": {
+        "title": "@babel/helper-optimise-call-expression",
+        "sidebar_label": "helper-optimise-call-expression"
+      },
+      "babel-helper-plugin-test-runner": {
+        "title": "@babel/helper-plugin-test-runner",
+        "sidebar_label": "helper-plugin-test-runner"
+      },
+      "babel-helper-plugin-utils": {
+        "title": "@babel/helper-plugin-utils",
+        "sidebar_label": "helper-plugin-utils"
+      },
+      "babel-helper-regex": {
+        "title": "@babel/helper-regex",
+        "sidebar_label": "helper-regex"
+      },
+      "babel-helper-remap-async-to-generator": {
+        "title": "@babel/helper-remap-async-to-generator",
+        "sidebar_label": "helper-remap-async-to-generator"
+      },
+      "babel-helper-remove-or-void": {
+        "title": "babel-helper-remove-or-void",
+        "sidebar_label": "babel-helper-remove-or-void"
+      },
+      "babel-helper-replace-supers": {
+        "title": "@babel/helper-replace-supers",
+        "sidebar_label": "helper-replace-supers"
+      },
+      "babel-helper-simple-access": {
+        "title": "@babel/helper-simple-access",
+        "sidebar_label": "helper-simple-access"
+      },
+      "babel-helper-split-export-declaration": {
+        "title": "@babel/helper-split-export-declaration",
+        "sidebar_label": "helper-split-export-declaration"
+      },
+      "babel-helper-to-multiple-sequence-expressions": {
+        "title": "babel-helper-to-multiple-sequence-expressions",
+        "sidebar_label": "babel-helper-to-multiple-sequence-expressions"
+      },
+      "babel-helper-transform-fixture-test-runner": {
+        "title": "@babel/helper-transform-fixture-test-runner",
+        "sidebar_label": "helper-transform-fixture-test-runner"
+      },
+      "babel-helper-wrap-function": {
+        "title": "@babel/helper-wrap-function",
+        "sidebar_label": "helper-wrap-function"
+      },
+      "babel-helpers": {
+        "title": "@babel/helpers",
+        "sidebar_label": "helpers"
+      },
+      "babel-highlight": {
+        "title": "@babel/highlight",
+        "sidebar_label": "highlight"
+      },
+      "index": {
+        "title": "What is Babel?"
+      },
+      "learn": {
+        "title": "Learn ES2015"
+      },
+      "babel-minify": {
+        "title": "babel-minify",
+        "sidebar_label": "babel-minify"
+      },
+      "babel-node": {
+        "title": "@babel/node",
+        "sidebar_label": "node"
+      },
+      "options": {
+        "title": "Options"
+      },
+      "babel-parser": {
+        "title": "@babel/parser",
+        "sidebar_label": "parser"
+      },
+      "babel-plugin-external-helpers": {
+        "title": "@babel/plugin-external-helpers",
+        "sidebar_label": "external-helpers"
+      },
+      "babel-plugin-minify-builtins": {
+        "title": "babel-plugin-minify-builtins",
+        "sidebar_label": "minify-builtins"
+      },
+      "babel-plugin-minify-constant-folding": {
+        "title": "babel-plugin-minify-constant-folding",
+        "sidebar_label": "minify-constant-folding"
+      },
+      "babel-plugin-minify-dead-code-elimination": {
+        "title": "babel-plugin-minify-dead-code-elimination",
+        "sidebar_label": "minify-dead-code-elimination"
+      },
+      "babel-plugin-minify-flip-comparisons": {
+        "title": "babel-plugin-minify-flip-comparisons",
+        "sidebar_label": "minify-flip-comparisons"
+      },
+      "babel-plugin-minify-guarded-expressions": {
+        "title": "babel-plugin-minify-guarded-expressions",
+        "sidebar_label": "minify-guarded-expressions"
+      },
+      "babel-plugin-minify-infinity": {
+        "title": "babel-plugin-minify-infinity",
+        "sidebar_label": "minify-infinity"
+      },
+      "babel-plugin-minify-mangle-names": {
+        "title": "babel-plugin-minify-mangle-names",
+        "sidebar_label": "minify-mangle-names"
+      },
+      "babel-plugin-minify-numeric-literals": {
+        "title": "babel-plugin-minify-numeric-literals",
+        "sidebar_label": "minify-numeric-literals"
+      },
+      "babel-plugin-minify-replace": {
+        "title": "babel-plugin-minify-replace",
+        "sidebar_label": "minify-replace"
+      },
+      "babel-plugin-minify-simplify": {
+        "title": "babel-plugin-minify-simplify",
+        "sidebar_label": "minify-simplify"
+      },
+      "babel-plugin-minify-type-constructors": {
+        "title": "babel-plugin-minify-type-constructors",
+        "sidebar_label": "minify-type-constructors"
+      },
+      "babel-plugin-proposal-async-generator-functions": {
+        "title": "@babel/plugin-proposal-async-generator-functions",
+        "sidebar_label": "proposal-async-generator-functions"
+      },
+      "babel-plugin-proposal-class-properties": {
+        "title": "@babel/plugin-proposal-class-properties",
+        "sidebar_label": "proposal-class-properties"
+      },
+      "babel-plugin-proposal-decorators": {
+        "title": "@babel/plugin-proposal-decorators",
+        "sidebar_label": "proposal-decorators"
+      },
+      "babel-plugin-proposal-do-expressions": {
+        "title": "@babel/plugin-proposal-do-expressions",
+        "sidebar_label": "proposal-do-expressions"
+      },
+      "babel-plugin-proposal-export-default-from": {
+        "title": "@babel/plugin-proposal-export-default-from",
+        "sidebar_label": "proposal-export-default-from"
+      },
+      "babel-plugin-proposal-export-namespace-from": {
+        "title": "@babel/plugin-proposal-export-namespace-from",
+        "sidebar_label": "proposal-export-namespace-from"
+      },
+      "babel-plugin-proposal-function-bind": {
+        "title": "@babel/plugin-proposal-function-bind",
+        "sidebar_label": "proposal-function-bind"
+      },
+      "babel-plugin-proposal-function-sent": {
+        "title": "@babel/plugin-proposal-function-sent",
+        "sidebar_label": "proposal-function-sent"
+      },
+      "babel-plugin-proposal-json-strings": {
+        "title": "@babel/plugin-proposal-json-strings",
+        "sidebar_label": "proposal-json-strings"
+      },
+      "babel-plugin-proposal-logical-assignment-operators": {
+        "title": "@babel/plugin-proposal-logical-assignment-operators",
+        "sidebar_label": "proposal-logical-assignment-operators"
+      },
+      "babel-plugin-proposal-nullish-coalescing-operator": {
+        "title": "@babel/plugin-proposal-nullish-coalescing-operator",
+        "sidebar_label": "proposal-nullish-coalescing-operator"
+      },
+      "babel-plugin-proposal-numeric-separator": {
+        "title": "@babel/plugin-proposal-numeric-separator",
+        "sidebar_label": "proposal-numeric-separator"
+      },
+      "babel-plugin-proposal-object-rest-spread": {
+        "title": "@babel/plugin-proposal-object-rest-spread",
+        "sidebar_label": "proposal-object-rest-spread"
+      },
+      "babel-plugin-proposal-optional-catch-binding": {
+        "title": "@babel/plugin-proposal-optional-catch-binding",
+        "sidebar_label": "proposal-optional-catch-binding"
+      },
+      "babel-plugin-proposal-optional-chaining": {
+        "title": "@babel/plugin-proposal-optional-chaining",
+        "sidebar_label": "proposal-optional-chaining"
+      },
+      "babel-plugin-proposal-pipeline-operator": {
+        "title": "@babel/plugin-proposal-pipeline-operator",
+        "sidebar_label": "proposal-pipeline-operator"
+      },
+      "babel-plugin-proposal-throw-expressions": {
+        "title": "@babel/plugin-proposal-throw-expressions",
+        "sidebar_label": "proposal-throw-expressions"
+      },
+      "babel-plugin-proposal-unicode-property-regex": {
+        "title": "@babel/plugin-proposal-unicode-property-regex",
+        "sidebar_label": "proposal-unicode-property-regex"
+      },
+      "babel-plugin-syntax-async-generators": {
+        "title": "@babel/plugin-syntax-async-generators",
+        "sidebar_label": "syntax-async-generators"
+      },
+      "babel-plugin-syntax-bigint": {
+        "title": "@babel/plugin-syntax-bigint",
+        "sidebar_label": "syntax-bigint"
+      },
+      "babel-plugin-syntax-class-properties": {
+        "title": "@babel/plugin-syntax-class-properties",
+        "sidebar_label": "syntax-class-properties"
+      },
+      "babel-plugin-syntax-decorators": {
+        "title": "@babel/plugin-syntax-decorators",
+        "sidebar_label": "syntax-decorators"
+      },
+      "babel-plugin-syntax-do-expressions": {
+        "title": "@babel/plugin-syntax-do-expressions",
+        "sidebar_label": "syntax-do-expressions"
+      },
+      "babel-plugin-syntax-dynamic-import": {
+        "title": "@babel/plugin-syntax-dynamic-import",
+        "sidebar_label": "syntax-dynamic-import"
+      },
+      "babel-plugin-syntax-export-default-from": {
+        "title": "@babel/plugin-syntax-export-default-from",
+        "sidebar_label": "syntax-export-default-from"
+      },
+      "babel-plugin-syntax-export-namespace-from": {
+        "title": "@babel/plugin-syntax-export-namespace-from",
+        "sidebar_label": "syntax-export-namespace-from"
+      },
+      "babel-plugin-syntax-flow": {
+        "title": "@babel/plugin-syntax-flow",
+        "sidebar_label": "syntax-flow"
+      },
+      "babel-plugin-syntax-function-bind": {
+        "title": "@babel/plugin-syntax-function-bind",
+        "sidebar_label": "syntax-function-bind"
+      },
+      "babel-plugin-syntax-function-sent": {
+        "title": "@babel/plugin-syntax-function-sent",
+        "sidebar_label": "syntax-function-sent"
+      },
+      "babel-plugin-syntax-import-meta": {
+        "title": "@babel/plugin-syntax-import-meta",
+        "sidebar_label": "syntax-import-meta"
+      },
+      "babel-plugin-syntax-json-strings": {
+        "title": "@babel/plugin-syntax-json-strings",
+        "sidebar_label": "syntax-json-strings"
+      },
+      "babel-plugin-syntax-jsx": {
+        "title": "@babel/plugin-syntax-jsx",
+        "sidebar_label": "syntax-jsx"
+      },
+      "babel-plugin-syntax-logical-assignment-operators": {
+        "title": "@babel/plugin-syntax-logical-assignment-operators",
+        "sidebar_label": "syntax-logical-assignment-operators"
+      },
+      "babel-plugin-syntax-nullish-coalescing-operator": {
+        "title": "@babel/plugin-syntax-nullish-coalescing-operator",
+        "sidebar_label": "syntax-nullish-coalescing-operator"
+      },
+      "babel-plugin-syntax-numeric-separator": {
+        "title": "@babel/plugin-syntax-numeric-separator",
+        "sidebar_label": "syntax-numeric-separator"
+      },
+      "babel-plugin-syntax-object-rest-spread": {
+        "title": "@babel/plugin-syntax-object-rest-spread",
+        "sidebar_label": "syntax-object-rest-spread"
+      },
+      "babel-plugin-syntax-optional-catch-binding": {
+        "title": "@babel/plugin-syntax-optional-catch-binding",
+        "sidebar_label": "syntax-optional-catch-binding"
+      },
+      "babel-plugin-syntax-optional-chaining": {
+        "title": "@babel/plugin-syntax-optional-chaining",
+        "sidebar_label": "syntax-optional-chaining"
+      },
+      "babel-plugin-syntax-pipeline-operator": {
+        "title": "@babel/plugin-syntax-pipeline-operator",
+        "sidebar_label": "syntax-pipeline-operator"
+      },
+      "babel-plugin-syntax-throw-expressions": {
+        "title": "@babel/plugin-syntax-throw-expressions",
+        "sidebar_label": "syntax-throw-expressions"
+      },
+      "babel-plugin-syntax-typescript": {
+        "title": "@babel/plugin-syntax-typescript",
+        "sidebar_label": "syntax-typescript"
+      },
+      "babel-plugin-transform-arrow-functions": {
+        "title": "@babel/plugin-transform-arrow-functions",
+        "sidebar_label": "transform-arrow-functions"
+      },
+      "babel-plugin-transform-async-to-generator": {
+        "title": "@babel/plugin-transform-async-to-generator",
+        "sidebar_label": "transform-async-to-generator"
+      },
+      "babel-plugin-transform-block-scoped-functions": {
+        "title": "@babel/plugin-transform-block-scoped-functions",
+        "sidebar_label": "transform-block-scoped-functions"
+      },
+      "babel-plugin-transform-block-scoping": {
+        "title": "@babel/plugin-transform-block-scoping",
+        "sidebar_label": "transform-block-scoping"
+      },
+      "babel-plugin-transform-classes": {
+        "title": "@babel/plugin-transform-classes",
+        "sidebar_label": "transform-classes"
+      },
+      "babel-plugin-transform-computed-properties": {
+        "title": "@babel/plugin-transform-computed-properties",
+        "sidebar_label": "transform-computed-properties"
+      },
+      "babel-plugin-transform-destructuring": {
+        "title": "@babel/plugin-transform-destructuring",
+        "sidebar_label": "transform-destructuring"
+      },
+      "babel-plugin-transform-dotall-regex": {
+        "title": "@babel/plugin-transform-dotall-regex",
+        "sidebar_label": "transform-dotall-regex"
+      },
+      "babel-plugin-transform-duplicate-keys": {
+        "title": "@babel/plugin-transform-duplicate-keys",
+        "sidebar_label": "transform-duplicate-keys"
+      },
+      "babel-plugin-transform-exponentiation-operator": {
+        "title": "@babel/plugin-transform-exponentiation-operator",
+        "sidebar_label": "transform-exponentiation-operator"
+      },
+      "babel-plugin-transform-flow-comments": {
+        "title": "@babel/plugin-transform-flow-comments",
+        "sidebar_label": "transform-flow-comments"
+      },
+      "babel-plugin-transform-flow-strip-types": {
+        "title": "@babel/plugin-transform-flow-strip-types",
+        "sidebar_label": "transform-flow-strip-types"
+      },
+      "babel-plugin-transform-for-of": {
+        "title": "@babel/plugin-transform-for-of",
+        "sidebar_label": "transform-for-of"
+      },
+      "babel-plugin-transform-function-name": {
+        "title": "@babel/plugin-transform-function-name",
+        "sidebar_label": "transform-function-name"
+      },
+      "babel-plugin-transform-inline-consecutive-adds": {
+        "title": "@babel/plugin-transform-inline-consecutive-adds",
+        "sidebar_label": "transform-inline-consecutive-adds"
+      },
+      "babel-plugin-transform-inline-environment-variables": {
+        "title": "babel-plugin-transform-inline-environment-variables",
+        "sidebar_label": "transform-inline-environment-variables"
+      },
+      "babel-plugin-transform-instanceof": {
+        "title": "@babel/plugin-transform-instanceof",
+        "sidebar_label": "transform-instanceof"
+      },
+      "babel-plugin-transform-jscript": {
+        "title": "@babel/plugin-transform-jscript",
+        "sidebar_label": "transform-jscript"
+      },
+      "babel-plugin-transform-literals": {
+        "title": "@babel/plugin-transform-literals",
+        "sidebar_label": "transform-literals"
+      },
+      "babel-plugin-transform-member-expression-literals": {
+        "title": "babel-plugin-transform-member-expression-literals",
+        "sidebar_label": "transform-member-expression-literals"
+      },
+      "babel-plugin-transform-merge-sibling-variables": {
+        "title": "babel-plugin-transform-merge-sibling-variables",
+        "sidebar_label": "transform-merge-sibling-variables"
+      },
+      "babel-plugin-transform-minify-booleans": {
+        "title": "babel-plugin-transform-minify-booleans",
+        "sidebar_label": "transform-minify-booleans"
+      },
+      "babel-plugin-transform-modules-amd": {
+        "title": "@babel/plugin-transform-modules-amd",
+        "sidebar_label": "transform-modules-amd"
+      },
+      "babel-plugin-transform-modules-commonjs": {
+        "title": "@babel/plugin-transform-modules-commonjs",
+        "sidebar_label": "transform-modules-commonjs"
+      },
+      "babel-plugin-transform-modules-systemjs": {
+        "title": "@babel/plugin-transform-modules-systemjs",
+        "sidebar_label": "transform-modules-systemjs"
+      },
+      "babel-plugin-transform-modules-umd": {
+        "title": "@babel/plugin-transform-modules-umd",
+        "sidebar_label": "transform-modules-umd"
+      },
+      "babel-plugin-transform-new-target": {
+        "title": "@babel/plugin-transform-new-target",
+        "sidebar_label": "transform-new-target"
+      },
+      "babel-plugin-transform-node-env-inline": {
+        "title": "babel-plugin-transform-node-env-inline",
+        "sidebar_label": "transform-node-env-inline"
+      },
+      "babel-plugin-transform-object-assign": {
+        "title": "@babel/plugin-transform-object-assign",
+        "sidebar_label": "transform-object-assign"
+      },
+      "babel-plugin-transform-object-set-prototype-of-to-assign": {
+        "title": "@babel/plugin-transform-object-set-prototype-of-to-assign",
+        "sidebar_label": "transform-object-set-prototype-of-to-assign"
+      },
+      "babel-plugin-transform-object-super": {
+        "title": "@babel/plugin-transform-object-super",
+        "sidebar_label": "transform-object-super"
+      },
+      "babel-plugin-transform-parameters": {
+        "title": "@babel/plugin-transform-parameters",
+        "sidebar_label": "transform-parameters"
+      },
+      "babel-plugin-transform-property-literals": {
+        "title": "babel-plugin-transform-property-literals",
+        "sidebar_label": "transform-property-literals"
+      },
+      "babel-plugin-transform-property-mutators": {
+        "title": "@babel/plugin-transform-property-mutators",
+        "sidebar_label": "transform-property-mutators"
+      },
+      "babel-plugin-transform-proto-to-assign": {
+        "title": "@babel/plugin-transform-proto-to-assign",
+        "sidebar_label": "transform-proto-to-assign"
+      },
+      "babel-plugin-transform-react-constant-elements": {
+        "title": "@babel/plugin-transform-react-constant-elements",
+        "sidebar_label": "transform-react-constant-elements"
+      },
+      "babel-plugin-transform-react-display-name": {
+        "title": "@babel/plugin-transform-react-display-name",
+        "sidebar_label": "transform-react-display-name"
+      },
+      "babel-plugin-transform-react-inline-elements": {
+        "title": "@babel/plugin-transform-react-inline-elements",
+        "sidebar_label": "transform-react-inline-elements"
+      },
+      "babel-plugin-transform-react-jsx-compat": {
+        "title": "@babel/plugin-transform-react-jsx-compat",
+        "sidebar_label": "transform-react-jsx-compat"
+      },
+      "babel-plugin-transform-react-jsx-self": {
+        "title": "@babel/plugin-transform-react-jsx-self",
+        "sidebar_label": "transform-react-jsx-self"
+      },
+      "babel-plugin-transform-react-jsx-source": {
+        "title": "@babel/plugin-transform-react-jsx-source",
+        "sidebar_label": "transform-react-jsx-source"
+      },
+      "babel-plugin-transform-react-jsx": {
+        "title": "@babel/plugin-transform-react-jsx",
+        "sidebar_label": "transform-react-jsx"
+      },
+      "babel-plugin-transform-regenerator": {
+        "title": "@babel/plugin-transform-regenerator",
+        "sidebar_label": "transform-regenerator"
+      },
+      "babel-plugin-transform-regexp-constructors": {
+        "title": "babel-plugin-transform-regexp-constructors",
+        "sidebar_label": "transform-regexp-constructors"
+      },
+      "babel-plugin-transform-remove-console": {
+        "title": "babel-plugin-transform-remove-console",
+        "sidebar_label": "transform-remove-console"
+      },
+      "babel-plugin-transform-remove-debugger": {
+        "title": "babel-plugin-transform-remove-debugger",
+        "sidebar_label": "transform-remove-debugger"
+      },
+      "babel-plugin-transform-remove-undefined": {
+        "title": "babel-plugin-transform-remove-undefined",
+        "sidebar_label": "transform-remove-undefined"
+      },
+      "babel-plugin-transform-reserved-words": {
+        "title": "@babel/plugin-transform-reserved-words",
+        "sidebar_label": "transform-reserved-words"
+      },
+      "babel-plugin-transform-runtime": {
+        "title": "@babel/plugin-transform-runtime",
+        "sidebar_label": "transform-runtime"
+      },
+      "babel-plugin-transform-shorthand-properties": {
+        "title": "@babel/plugin-transform-shorthand-properties",
+        "sidebar_label": "transform-shorthand-properties"
+      },
+      "babel-plugin-transform-simplify-comparison-operators": {
+        "title": "babel-plugin-transform-simplify-comparison-operators",
+        "sidebar_label": "transform-simplify-comparison-operators"
+      },
+      "babel-plugin-transform-spread": {
+        "title": "@babel/plugin-transform-spread",
+        "sidebar_label": "transform-spread"
+      },
+      "babel-plugin-transform-sticky-regex": {
+        "title": "@babel/plugin-transform-sticky-regex",
+        "sidebar_label": "transform-sticky-regex"
+      },
+      "babel-plugin-transform-strict-mode": {
+        "title": "@babel/plugin-transform-strict-mode",
+        "sidebar_label": "transform-strict-mode"
+      },
+      "babel-plugin-transform-template-literals": {
+        "title": "@babel/plugin-transform-template-literals",
+        "sidebar_label": "transform-template-literals"
+      },
+      "babel-plugin-transform-typeof-symbol": {
+        "title": "@babel/plugin-transform-typeof-symbol",
+        "sidebar_label": "transform-typeof-symbol"
+      },
+      "babel-plugin-transform-typescript": {
+        "title": "@babel/plugin-transform-typescript",
+        "sidebar_label": "transform-typescript"
+      },
+      "babel-plugin-transform-undefined-to-void": {
+        "title": "babel-plugin-transform-undefined-to-void",
+        "sidebar_label": "transform-undefined-to-void"
+      },
+      "babel-plugin-transform-unicode-regex": {
+        "title": "@babel/plugin-transform-unicode-regex",
+        "sidebar_label": "transform-unicode-regex"
+      },
+      "plugins": {
+        "title": "Plugins"
+      },
+      "babel-polyfill": {
+        "title": "@babel/polyfill",
+        "sidebar_label": "polyfill"
+      },
+      "babel-preset-env-standalone": {
+        "title": "@babel/preset-env-standalone",
+        "sidebar_label": "env-standalone"
+      },
+      "babel-preset-env": {
+        "title": "@babel/preset-env",
+        "sidebar_label": "env"
+      },
+      "babel-preset-es2015": {
+        "title": "@babel/preset-es2015",
+        "sidebar_label": "es2015"
+      },
+      "babel-preset-es2016": {
+        "title": "@babel/preset-es2016",
+        "sidebar_label": "es2016"
+      },
+      "babel-preset-es2017": {
+        "title": "@babel/preset-es2017",
+        "sidebar_label": "es2017"
+      },
+      "babel-preset-flow": {
+        "title": "@babel/preset-flow",
+        "sidebar_label": "flow"
+      },
+      "babel-preset-minify": {
+        "title": "babel-preset-minify",
+        "sidebar_label": "minify"
+      },
+      "babel-preset-react": {
+        "title": "@babel/preset-react",
+        "sidebar_label": "react"
+      },
+      "babel-preset-stage-0": {
+        "title": "@babel/preset-stage-0",
+        "sidebar_label": "stage-0"
+      },
+      "babel-preset-stage-1": {
+        "title": "@babel/preset-stage-1",
+        "sidebar_label": "stage-1"
+      },
+      "babel-preset-stage-2": {
+        "title": "@babel/preset-stage-2",
+        "sidebar_label": "stage-2"
+      },
+      "babel-preset-stage-3": {
+        "title": "@babel/preset-stage-3",
+        "sidebar_label": "stage-3"
+      },
+      "babel-preset-typescript": {
+        "title": "@babel/preset-typescript",
+        "sidebar_label": "typescript"
+      },
+      "presets": {
+        "title": "Presets"
+      },
+      "babel-register": {
+        "title": "@babel/register",
+        "sidebar_label": "register"
+      },
+      "roadmap": {
+        "title": "Babel Roadmap",
+        "sidebar_label": "Roadmap"
+      },
+      "babel-runtime-corejs2": {
+        "title": "@babel/runtime-corejs2",
+        "sidebar_label": "runtime-corejs2"
+      },
+      "babel-runtime": {
+        "title": "@babel/runtime",
+        "sidebar_label": "runtime"
+      },
+      "babel-standalone": {
+        "title": "@babel/standalone",
+        "sidebar_label": "standalone"
+      },
+      "babel-template": {
+        "title": "@babel/template",
+        "sidebar_label": "template"
+      },
+      "tools/ava/install": {
+        "title": "tools/ava/install"
+      },
+      "tools/ava/usage": {
+        "title": "tools/ava/usage"
+      },
+      "tools/babel_cli/install": {
+        "title": "tools/babel_cli/install"
+      },
+      "tools/babel_cli/usage": {
+        "title": "tools/babel_cli/usage"
+      },
+      "tools/babel_node_debug/install": {
+        "title": "tools/babel_node_debug/install"
+      },
+      "tools/babel_node_debug/usage": {
+        "title": "tools/babel_node_debug/usage"
+      },
+      "tools/babel_register/install": {
+        "title": "tools/babel_register/install"
+      },
+      "tools/babel_register/usage": {
+        "title": "tools/babel_register/usage"
+      },
+      "tools/broccoli/install": {
+        "title": "tools/broccoli/install"
+      },
+      "tools/broccoli/usage": {
+        "title": "tools/broccoli/usage"
+      },
+      "tools/browser/install": {
+        "title": "tools/browser/install"
+      },
+      "tools/browser/usage": {
+        "title": "tools/browser/usage"
+      },
+      "tools/browserify/install": {
+        "title": "tools/browserify/install"
+      },
+      "tools/browserify/usage": {
+        "title": "tools/browserify/usage"
+      },
+      "tools/brunch/install": {
+        "title": "tools/brunch/install"
+      },
+      "tools/brunch/usage": {
+        "title": "tools/brunch/usage"
+      },
+      "tools/connect/install": {
+        "title": "tools/connect/install"
+      },
+      "tools/connect/usage": {
+        "title": "tools/connect/usage"
+      },
+      "tools/dotnet/install": {
+        "title": "tools/dotnet/install"
+      },
+      "tools/dotnet/usage": {
+        "title": "tools/dotnet/usage"
+      },
+      "tools/duo/install": {
+        "title": "tools/duo/install"
+      },
+      "tools/duo/usage": {
+        "title": "tools/duo/usage"
+      },
+      "tools/ember/install": {
+        "title": "tools/ember/install"
+      },
+      "tools/ember/usage": {
+        "title": "tools/ember/usage"
+      },
+      "tools/fly/install": {
+        "title": "tools/fly/install"
+      },
+      "tools/fly/usage": {
+        "title": "tools/fly/usage"
+      },
+      "tools/gobble/install": {
+        "title": "tools/gobble/install"
+      },
+      "tools/gobble/usage": {
+        "title": "tools/gobble/usage"
+      },
+      "tools/grunt/install": {
+        "title": "tools/grunt/install"
+      },
+      "tools/grunt/usage": {
+        "title": "tools/grunt/usage"
+      },
+      "tools/gulp/install": {
+        "title": "tools/gulp/install"
+      },
+      "tools/gulp/usage": {
+        "title": "tools/gulp/usage"
+      },
+      "tools/jasmine/install": {
+        "title": "tools/jasmine/install"
+      },
+      "tools/jasmine/usage": {
+        "title": "tools/jasmine/usage"
+      },
+      "tools/jest/install": {
+        "title": "tools/jest/install"
+      },
+      "tools/jest/usage": {
+        "title": "tools/jest/usage"
+      },
+      "tools/jspm/install": {
+        "title": "tools/jspm/install"
+      },
+      "tools/jspm/usage": {
+        "title": "tools/jspm/usage"
+      },
+      "tools/karma/install": {
+        "title": "tools/karma/install"
+      },
+      "tools/karma/usage": {
+        "title": "tools/karma/usage"
+      },
+      "tools/lab/install": {
+        "title": "tools/lab/install"
+      },
+      "tools/lab/usage": {
+        "title": "tools/lab/usage"
+      },
+      "tools/make/install": {
+        "title": "tools/make/install"
+      },
+      "tools/make/usage": {
+        "title": "tools/make/usage"
+      },
+      "tools/metalsmith/install": {
+        "title": "tools/metalsmith/install"
+      },
+      "tools/metalsmith/usage": {
+        "title": "tools/metalsmith/usage"
+      },
+      "tools/meteor/install": {
+        "title": "tools/meteor/install"
+      },
+      "tools/meteor/usage": {
+        "title": "tools/meteor/usage"
+      },
+      "tools/mocha/install": {
+        "title": "tools/mocha/install"
+      },
+      "tools/mocha/usage": {
+        "title": "tools/mocha/usage"
+      },
+      "tools/msbuild/install": {
+        "title": "tools/msbuild/install"
+      },
+      "tools/msbuild/usage": {
+        "title": "tools/msbuild/usage"
+      },
+      "tools/node/install": {
+        "title": "tools/node/install"
+      },
+      "tools/node/usage": {
+        "title": "tools/node/usage"
+      },
+      "tools/nodemon/install": {
+        "title": "tools/nodemon/install"
+      },
+      "tools/nodemon/usage": {
+        "title": "tools/nodemon/usage"
+      },
+      "tools/pug/install": {
+        "title": "tools/pug/install"
+      },
+      "tools/pug/usage": {
+        "title": "tools/pug/usage"
+      },
+      "tools/rails/install": {
+        "title": "tools/rails/install"
+      },
+      "tools/rails/usage": {
+        "title": "tools/rails/usage"
+      },
+      "tools/requirejs/install": {
+        "title": "tools/requirejs/install"
+      },
+      "tools/requirejs/usage": {
+        "title": "tools/requirejs/usage"
+      },
+      "tools/rollup/install": {
+        "title": "tools/rollup/install"
+      },
+      "tools/rollup/usage": {
+        "title": "tools/rollup/usage"
+      },
+      "tools/ruby/install": {
+        "title": "tools/ruby/install"
+      },
+      "tools/ruby/usage": {
+        "title": "tools/ruby/usage"
+      },
+      "tools/sails/install": {
+        "title": "tools/sails/install"
+      },
+      "tools/sails/usage": {
+        "title": "tools/sails/usage"
+      },
+      "tools/setup": {
+        "title": "tools/setup"
+      },
+      "tools/sprockets/install": {
+        "title": "tools/sprockets/install"
+      },
+      "tools/sprockets/usage": {
+        "title": "tools/sprockets/usage"
+      },
+      "tools/start/install": {
+        "title": "tools/start/install"
+      },
+      "tools/start/usage": {
+        "title": "tools/start/usage"
+      },
+      "tools/webpack/install": {
+        "title": "tools/webpack/install"
+      },
+      "tools/webpack/usage": {
+        "title": "tools/webpack/usage"
+      },
+      "tools/webpack2/install": {
+        "title": "tools/webpack2/install"
+      },
+      "tools/webpack2/usage": {
+        "title": "tools/webpack2/usage"
+      },
+      "tools/webstorm/install": {
+        "title": "tools/webstorm/install"
+      },
+      "tools/webstorm/usage": {
+        "title": "tools/webstorm/usage"
+      },
+      "babel-traverse": {
+        "title": "@babel/traverse",
+        "sidebar_label": "traverse"
+      },
+      "babel-types": {
+        "title": "@babel/types",
+        "sidebar_label": "types"
+      },
+      "usage": {
+        "title": "Usage Guide"
+      },
+      "v7-migration-api": {
+        "title": "Upgrade to Babel 7 (API)"
+      },
+      "v7-migration": {
+        "title": "Upgrade to Babel 7"
+      },
+      "version-6.26.3-babel": {
+        "title": "babel",
+        "sidebar_label": "babel"
+      },
+      "version-6.26.3-babelrc": {
+        "title": ".babelrc"
+      },
+      "version-6.26.3-babylon": {
+        "title": "babylon",
+        "sidebar_label": "babylon"
+      },
+      "version-6.26.3-caveats": {
+        "title": "Caveats"
+      },
+      "version-6.26.3-babel-cli": {
+        "title": "babel-cli",
+        "sidebar_label": "babel-cli"
+      },
+      "version-6.26.3-babel-code-frame": {
+        "title": "babel-code-frame",
+        "sidebar_label": "babel-code-frame"
+      },
+      "version-6.26.3-core-packages": {
+        "title": "Babel's core packages"
+      },
+      "version-6.26.3-babel-core": {
+        "title": "babel-core",
+        "sidebar_label": "babel-core"
+      },
+      "version-6.26.3-editors": {
+        "title": "Editors"
+      },
+      "version-6.26.3-env": {
+        "title": "babel-preset-es2015 -> babel-preset-env"
+      },
+      "version-6.26.3-faq": {
+        "title": "FAQ"
+      },
+      "version-6.26.3-babel-generator": {
+        "title": "babel-generator",
+        "sidebar_label": "babel-generator"
+      },
+      "version-6.26.3-gulp-babel-minify": {
+        "title": "gulp-babel-minify",
+        "sidebar_label": "gulp-babel-minify"
+      },
+      "version-6.26.3-babel-helper-bindify-decorators": {
+        "title": "babel-helper-bindify-decorators",
+        "sidebar_label": "babel-helper-bindify-decorators"
+      },
+      "version-6.26.3-babel-helper-builder-binary-assignment-operator-visitor": {
+        "title": "babel-helper-builder-binary-assignment-operator-visitor",
+        "sidebar_label": "babel-helper-builder-binary-assignment-operator-visitor"
+      },
+      "version-6.26.3-babel-helper-builder-conditional-assignment-operator-visitor": {
+        "title": "babel-helper-builder-conditional-assignment-operator-visitor",
+        "sidebar_label": "babel-helper-builder-conditional-assignment-operator-visitor"
+      },
+      "version-6.26.3-babel-helper-builder-react-jsx": {
+        "title": "babel-helper-builder-react-jsx",
+        "sidebar_label": "babel-helper-builder-react-jsx"
+      },
+      "version-6.26.3-babel-helper-call-delegate": {
+        "title": "babel-helper-call-delegate",
+        "sidebar_label": "babel-helper-call-delegate"
+      },
+      "version-6.26.3-babel-helper-define-map": {
+        "title": "babel-helper-define-map",
+        "sidebar_label": "babel-helper-define-map"
+      },
+      "version-6.26.3-babel-helper-evaluate-path": {
+        "title": "babel-helper-evaluate-path",
+        "sidebar_label": "babel-helper-evaluate-path"
+      },
+      "version-6.26.3-babel-helper-explode-assignable-expression": {
+        "title": "babel-helper-explode-assignable-expression",
+        "sidebar_label": "babel-helper-explode-assignable-expression"
+      },
+      "version-6.26.3-babel-helper-explode-class": {
+        "title": "babel-helper-explode-class",
+        "sidebar_label": "babel-helper-explode-class"
+      },
+      "version-6.26.3-babel-helper-fixtures": {
+        "title": "babel-helper-fixtures",
+        "sidebar_label": "babel-helper-fixtures"
+      },
+      "version-6.26.3-babel-helper-flip-expressions": {
+        "title": "babel-helper-flip-expressions",
+        "sidebar_label": "babel-helper-flip-expressions"
+      },
+      "version-6.26.3-babel-helper-function-name": {
+        "title": "babel-helper-function-name",
+        "sidebar_label": "babel-helper-function-name"
+      },
+      "version-6.26.3-babel-helper-get-function-arity": {
+        "title": "babel-helper-get-function-arity",
+        "sidebar_label": "babel-helper-get-function-arity"
+      },
+      "version-6.26.3-babel-helper-hoist-variables": {
+        "title": "babel-helper-hoist-variables",
+        "sidebar_label": "babel-helper-hoist-variables"
+      },
+      "version-6.26.3-babel-helper-is-void-0": {
+        "title": "babel-helper-is-void-0",
+        "sidebar_label": "babel-helper-is-void-0"
+      },
+      "version-6.26.3-babel-helper-mark-eval-scopes": {
+        "title": "babel-helper-mark-eval-scopes",
+        "sidebar_label": "babel-helper-mark-eval-scopes"
+      },
+      "version-6.26.3-babel-helper-optimise-call-expression": {
+        "title": "babel-helper-optimise-call-expression",
+        "sidebar_label": "babel-helper-optimise-call-expression"
+      },
+      "version-6.26.3-babel-helper-plugin-test-runner": {
+        "title": "babel-helper-plugin-test-runner",
+        "sidebar_label": "babel-helper-plugin-test-runner"
+      },
+      "version-6.26.3-babel-helper-regex": {
+        "title": "babel-helper-regex",
+        "sidebar_label": "babel-helper-regex"
+      },
+      "version-6.26.3-babel-helper-remap-async-to-generator": {
+        "title": "babel-helper-remap-async-to-generator",
+        "sidebar_label": "babel-helper-remap-async-to-generator"
+      },
+      "version-6.26.3-babel-helper-remove-or-void": {
+        "title": "babel-helper-remove-or-void",
+        "sidebar_label": "babel-helper-remove-or-void"
+      },
+      "version-6.26.3-babel-helper-replace-supers": {
+        "title": "babel-helper-replace-supers",
+        "sidebar_label": "babel-helper-replace-supers"
+      },
+      "version-6.26.3-babel-helper-to-multiple-sequence-expressions": {
+        "title": "babel-helper-to-multiple-sequence-expressions",
+        "sidebar_label": "babel-helper-to-multiple-sequence-expressions"
+      },
+      "version-6.26.3-babel-helper-transform-fixture-test-runner": {
+        "title": "babel-helper-transform-fixture-test-runner",
+        "sidebar_label": "babel-helper-transform-fixture-test-runner"
+      },
+      "version-6.26.3-babel-helpers": {
+        "title": "babel-helpers",
+        "sidebar_label": "babel-helpers"
+      },
+      "version-6.26.3-index": {
+        "title": "What is Babel?"
+      },
+      "version-6.26.3-learn": {
+        "title": "Learn ES2015"
+      },
+      "version-6.26.3-babel-messages": {
+        "title": "babel-messages",
+        "sidebar_label": "babel-messages"
+      },
+      "version-6.26.3-babel-minify": {
+        "title": "babel-minify",
+        "sidebar_label": "babel-minify"
+      },
+      "version-6.26.3-babel-plugin-check-es2015-constants": {
+        "title": "babel-plugin-check-es2015-constants",
+        "sidebar_label": "check-es2015-constants"
+      },
+      "version-6.26.3-babel-plugin-external-helpers": {
+        "title": "babel-plugin-external-helpers",
+        "sidebar_label": "external-helpers"
+      },
+      "version-6.26.3-babel-plugin-minify-builtins": {
+        "title": "babel-plugin-minify-builtins",
+        "sidebar_label": "minify-builtins"
+      },
+      "version-6.26.3-babel-plugin-minify-constant-folding": {
+        "title": "babel-plugin-minify-constant-folding",
+        "sidebar_label": "minify-constant-folding"
+      },
+      "version-6.26.3-babel-plugin-minify-dead-code-elimination": {
+        "title": "babel-plugin-minify-dead-code-elimination",
+        "sidebar_label": "minify-dead-code-elimination"
+      },
+      "version-6.26.3-babel-plugin-minify-flip-comparisons": {
+        "title": "babel-plugin-minify-flip-comparisons",
+        "sidebar_label": "minify-flip-comparisons"
+      },
+      "version-6.26.3-babel-plugin-minify-guarded-expressions": {
+        "title": "babel-plugin-minify-guarded-expressions",
+        "sidebar_label": "minify-guarded-expressions"
+      },
+      "version-6.26.3-babel-plugin-minify-infinity": {
+        "title": "babel-plugin-minify-infinity",
+        "sidebar_label": "minify-infinity"
+      },
+      "version-6.26.3-babel-plugin-minify-mangle-names": {
+        "title": "babel-plugin-minify-mangle-names",
+        "sidebar_label": "minify-mangle-names"
+      },
+      "version-6.26.3-babel-plugin-minify-numeric-literals": {
+        "title": "babel-plugin-minify-numeric-literals",
+        "sidebar_label": "minify-numeric-literals"
+      },
+      "version-6.26.3-babel-plugin-minify-replace": {
+        "title": "babel-plugin-minify-replace",
+        "sidebar_label": "minify-replace"
+      },
+      "version-6.26.3-babel-plugin-minify-simplify": {
+        "title": "babel-plugin-minify-simplify",
+        "sidebar_label": "minify-simplify"
+      },
+      "version-6.26.3-babel-plugin-minify-type-constructors": {
+        "title": "babel-plugin-minify-type-constructors",
+        "sidebar_label": "minify-type-constructors"
+      },
+      "version-6.26.3-babel-plugin-syntax-async-functions": {
+        "title": "babel-plugin-syntax-async-functions",
+        "sidebar_label": "syntax-async-functions"
+      },
+      "version-6.26.3-babel-plugin-syntax-async-generators": {
+        "title": "babel-plugin-syntax-async-generators",
+        "sidebar_label": "syntax-async-generators"
+      },
+      "version-6.26.3-babel-plugin-syntax-class-constructor-call": {
+        "title": "babel-plugin-syntax-class-constructor-call",
+        "sidebar_label": "syntax-class-constructor-call"
+      },
+      "version-6.26.3-babel-plugin-syntax-class-properties": {
+        "title": "babel-plugin-syntax-class-properties",
+        "sidebar_label": "syntax-class-properties"
+      },
+      "version-6.26.3-babel-plugin-syntax-decorators": {
+        "title": "babel-plugin-syntax-decorators",
+        "sidebar_label": "syntax-decorators"
+      },
+      "version-6.26.3-babel-plugin-syntax-do-expressions": {
+        "title": "babel-plugin-syntax-do-expressions",
+        "sidebar_label": "syntax-do-expressions"
+      },
+      "version-6.26.3-babel-plugin-syntax-dynamic-import": {
+        "title": "babel-plugin-syntax-dynamic-import",
+        "sidebar_label": "syntax-dynamic-import"
+      },
+      "version-6.26.3-babel-plugin-syntax-exponentiation-operator": {
+        "title": "babel-plugin-syntax-exponentiation-operator",
+        "sidebar_label": "syntax-exponentiation-operator"
+      },
+      "version-6.26.3-babel-plugin-syntax-export-extensions": {
+        "title": "babel-plugin-syntax-export-extensions",
+        "sidebar_label": "syntax-export-extensions"
+      },
+      "version-6.26.3-babel-plugin-syntax-flow": {
+        "title": "babel-plugin-syntax-flow",
+        "sidebar_label": "syntax-flow"
+      },
+      "version-6.26.3-babel-plugin-syntax-function-bind": {
+        "title": "babel-plugin-syntax-function-bind",
+        "sidebar_label": "syntax-function-bind"
+      },
+      "version-6.26.3-babel-plugin-syntax-function-sent": {
+        "title": "babel-plugin-syntax-function-sent",
+        "sidebar_label": "syntax-function-sent"
+      },
+      "version-6.26.3-babel-plugin-syntax-jsx": {
+        "title": "babel-plugin-syntax-jsx",
+        "sidebar_label": "syntax-jsx"
+      },
+      "version-6.26.3-babel-plugin-syntax-object-rest-spread": {
+        "title": "babel-plugin-syntax-object-rest-spread",
+        "sidebar_label": "syntax-object-rest-spread"
+      },
+      "version-6.26.3-babel-plugin-syntax-trailing-function-commas": {
+        "title": "babel-plugin-syntax-trailing-function-commas",
+        "sidebar_label": "syntax-trailing-function-commas"
+      },
+      "version-6.26.3-babel-plugin-transform-async-functions": {
+        "title": "babel-plugin-transform-async-functions",
+        "sidebar_label": "transform-async-functions"
+      },
+      "version-6.26.3-babel-plugin-transform-async-generator-functions": {
+        "title": "babel-plugin-transform-async-generator-functions",
+        "sidebar_label": "transform-async-generator-functions"
+      },
+      "version-6.26.3-babel-plugin-transform-async-to-generator": {
+        "title": "babel-plugin-transform-async-to-generator",
+        "sidebar_label": "transform-async-to-generator"
+      },
+      "version-6.26.3-babel-plugin-transform-async-to-module-method": {
+        "title": "babel-plugin-transform-async-to-module-method",
+        "sidebar_label": "transform-async-to-module-method"
+      },
+      "version-6.26.3-babel-plugin-transform-class-constructor-call": {
+        "title": "babel-plugin-transform-class-constructor-call",
+        "sidebar_label": "transform-class-constructor-call"
+      },
+      "version-6.26.3-babel-plugin-transform-class-properties": {
+        "title": "babel-plugin-transform-class-properties",
+        "sidebar_label": "transform-class-properties"
+      },
+      "version-6.26.3-babel-plugin-transform-decorators": {
+        "title": "babel-plugin-transform-decorators",
+        "sidebar_label": "transform-decorators"
+      },
+      "version-6.26.3-babel-plugin-transform-do-expressions": {
+        "title": "babel-plugin-transform-do-expressions",
+        "sidebar_label": "transform-do-expressions"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-arrow-functions": {
+        "title": "babel-plugin-transform-es2015-arrow-functions",
+        "sidebar_label": "transform-es2015-arrow-functions"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-block-scoped-functions": {
+        "title": "babel-plugin-transform-es2015-block-scoped-functions",
+        "sidebar_label": "transform-es2015-block-scoped-functions"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-block-scoping": {
+        "title": "babel-plugin-transform-es2015-block-scoping",
+        "sidebar_label": "transform-es2015-block-scoping"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-classes": {
+        "title": "babel-plugin-transform-es2015-classes",
+        "sidebar_label": "transform-es2015-classes"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-computed-properties": {
+        "title": "babel-plugin-transform-es2015-computed-properties",
+        "sidebar_label": "transform-es2015-computed-properties"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-destructuring": {
+        "title": "babel-plugin-transform-es2015-destructuring",
+        "sidebar_label": "transform-es2015-destructuring"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-duplicate-keys": {
+        "title": "babel-plugin-transform-es2015-duplicate-keys",
+        "sidebar_label": "transform-es2015-duplicate-keys"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-for-of": {
+        "title": "babel-plugin-transform-es2015-for-of",
+        "sidebar_label": "transform-es2015-for-of"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-function-name": {
+        "title": "babel-plugin-transform-es2015-function-name",
+        "sidebar_label": "transform-es2015-function-name"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-instanceof": {
+        "title": "babel-plugin-transform-es2015-instanceof",
+        "sidebar_label": "transform-es2015-instanceof"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-literals": {
+        "title": "babel-plugin-transform-es2015-literals",
+        "sidebar_label": "transform-es2015-literals"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-modules-amd": {
+        "title": "babel-plugin-transform-es2015-modules-amd",
+        "sidebar_label": "transform-es2015-modules-amd"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-modules-commonjs": {
+        "title": "babel-plugin-transform-es2015-modules-commonjs",
+        "sidebar_label": "transform-es2015-modules-commonjs"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-modules-systemjs": {
+        "title": "babel-plugin-transform-es2015-modules-systemjs",
+        "sidebar_label": "transform-es2015-modules-systemjs"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-modules-umd": {
+        "title": "babel-plugin-transform-es2015-modules-umd",
+        "sidebar_label": "transform-es2015-modules-umd"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-object-super": {
+        "title": "babel-plugin-transform-es2015-object-super",
+        "sidebar_label": "transform-es2015-object-super"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-parameters": {
+        "title": "babel-plugin-transform-es2015-parameters",
+        "sidebar_label": "transform-es2015-parameters"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-shorthand-properties": {
+        "title": "babel-plugin-transform-es2015-shorthand-properties",
+        "sidebar_label": "transform-es2015-shorthand-properties"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-spread": {
+        "title": "babel-plugin-transform-es2015-spread",
+        "sidebar_label": "transform-es2015-spread"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-sticky-regex": {
+        "title": "babel-plugin-transform-es2015-sticky-regex",
+        "sidebar_label": "transform-es2015-sticky-regex"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-template-literals": {
+        "title": "babel-plugin-transform-es2015-template-literals",
+        "sidebar_label": "transform-es2015-template-literals"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-typeof-symbol": {
+        "title": "babel-plugin-transform-es2015-typeof-symbol",
+        "sidebar_label": "transform-es2015-typeof-symbol"
+      },
+      "version-6.26.3-babel-plugin-transform-es2015-unicode-regex": {
+        "title": "babel-plugin-transform-es2015-unicode-regex",
+        "sidebar_label": "transform-es2015-unicode-regex"
+      },
+      "version-6.26.3-babel-plugin-transform-es3-member-expression-literals": {
+        "title": "babel-plugin-transform-es3-member-expression-literals",
+        "sidebar_label": "transform-es3-member-expression-literals"
+      },
+      "version-6.26.3-babel-plugin-transform-es3-property-literals": {
+        "title": "babel-plugin-transform-es3-property-literals",
+        "sidebar_label": "transform-es3-property-literals"
+      },
+      "version-6.26.3-babel-plugin-transform-es5-property-mutators": {
+        "title": "babel-plugin-transform-es5-property-mutators",
+        "sidebar_label": "transform-es5-property-mutators"
+      },
+      "version-6.26.3-babel-plugin-transform-eval": {
+        "title": "babel-plugin-transform-eval",
+        "sidebar_label": "transform-eval"
+      },
+      "version-6.26.3-babel-plugin-transform-exponentiation-operator": {
+        "title": "babel-plugin-transform-exponentiation-operator",
+        "sidebar_label": "transform-exponentiation-operator"
+      },
+      "version-6.26.3-babel-plugin-transform-export-extensions": {
+        "title": "babel-plugin-transform-export-extensions",
+        "sidebar_label": "transform-export-extensions"
+      },
+      "version-6.26.3-babel-plugin-transform-flow-comments": {
+        "title": "babel-plugin-transform-flow-comments",
+        "sidebar_label": "transform-flow-comments"
+      },
+      "version-6.26.3-babel-plugin-transform-flow-strip-types": {
+        "title": "babel-plugin-transform-flow-strip-types",
+        "sidebar_label": "transform-flow-strip-types"
+      },
+      "version-6.26.3-babel-plugin-transform-function-bind": {
+        "title": "babel-plugin-transform-function-bind",
+        "sidebar_label": "transform-function-bind"
+      },
+      "version-6.26.3-babel-plugin-transform-inline-consecutive-adds": {
+        "title": "babel-plugin-transform-inline-consecutive-adds",
+        "sidebar_label": "transform-inline-consecutive-adds"
+      },
+      "version-6.26.3-babel-plugin-transform-inline-environment-variables": {
+        "title": "babel-plugin-transform-inline-environment-variables",
+        "sidebar_label": "transform-inline-environment-variables"
+      },
+      "version-6.26.3-babel-plugin-transform-jscript": {
+        "title": "babel-plugin-transform-jscript",
+        "sidebar_label": "transform-jscript"
+      },
+      "version-6.26.3-babel-plugin-transform-member-expression-literals": {
+        "title": "babel-plugin-transform-member-expression-literals",
+        "sidebar_label": "transform-member-expression-literals"
+      },
+      "version-6.26.3-babel-plugin-transform-merge-sibling-variables": {
+        "title": "babel-plugin-transform-merge-sibling-variables",
+        "sidebar_label": "transform-merge-sibling-variables"
+      },
+      "version-6.26.3-babel-plugin-transform-minify-booleans": {
+        "title": "babel-plugin-transform-minify-booleans",
+        "sidebar_label": "transform-minify-booleans"
+      },
+      "version-6.26.3-babel-plugin-transform-node-env-inline": {
+        "title": "babel-plugin-transform-node-env-inline",
+        "sidebar_label": "transform-node-env-inline"
+      },
+      "version-6.26.3-babel-plugin-transform-object-assign": {
+        "title": "babel-plugin-transform-object-assign",
+        "sidebar_label": "transform-object-assign"
+      },
+      "version-6.26.3-babel-plugin-transform-object-rest-spread": {
+        "title": "babel-plugin-transform-object-rest-spread",
+        "sidebar_label": "transform-object-rest-spread"
+      },
+      "version-6.26.3-babel-plugin-transform-object-set-prototype-of-to-assign": {
+        "title": "babel-plugin-transform-object-set-prototype-of-to-assign",
+        "sidebar_label": "transform-object-set-prototype-of-to-assign"
+      },
+      "version-6.26.3-babel-plugin-transform-property-literals": {
+        "title": "babel-plugin-transform-property-literals",
+        "sidebar_label": "transform-property-literals"
+      },
+      "version-6.26.3-babel-plugin-transform-proto-to-assign": {
+        "title": "babel-plugin-transform-proto-to-assign",
+        "sidebar_label": "transform-proto-to-assign"
+      },
+      "version-6.26.3-babel-plugin-transform-react-constant-elements": {
+        "title": "babel-plugin-transform-react-constant-elements",
+        "sidebar_label": "transform-react-constant-elements"
+      },
+      "version-6.26.3-babel-plugin-transform-react-display-name": {
+        "title": "babel-plugin-transform-react-display-name",
+        "sidebar_label": "transform-react-display-name"
+      },
+      "version-6.26.3-babel-plugin-transform-react-inline-elements": {
+        "title": "babel-plugin-transform-react-inline-elements",
+        "sidebar_label": "transform-react-inline-elements"
+      },
+      "version-6.26.3-babel-plugin-transform-react-jsx-compat": {
+        "title": "babel-plugin-transform-react-jsx-compat",
+        "sidebar_label": "transform-react-jsx-compat"
+      },
+      "version-6.26.3-babel-plugin-transform-react-jsx-self": {
+        "title": "babel-plugin-transform-react-jsx-self",
+        "sidebar_label": "transform-react-jsx-self"
+      },
+      "version-6.26.3-babel-plugin-transform-react-jsx-source": {
+        "title": "babel-plugin-transform-react-jsx-source",
+        "sidebar_label": "transform-react-jsx-source"
+      },
+      "version-6.26.3-babel-plugin-transform-react-jsx": {
+        "title": "babel-plugin-transform-react-jsx",
+        "sidebar_label": "transform-react-jsx"
+      },
+      "version-6.26.3-babel-plugin-transform-regenerator": {
+        "title": "babel-plugin-transform-regenerator",
+        "sidebar_label": "transform-regenerator"
+      },
+      "version-6.26.3-babel-plugin-transform-regexp-constructors": {
+        "title": "babel-plugin-transform-regexp-constructors",
+        "sidebar_label": "transform-regexp-constructors"
+      },
+      "version-6.26.3-babel-plugin-transform-remove-console": {
+        "title": "babel-plugin-transform-remove-console",
+        "sidebar_label": "transform-remove-console"
+      },
+      "version-6.26.3-babel-plugin-transform-remove-debugger": {
+        "title": "babel-plugin-transform-remove-debugger",
+        "sidebar_label": "transform-remove-debugger"
+      },
+      "version-6.26.3-babel-plugin-transform-remove-undefined": {
+        "title": "babel-plugin-transform-remove-undefined",
+        "sidebar_label": "transform-remove-undefined"
+      },
+      "version-6.26.3-babel-plugin-transform-runtime": {
+        "title": "babel-plugin-transform-runtime",
+        "sidebar_label": "transform-runtime"
+      },
+      "version-6.26.3-babel-plugin-transform-simplify-comparison-operators": {
+        "title": "babel-plugin-transform-simplify-comparison-operators",
+        "sidebar_label": "transform-simplify-comparison-operators"
+      },
+      "version-6.26.3-babel-plugin-transform-strict-mode": {
+        "title": "babel-plugin-transform-strict-mode",
+        "sidebar_label": "transform-strict-mode"
+      },
+      "version-6.26.3-babel-plugin-transform-undefined-to-void": {
+        "title": "babel-plugin-transform-undefined-to-void",
+        "sidebar_label": "transform-undefined-to-void"
+      },
+      "version-6.26.3-babel-plugin-undeclared-variables-check": {
+        "title": "babel-plugin-undeclared-variables-check",
+        "sidebar_label": "undeclared-variables-check"
+      },
+      "version-6.26.3-plugins": {
+        "title": "Plugins"
+      },
+      "version-6.26.3-babel-polyfill": {
+        "title": "babel-polyfill",
+        "sidebar_label": "babel-polyfill"
+      },
+      "version-6.26.3-babel-preset-env": {
+        "title": "babel-preset-env",
+        "sidebar_label": "env"
+      },
+      "version-6.26.3-babel-preset-es2015": {
+        "title": "babel-preset-es2015",
+        "sidebar_label": "es2015"
+      },
+      "version-6.26.3-babel-preset-es2016": {
+        "title": "babel-preset-es2016",
+        "sidebar_label": "es2016"
+      },
+      "version-6.26.3-babel-preset-es2017": {
+        "title": "babel-preset-es2017",
+        "sidebar_label": "es2017"
+      },
+      "version-6.26.3-babel-preset-flow": {
+        "title": "babel-preset-flow",
+        "sidebar_label": "flow"
+      },
+      "version-6.26.3-babel-preset-latest": {
+        "title": "babel-preset-latest",
+        "sidebar_label": "latest"
+      },
+      "version-6.26.3-babel-preset-minify": {
+        "title": "babel-preset-minify",
+        "sidebar_label": "minify"
+      },
+      "version-6.26.3-babel-preset-react": {
+        "title": "babel-preset-react",
+        "sidebar_label": "react"
+      },
+      "version-6.26.3-babel-preset-stage-0": {
+        "title": "babel-preset-stage-0",
+        "sidebar_label": "stage-0"
+      },
+      "version-6.26.3-babel-preset-stage-1": {
+        "title": "babel-preset-stage-1",
+        "sidebar_label": "stage-1"
+      },
+      "version-6.26.3-babel-preset-stage-2": {
+        "title": "babel-preset-stage-2",
+        "sidebar_label": "stage-2"
+      },
+      "version-6.26.3-babel-preset-stage-3": {
+        "title": "babel-preset-stage-3",
+        "sidebar_label": "stage-3"
+      },
+      "version-6.26.3-babel-register": {
+        "title": "babel-register",
+        "sidebar_label": "babel-register"
+      },
+      "version-6.26.3-babel-runtime": {
+        "title": "babel-runtime",
+        "sidebar_label": "babel-runtime"
+      },
+      "version-6.26.3-babel-template": {
+        "title": "babel-template",
+        "sidebar_label": "babel-template"
+      },
+      "version-6.26.3-babel-traverse": {
+        "title": "babel-traverse",
+        "sidebar_label": "babel-traverse"
+      },
+      "version-6.26.3-babel-types": {
+        "title": "babel-types",
+        "sidebar_label": "babel-types"
+      },
+      "version-7.0.0-babelconfigjs": {
+        "title": "babel.config.js"
+      },
+      "version-7.0.0-babelrc": {
+        "title": ".babelrc"
+      },
+      "version-7.0.0-caveats": {
+        "title": "Caveats"
+      },
+      "version-7.0.0-babel-cli": {
+        "title": "@babel/cli",
+        "sidebar_label": "cli"
+      },
+      "version-7.0.0-babel-code-frame": {
+        "title": "@babel/code-frame",
+        "sidebar_label": "code-frame"
+      },
+      "version-7.0.0-config-files": {
+        "title": "Config Files"
+      },
+      "version-7.0.0-configuration": {
+        "title": "Configure Babel"
+      },
+      "version-7.0.0-core-packages": {
+        "title": "Babel's core packages"
+      },
+      "version-7.0.0-babel-core": {
+        "title": "@babel/core",
+        "sidebar_label": "core"
+      },
+      "version-7.0.0-env": {
+        "title": "babel-preset-es2015 -> babel-preset-env"
+      },
+      "version-7.0.0-faq": {
+        "title": "FAQ"
+      },
+      "version-7.0.0-babel-generator": {
+        "title": "@babel/generator",
+        "sidebar_label": "generator"
+      },
+      "version-7.0.0-gulp-babel-minify": {
+        "title": "gulp-babel-minify",
+        "sidebar_label": "gulp-babel-minify"
+      },
+      "version-7.0.0-babel-helper-annotate-as-pure": {
+        "title": "@babel/helper-annotate-as-pure",
+        "sidebar_label": "helper-annotate-as-pure"
+      },
+      "version-7.0.0-babel-helper-bindify-decorators": {
+        "title": "@babel/helper-bindify-decorators",
+        "sidebar_label": "helper-bindify-decorators"
+      },
+      "version-7.0.0-babel-helper-builder-react-jsx": {
+        "title": "@babel/helper-builder-react-jsx",
+        "sidebar_label": "helper-builder-react-jsx"
+      },
+      "version-7.0.0-babel-helper-evaluate-path": {
+        "title": "babel-helper-evaluate-path",
+        "sidebar_label": "babel-helper-evaluate-path"
+      },
+      "version-7.0.0-babel-helper-fixtures": {
+        "title": "@babel/helper-fixtures",
+        "sidebar_label": "helper-fixtures"
+      },
+      "version-7.0.0-babel-helper-flip-expressions": {
+        "title": "babel-helper-flip-expressions",
+        "sidebar_label": "babel-helper-flip-expressions"
+      },
+      "version-7.0.0-babel-helper-get-function-arity": {
+        "title": "@babel/helper-get-function-arity",
+        "sidebar_label": "helper-get-function-arity"
+      },
+      "version-7.0.0-babel-helper-hoist-variables": {
+        "title": "@babel/helper-hoist-variables",
+        "sidebar_label": "helper-hoist-variables"
+      },
+      "version-7.0.0-babel-helper-is-void-0": {
+        "title": "babel-helper-is-void-0",
+        "sidebar_label": "babel-helper-is-void-0"
+      },
+      "version-7.0.0-babel-helper-mark-eval-scopes": {
+        "title": "babel-helper-mark-eval-scopes",
+        "sidebar_label": "babel-helper-mark-eval-scopes"
+      },
+      "version-7.0.0-babel-helper-member-expression-to-functions": {
+        "title": "@babel/helper-member-expression-to-functions",
+        "sidebar_label": "helper-member-expression-to-functions"
+      },
+      "version-7.0.0-babel-helper-module-imports": {
+        "title": "@babel/helper-module-imports",
+        "sidebar_label": "helper-module-imports"
+      },
+      "version-7.0.0-babel-helper-module-transforms": {
+        "title": "@babel/helper-module-transforms",
+        "sidebar_label": "helper-module-transforms"
+      },
+      "version-7.0.0-babel-helper-plugin-test-runner": {
+        "title": "@babel/helper-plugin-test-runner",
+        "sidebar_label": "helper-plugin-test-runner"
+      },
+      "version-7.0.0-babel-helper-plugin-utils": {
+        "title": "@babel/helper-plugin-utils",
+        "sidebar_label": "helper-plugin-utils"
+      },
+      "version-7.0.0-babel-helper-remove-or-void": {
+        "title": "babel-helper-remove-or-void",
+        "sidebar_label": "babel-helper-remove-or-void"
+      },
+      "version-7.0.0-babel-helper-simple-access": {
+        "title": "@babel/helper-simple-access",
+        "sidebar_label": "helper-simple-access"
+      },
+      "version-7.0.0-babel-helper-split-export-declaration": {
+        "title": "@babel/helper-split-export-declaration",
+        "sidebar_label": "helper-split-export-declaration"
+      },
+      "version-7.0.0-babel-helper-to-multiple-sequence-expressions": {
+        "title": "babel-helper-to-multiple-sequence-expressions",
+        "sidebar_label": "babel-helper-to-multiple-sequence-expressions"
+      },
+      "version-7.0.0-babel-helper-transform-fixture-test-runner": {
+        "title": "@babel/helper-transform-fixture-test-runner",
+        "sidebar_label": "helper-transform-fixture-test-runner"
+      },
+      "version-7.0.0-babel-helper-wrap-function": {
+        "title": "@babel/helper-wrap-function",
+        "sidebar_label": "helper-wrap-function"
+      },
+      "version-7.0.0-babel-helpers": {
+        "title": "@babel/helpers",
+        "sidebar_label": "helpers"
+      },
+      "version-7.0.0-babel-highlight": {
+        "title": "@babel/highlight",
+        "sidebar_label": "highlight"
+      },
+      "version-7.0.0-index": {
+        "title": "What is Babel?"
+      },
+      "version-7.0.0-learn": {
+        "title": "Learn ES2015"
+      },
+      "version-7.0.0-babel-minify": {
+        "title": "babel-minify",
+        "sidebar_label": "babel-minify"
+      },
+      "version-7.0.0-babel-node": {
+        "title": "@babel/node",
+        "sidebar_label": "node"
+      },
+      "version-7.0.0-options": {
+        "title": "Options"
+      },
+      "version-7.0.0-babel-parser": {
+        "title": "@babel/parser",
+        "sidebar_label": "parser"
+      },
+      "version-7.0.0-babel-plugin-external-helpers": {
+        "title": "@babel/plugin-external-helpers",
+        "sidebar_label": "external-helpers"
+      },
+      "version-7.0.0-babel-plugin-minify-builtins": {
+        "title": "babel-plugin-minify-builtins",
+        "sidebar_label": "minify-builtins"
+      },
+      "version-7.0.0-babel-plugin-minify-constant-folding": {
+        "title": "babel-plugin-minify-constant-folding",
+        "sidebar_label": "minify-constant-folding"
+      },
+      "version-7.0.0-babel-plugin-minify-dead-code-elimination": {
+        "title": "babel-plugin-minify-dead-code-elimination",
+        "sidebar_label": "minify-dead-code-elimination"
+      },
+      "version-7.0.0-babel-plugin-minify-flip-comparisons": {
+        "title": "babel-plugin-minify-flip-comparisons",
+        "sidebar_label": "minify-flip-comparisons"
+      },
+      "version-7.0.0-babel-plugin-minify-guarded-expressions": {
+        "title": "babel-plugin-minify-guarded-expressions",
+        "sidebar_label": "minify-guarded-expressions"
+      },
+      "version-7.0.0-babel-plugin-minify-infinity": {
+        "title": "babel-plugin-minify-infinity",
+        "sidebar_label": "minify-infinity"
+      },
+      "version-7.0.0-babel-plugin-minify-mangle-names": {
+        "title": "babel-plugin-minify-mangle-names",
+        "sidebar_label": "minify-mangle-names"
+      },
+      "version-7.0.0-babel-plugin-minify-numeric-literals": {
+        "title": "babel-plugin-minify-numeric-literals",
+        "sidebar_label": "minify-numeric-literals"
+      },
+      "version-7.0.0-babel-plugin-minify-replace": {
+        "title": "babel-plugin-minify-replace",
+        "sidebar_label": "minify-replace"
+      },
+      "version-7.0.0-babel-plugin-minify-simplify": {
+        "title": "babel-plugin-minify-simplify",
+        "sidebar_label": "minify-simplify"
+      },
+      "version-7.0.0-babel-plugin-minify-type-constructors": {
+        "title": "babel-plugin-minify-type-constructors",
+        "sidebar_label": "minify-type-constructors"
+      },
+      "version-7.0.0-babel-plugin-proposal-async-generator-functions": {
+        "title": "@babel/plugin-proposal-async-generator-functions",
+        "sidebar_label": "proposal-async-generator-functions"
+      },
+      "version-7.0.0-babel-plugin-proposal-class-properties": {
+        "title": "@babel/plugin-proposal-class-properties",
+        "sidebar_label": "proposal-class-properties"
+      },
+      "version-7.0.0-babel-plugin-proposal-decorators": {
+        "title": "@babel/plugin-proposal-decorators",
+        "sidebar_label": "proposal-decorators"
+      },
+      "version-7.0.0-babel-plugin-proposal-do-expressions": {
+        "title": "@babel/plugin-proposal-do-expressions",
+        "sidebar_label": "proposal-do-expressions"
+      },
+      "version-7.0.0-babel-plugin-proposal-export-default-from": {
+        "title": "@babel/plugin-proposal-export-default-from",
+        "sidebar_label": "proposal-export-default-from"
+      },
+      "version-7.0.0-babel-plugin-proposal-export-namespace-from": {
+        "title": "@babel/plugin-proposal-export-namespace-from",
+        "sidebar_label": "proposal-export-namespace-from"
+      },
+      "version-7.0.0-babel-plugin-proposal-function-bind": {
+        "title": "@babel/plugin-proposal-function-bind",
+        "sidebar_label": "proposal-function-bind"
+      },
+      "version-7.0.0-babel-plugin-proposal-function-sent": {
+        "title": "@babel/plugin-proposal-function-sent",
+        "sidebar_label": "proposal-function-sent"
+      },
+      "version-7.0.0-babel-plugin-proposal-json-strings": {
+        "title": "@babel/plugin-proposal-json-strings",
+        "sidebar_label": "proposal-json-strings"
+      },
+      "version-7.0.0-babel-plugin-proposal-logical-assignment-operators": {
+        "title": "@babel/plugin-proposal-logical-assignment-operators",
+        "sidebar_label": "proposal-logical-assignment-operators"
+      },
+      "version-7.0.0-babel-plugin-proposal-nullish-coalescing-operator": {
+        "title": "@babel/plugin-proposal-nullish-coalescing-operator",
+        "sidebar_label": "proposal-nullish-coalescing-operator"
+      },
+      "version-7.0.0-babel-plugin-proposal-numeric-separator": {
+        "title": "@babel/plugin-proposal-numeric-separator",
+        "sidebar_label": "proposal-numeric-separator"
+      },
+      "version-7.0.0-babel-plugin-proposal-object-rest-spread": {
+        "title": "@babel/plugin-proposal-object-rest-spread",
+        "sidebar_label": "proposal-object-rest-spread"
+      },
+      "version-7.0.0-babel-plugin-proposal-optional-catch-binding": {
+        "title": "@babel/plugin-proposal-optional-catch-binding",
+        "sidebar_label": "proposal-optional-catch-binding"
+      },
+      "version-7.0.0-babel-plugin-proposal-optional-chaining": {
+        "title": "@babel/plugin-proposal-optional-chaining",
+        "sidebar_label": "proposal-optional-chaining"
+      },
+      "version-7.0.0-babel-plugin-proposal-pipeline-operator": {
+        "title": "@babel/plugin-proposal-pipeline-operator",
+        "sidebar_label": "proposal-pipeline-operator"
+      },
+      "version-7.0.0-babel-plugin-proposal-throw-expressions": {
+        "title": "@babel/plugin-proposal-throw-expressions",
+        "sidebar_label": "proposal-throw-expressions"
+      },
+      "version-7.0.0-babel-plugin-proposal-unicode-property-regex": {
+        "title": "@babel/plugin-proposal-unicode-property-regex",
+        "sidebar_label": "proposal-unicode-property-regex"
+      },
+      "version-7.0.0-babel-plugin-syntax-async-generators": {
+        "title": "@babel/plugin-syntax-async-generators",
+        "sidebar_label": "syntax-async-generators"
+      },
+      "version-7.0.0-babel-plugin-syntax-bigint": {
+        "title": "@babel/plugin-syntax-bigint",
+        "sidebar_label": "syntax-bigint"
+      },
+      "version-7.0.0-babel-plugin-syntax-class-properties": {
+        "title": "@babel/plugin-syntax-class-properties",
+        "sidebar_label": "syntax-class-properties"
+      },
+      "version-7.0.0-babel-plugin-syntax-decorators": {
+        "title": "@babel/plugin-syntax-decorators",
+        "sidebar_label": "syntax-decorators"
+      },
+      "version-7.0.0-babel-plugin-syntax-do-expressions": {
+        "title": "@babel/plugin-syntax-do-expressions",
+        "sidebar_label": "syntax-do-expressions"
+      },
+      "version-7.0.0-babel-plugin-syntax-dynamic-import": {
+        "title": "@babel/plugin-syntax-dynamic-import",
+        "sidebar_label": "syntax-dynamic-import"
+      },
+      "version-7.0.0-babel-plugin-syntax-export-default-from": {
+        "title": "@babel/plugin-syntax-export-default-from",
+        "sidebar_label": "syntax-export-default-from"
+      },
+      "version-7.0.0-babel-plugin-syntax-export-namespace-from": {
+        "title": "@babel/plugin-syntax-export-namespace-from",
+        "sidebar_label": "syntax-export-namespace-from"
+      },
+      "version-7.0.0-babel-plugin-syntax-flow": {
+        "title": "@babel/plugin-syntax-flow",
+        "sidebar_label": "syntax-flow"
+      },
+      "version-7.0.0-babel-plugin-syntax-function-bind": {
+        "title": "@babel/plugin-syntax-function-bind",
+        "sidebar_label": "syntax-function-bind"
+      },
+      "version-7.0.0-babel-plugin-syntax-function-sent": {
+        "title": "@babel/plugin-syntax-function-sent",
+        "sidebar_label": "syntax-function-sent"
+      },
+      "version-7.0.0-babel-plugin-syntax-import-meta": {
+        "title": "@babel/plugin-syntax-import-meta",
+        "sidebar_label": "syntax-import-meta"
+      },
+      "version-7.0.0-babel-plugin-syntax-json-strings": {
+        "title": "@babel/plugin-syntax-json-strings",
+        "sidebar_label": "syntax-json-strings"
+      },
+      "version-7.0.0-babel-plugin-syntax-jsx": {
+        "title": "@babel/plugin-syntax-jsx",
+        "sidebar_label": "syntax-jsx"
+      },
+      "version-7.0.0-babel-plugin-syntax-logical-assignment-operators": {
+        "title": "@babel/plugin-syntax-logical-assignment-operators",
+        "sidebar_label": "syntax-logical-assignment-operators"
+      },
+      "version-7.0.0-babel-plugin-syntax-nullish-coalescing-operator": {
+        "title": "@babel/plugin-syntax-nullish-coalescing-operator",
+        "sidebar_label": "syntax-nullish-coalescing-operator"
+      },
+      "version-7.0.0-babel-plugin-syntax-numeric-separator": {
+        "title": "@babel/plugin-syntax-numeric-separator",
+        "sidebar_label": "syntax-numeric-separator"
+      },
+      "version-7.0.0-babel-plugin-syntax-object-rest-spread": {
+        "title": "@babel/plugin-syntax-object-rest-spread",
+        "sidebar_label": "syntax-object-rest-spread"
+      },
+      "version-7.0.0-babel-plugin-syntax-optional-catch-binding": {
+        "title": "@babel/plugin-syntax-optional-catch-binding",
+        "sidebar_label": "syntax-optional-catch-binding"
+      },
+      "version-7.0.0-babel-plugin-syntax-optional-chaining": {
+        "title": "@babel/plugin-syntax-optional-chaining",
+        "sidebar_label": "syntax-optional-chaining"
+      },
+      "version-7.0.0-babel-plugin-syntax-pipeline-operator": {
+        "title": "@babel/plugin-syntax-pipeline-operator",
+        "sidebar_label": "syntax-pipeline-operator"
+      },
+      "version-7.0.0-babel-plugin-syntax-throw-expressions": {
+        "title": "@babel/plugin-syntax-throw-expressions",
+        "sidebar_label": "syntax-throw-expressions"
+      },
+      "version-7.0.0-babel-plugin-syntax-typescript": {
+        "title": "@babel/plugin-syntax-typescript",
+        "sidebar_label": "syntax-typescript"
+      },
+      "version-7.0.0-babel-plugin-transform-arrow-functions": {
+        "title": "@babel/plugin-transform-arrow-functions",
+        "sidebar_label": "transform-arrow-functions"
+      },
+      "version-7.0.0-babel-plugin-transform-async-to-generator": {
+        "title": "@babel/plugin-transform-async-to-generator",
+        "sidebar_label": "transform-async-to-generator"
+      },
+      "version-7.0.0-babel-plugin-transform-block-scoped-functions": {
+        "title": "@babel/plugin-transform-block-scoped-functions",
+        "sidebar_label": "transform-block-scoped-functions"
+      },
+      "version-7.0.0-babel-plugin-transform-block-scoping": {
+        "title": "@babel/plugin-transform-block-scoping",
+        "sidebar_label": "transform-block-scoping"
+      },
+      "version-7.0.0-babel-plugin-transform-classes": {
+        "title": "@babel/plugin-transform-classes",
+        "sidebar_label": "transform-classes"
+      },
+      "version-7.0.0-babel-plugin-transform-computed-properties": {
+        "title": "@babel/plugin-transform-computed-properties",
+        "sidebar_label": "transform-computed-properties"
+      },
+      "version-7.0.0-babel-plugin-transform-destructuring": {
+        "title": "@babel/plugin-transform-destructuring",
+        "sidebar_label": "transform-destructuring"
+      },
+      "version-7.0.0-babel-plugin-transform-dotall-regex": {
+        "title": "@babel/plugin-transform-dotall-regex",
+        "sidebar_label": "transform-dotall-regex"
+      },
+      "version-7.0.0-babel-plugin-transform-duplicate-keys": {
+        "title": "@babel/plugin-transform-duplicate-keys",
+        "sidebar_label": "transform-duplicate-keys"
+      },
+      "version-7.0.0-babel-plugin-transform-exponentiation-operator": {
+        "title": "@babel/plugin-transform-exponentiation-operator",
+        "sidebar_label": "transform-exponentiation-operator"
+      },
+      "version-7.0.0-babel-plugin-transform-flow-comments": {
+        "title": "@babel/plugin-transform-flow-comments",
+        "sidebar_label": "transform-flow-comments"
+      },
+      "version-7.0.0-babel-plugin-transform-flow-strip-types": {
+        "title": "@babel/plugin-transform-flow-strip-types",
+        "sidebar_label": "transform-flow-strip-types"
+      },
+      "version-7.0.0-babel-plugin-transform-for-of": {
+        "title": "@babel/plugin-transform-for-of",
+        "sidebar_label": "transform-for-of"
+      },
+      "version-7.0.0-babel-plugin-transform-function-name": {
+        "title": "@babel/plugin-transform-function-name",
+        "sidebar_label": "transform-function-name"
+      },
+      "version-7.0.0-babel-plugin-transform-inline-consecutive-adds": {
+        "title": "@babel/plugin-transform-inline-consecutive-adds",
+        "sidebar_label": "transform-inline-consecutive-adds"
+      },
+      "version-7.0.0-babel-plugin-transform-inline-environment-variables": {
+        "title": "babel-plugin-transform-inline-environment-variables",
+        "sidebar_label": "transform-inline-environment-variables"
+      },
+      "version-7.0.0-babel-plugin-transform-instanceof": {
+        "title": "@babel/plugin-transform-instanceof",
+        "sidebar_label": "transform-instanceof"
+      },
+      "version-7.0.0-babel-plugin-transform-jscript": {
+        "title": "@babel/plugin-transform-jscript",
+        "sidebar_label": "transform-jscript"
+      },
+      "version-7.0.0-babel-plugin-transform-literals": {
+        "title": "@babel/plugin-transform-literals",
+        "sidebar_label": "transform-literals"
+      },
+      "version-7.0.0-babel-plugin-transform-member-expression-literals": {
+        "title": "babel-plugin-transform-member-expression-literals",
+        "sidebar_label": "transform-member-expression-literals"
+      },
+      "version-7.0.0-babel-plugin-transform-merge-sibling-variables": {
+        "title": "babel-plugin-transform-merge-sibling-variables",
+        "sidebar_label": "transform-merge-sibling-variables"
+      },
+      "version-7.0.0-babel-plugin-transform-minify-booleans": {
+        "title": "babel-plugin-transform-minify-booleans",
+        "sidebar_label": "transform-minify-booleans"
+      },
+      "version-7.0.0-babel-plugin-transform-modules-amd": {
+        "title": "@babel/plugin-transform-modules-amd",
+        "sidebar_label": "transform-modules-amd"
+      },
+      "version-7.0.0-babel-plugin-transform-modules-commonjs": {
+        "title": "@babel/plugin-transform-modules-commonjs",
+        "sidebar_label": "transform-modules-commonjs"
+      },
+      "version-7.0.0-babel-plugin-transform-modules-systemjs": {
+        "title": "@babel/plugin-transform-modules-systemjs",
+        "sidebar_label": "transform-modules-systemjs"
+      },
+      "version-7.0.0-babel-plugin-transform-modules-umd": {
+        "title": "@babel/plugin-transform-modules-umd",
+        "sidebar_label": "transform-modules-umd"
+      },
+      "version-7.0.0-babel-plugin-transform-new-target": {
+        "title": "@babel/plugin-transform-new-target",
+        "sidebar_label": "transform-new-target"
+      },
+      "version-7.0.0-babel-plugin-transform-node-env-inline": {
+        "title": "babel-plugin-transform-node-env-inline",
+        "sidebar_label": "transform-node-env-inline"
+      },
+      "version-7.0.0-babel-plugin-transform-object-assign": {
+        "title": "@babel/plugin-transform-object-assign",
+        "sidebar_label": "transform-object-assign"
+      },
+      "version-7.0.0-babel-plugin-transform-object-set-prototype-of-to-assign": {
+        "title": "@babel/plugin-transform-object-set-prototype-of-to-assign",
+        "sidebar_label": "transform-object-set-prototype-of-to-assign"
+      },
+      "version-7.0.0-babel-plugin-transform-object-super": {
+        "title": "@babel/plugin-transform-object-super",
+        "sidebar_label": "transform-object-super"
+      },
+      "version-7.0.0-babel-plugin-transform-parameters": {
+        "title": "@babel/plugin-transform-parameters",
+        "sidebar_label": "transform-parameters"
+      },
+      "version-7.0.0-babel-plugin-transform-property-literals": {
+        "title": "babel-plugin-transform-property-literals",
+        "sidebar_label": "transform-property-literals"
+      },
+      "version-7.0.0-babel-plugin-transform-property-mutators": {
+        "title": "@babel/plugin-transform-property-mutators",
+        "sidebar_label": "transform-property-mutators"
+      },
+      "version-7.0.0-babel-plugin-transform-proto-to-assign": {
+        "title": "@babel/plugin-transform-proto-to-assign",
+        "sidebar_label": "transform-proto-to-assign"
+      },
+      "version-7.0.0-babel-plugin-transform-react-constant-elements": {
+        "title": "@babel/plugin-transform-react-constant-elements",
+        "sidebar_label": "transform-react-constant-elements"
+      },
+      "version-7.0.0-babel-plugin-transform-react-display-name": {
+        "title": "@babel/plugin-transform-react-display-name",
+        "sidebar_label": "transform-react-display-name"
+      },
+      "version-7.0.0-babel-plugin-transform-react-inline-elements": {
+        "title": "@babel/plugin-transform-react-inline-elements",
+        "sidebar_label": "transform-react-inline-elements"
+      },
+      "version-7.0.0-babel-plugin-transform-react-jsx-compat": {
+        "title": "@babel/plugin-transform-react-jsx-compat",
+        "sidebar_label": "transform-react-jsx-compat"
+      },
+      "version-7.0.0-babel-plugin-transform-react-jsx-self": {
+        "title": "@babel/plugin-transform-react-jsx-self",
+        "sidebar_label": "transform-react-jsx-self"
+      },
+      "version-7.0.0-babel-plugin-transform-react-jsx-source": {
+        "title": "@babel/plugin-transform-react-jsx-source",
+        "sidebar_label": "transform-react-jsx-source"
+      },
+      "version-7.0.0-babel-plugin-transform-react-jsx": {
+        "title": "@babel/plugin-transform-react-jsx",
+        "sidebar_label": "transform-react-jsx"
+      },
+      "version-7.0.0-babel-plugin-transform-regenerator": {
+        "title": "@babel/plugin-transform-regenerator",
+        "sidebar_label": "transform-regenerator"
+      },
+      "version-7.0.0-babel-plugin-transform-regexp-constructors": {
+        "title": "babel-plugin-transform-regexp-constructors",
+        "sidebar_label": "transform-regexp-constructors"
+      },
+      "version-7.0.0-babel-plugin-transform-remove-console": {
+        "title": "babel-plugin-transform-remove-console",
+        "sidebar_label": "transform-remove-console"
+      },
+      "version-7.0.0-babel-plugin-transform-remove-debugger": {
+        "title": "babel-plugin-transform-remove-debugger",
+        "sidebar_label": "transform-remove-debugger"
+      },
+      "version-7.0.0-babel-plugin-transform-remove-undefined": {
+        "title": "babel-plugin-transform-remove-undefined",
+        "sidebar_label": "transform-remove-undefined"
+      },
+      "version-7.0.0-babel-plugin-transform-reserved-words": {
+        "title": "@babel/plugin-transform-reserved-words",
+        "sidebar_label": "transform-reserved-words"
+      },
+      "version-7.0.0-babel-plugin-transform-runtime": {
+        "title": "@babel/plugin-transform-runtime",
+        "sidebar_label": "transform-runtime"
+      },
+      "version-7.0.0-babel-plugin-transform-shorthand-properties": {
+        "title": "@babel/plugin-transform-shorthand-properties",
+        "sidebar_label": "transform-shorthand-properties"
+      },
+      "version-7.0.0-babel-plugin-transform-simplify-comparison-operators": {
+        "title": "babel-plugin-transform-simplify-comparison-operators",
+        "sidebar_label": "transform-simplify-comparison-operators"
+      },
+      "version-7.0.0-babel-plugin-transform-spread": {
+        "title": "@babel/plugin-transform-spread",
+        "sidebar_label": "transform-spread"
+      },
+      "version-7.0.0-babel-plugin-transform-sticky-regex": {
+        "title": "@babel/plugin-transform-sticky-regex",
+        "sidebar_label": "transform-sticky-regex"
+      },
+      "version-7.0.0-babel-plugin-transform-strict-mode": {
+        "title": "@babel/plugin-transform-strict-mode",
+        "sidebar_label": "transform-strict-mode"
+      },
+      "version-7.0.0-babel-plugin-transform-template-literals": {
+        "title": "@babel/plugin-transform-template-literals",
+        "sidebar_label": "transform-template-literals"
+      },
+      "version-7.0.0-babel-plugin-transform-typeof-symbol": {
+        "title": "@babel/plugin-transform-typeof-symbol",
+        "sidebar_label": "transform-typeof-symbol"
+      },
+      "version-7.0.0-babel-plugin-transform-typescript": {
+        "title": "@babel/plugin-transform-typescript",
+        "sidebar_label": "transform-typescript"
+      },
+      "version-7.0.0-babel-plugin-transform-undefined-to-void": {
+        "title": "babel-plugin-transform-undefined-to-void",
+        "sidebar_label": "transform-undefined-to-void"
+      },
+      "version-7.0.0-babel-plugin-transform-unicode-regex": {
+        "title": "@babel/plugin-transform-unicode-regex",
+        "sidebar_label": "transform-unicode-regex"
+      },
+      "version-7.0.0-plugins": {
+        "title": "Plugins"
+      },
+      "version-7.0.0-babel-polyfill": {
+        "title": "@babel/polyfill",
+        "sidebar_label": "polyfill"
+      },
+      "version-7.0.0-babel-preset-env-standalone": {
+        "title": "@babel/preset-env-standalone",
+        "sidebar_label": "env-standalone"
+      },
+      "version-7.0.0-babel-preset-env": {
+        "title": "@babel/preset-env",
+        "sidebar_label": "env"
+      },
+      "version-7.0.0-babel-preset-es2015": {
+        "title": "@babel/preset-es2015",
+        "sidebar_label": "es2015"
+      },
+      "version-7.0.0-babel-preset-es2016": {
+        "title": "@babel/preset-es2016",
+        "sidebar_label": "es2016"
+      },
+      "version-7.0.0-babel-preset-es2017": {
+        "title": "@babel/preset-es2017",
+        "sidebar_label": "es2017"
+      },
+      "version-7.0.0-babel-preset-flow": {
+        "title": "@babel/preset-flow",
+        "sidebar_label": "flow"
+      },
+      "version-7.0.0-babel-preset-minify": {
+        "title": "babel-preset-minify",
+        "sidebar_label": "minify"
+      },
+      "version-7.0.0-babel-preset-react": {
+        "title": "@babel/preset-react",
+        "sidebar_label": "react"
+      },
+      "version-7.0.0-babel-preset-stage-0": {
+        "title": "@babel/preset-stage-0",
+        "sidebar_label": "stage-0"
+      },
+      "version-7.0.0-babel-preset-stage-1": {
+        "title": "@babel/preset-stage-1",
+        "sidebar_label": "stage-1"
+      },
+      "version-7.0.0-babel-preset-stage-2": {
+        "title": "@babel/preset-stage-2",
+        "sidebar_label": "stage-2"
+      },
+      "version-7.0.0-babel-preset-stage-3": {
+        "title": "@babel/preset-stage-3",
+        "sidebar_label": "stage-3"
+      },
+      "version-7.0.0-babel-preset-typescript": {
+        "title": "@babel/preset-typescript",
+        "sidebar_label": "typescript"
+      },
+      "version-7.0.0-presets": {
+        "title": "Presets"
+      },
+      "version-7.0.0-babel-register": {
+        "title": "@babel/register",
+        "sidebar_label": "register"
+      },
+      "version-7.0.0-roadmap": {
+        "title": "Babel Roadmap",
+        "sidebar_label": "Roadmap"
+      },
+      "version-7.0.0-babel-runtime-corejs2": {
+        "title": "@babel/runtime-corejs2",
+        "sidebar_label": "runtime-corejs2"
+      },
+      "version-7.0.0-babel-runtime": {
+        "title": "@babel/runtime",
+        "sidebar_label": "runtime"
+      },
+      "version-7.0.0-babel-standalone": {
+        "title": "@babel/standalone",
+        "sidebar_label": "standalone"
+      },
+      "version-7.0.0-babel-template": {
+        "title": "@babel/template",
+        "sidebar_label": "template"
+      },
+      "version-7.0.0-babel-traverse": {
+        "title": "@babel/traverse",
+        "sidebar_label": "traverse"
+      },
+      "version-7.0.0-babel-types": {
+        "title": "@babel/types",
+        "sidebar_label": "types"
+      },
+      "version-7.0.0-usage": {
+        "title": "Usage Guide"
+      },
+      "version-7.0.0-v7-migration-api": {
+        "title": "Upgrade to Babel 7 (API)"
+      },
+      "version-7.0.0-v7-migration": {
+        "title": "Upgrade to Babel 7"
+      }
+    },
+    "links": {
+      "Docs": "Docs",
+      "Setup": "Setup",
+      "Try it out": "Try it out",
+      "Blog": "Blog",
+      "Donate": "Donate",
+      "Team": "Team",
+      "GitHub": "GitHub"
+    },
+    "categories": {
+      "Guides": "Guides",
+      "General": "General",
+      "Usage": "Usage",
+      "Presets": "Presets",
+      "Tooling": "Tooling"
+    }
   },
   "pages-strings": {
     "Put in next-gen JavaScript|no description given": "Put in next-gen JavaScript",

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,6 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "^1.3.3"
+    "docusaurus": "^1.4.0"
   }
 }

--- a/website/versioned_docs/version-7.0.0/cli.md
+++ b/website/versioned_docs/version-7.0.0/cli.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-cli
 title: @babel/cli
-sidebar_label: babel-cli
+sidebar_label: cli
 original_id: babel-cli
 ---
 

--- a/website/versioned_docs/version-7.0.0/code-frame.md
+++ b/website/versioned_docs/version-7.0.0/code-frame.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-code-frame
 title: @babel/code-frame
-sidebar_label: babel-code-frame
+sidebar_label: code-frame
 original_id: babel-code-frame
 ---
 

--- a/website/versioned_docs/version-7.0.0/core.md
+++ b/website/versioned_docs/version-7.0.0/core.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-core
 title: @babel/core
-sidebar_label: babel-core
+sidebar_label: core
 original_id: babel-core
 ---
 

--- a/website/versioned_docs/version-7.0.0/generator.md
+++ b/website/versioned_docs/version-7.0.0/generator.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-generator
 title: @babel/generator
-sidebar_label: babel-generator
+sidebar_label: generator
 original_id: babel-generator
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-annotate-as-pure.md
+++ b/website/versioned_docs/version-7.0.0/helper-annotate-as-pure.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-annotate-as-pure
 title: @babel/helper-annotate-as-pure
-sidebar_label: babel-helper-annotate-as-pure
+sidebar_label: helper-annotate-as-pure
 original_id: babel-helper-annotate-as-pure
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-bindify-decorators.md
+++ b/website/versioned_docs/version-7.0.0/helper-bindify-decorators.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-bindify-decorators
 title: @babel/helper-bindify-decorators
-sidebar_label: babel-helper-bindify-decorators
+sidebar_label: helper-bindify-decorators
 original_id: babel-helper-bindify-decorators
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-builder-react-jsx.md
+++ b/website/versioned_docs/version-7.0.0/helper-builder-react-jsx.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-builder-react-jsx
 title: @babel/helper-builder-react-jsx
-sidebar_label: babel-helper-builder-react-jsx
+sidebar_label: helper-builder-react-jsx
 original_id: babel-helper-builder-react-jsx
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-fixtures.md
+++ b/website/versioned_docs/version-7.0.0/helper-fixtures.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-fixtures
 title: @babel/helper-fixtures
-sidebar_label: babel-helper-fixtures
+sidebar_label: helper-fixtures
 original_id: babel-helper-fixtures
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-get-function-arity.md
+++ b/website/versioned_docs/version-7.0.0/helper-get-function-arity.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-get-function-arity
 title: @babel/helper-get-function-arity
-sidebar_label: babel-helper-get-function-arity
+sidebar_label: helper-get-function-arity
 original_id: babel-helper-get-function-arity
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-hoist-variables.md
+++ b/website/versioned_docs/version-7.0.0/helper-hoist-variables.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-hoist-variables
 title: @babel/helper-hoist-variables
-sidebar_label: babel-helper-hoist-variables
+sidebar_label: helper-hoist-variables
 original_id: babel-helper-hoist-variables
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-member-expression-to-functions.md
+++ b/website/versioned_docs/version-7.0.0/helper-member-expression-to-functions.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-member-expression-to-functions
 title: @babel/helper-member-expression-to-functions
-sidebar_label: babel-helper-member-expression-to-functions
+sidebar_label: helper-member-expression-to-functions
 original_id: babel-helper-member-expression-to-functions
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-module-imports.md
+++ b/website/versioned_docs/version-7.0.0/helper-module-imports.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-module-imports
 title: @babel/helper-module-imports
-sidebar_label: babel-helper-module-imports
+sidebar_label: helper-module-imports
 original_id: babel-helper-module-imports
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-module-transforms.md
+++ b/website/versioned_docs/version-7.0.0/helper-module-transforms.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-module-transforms
 title: @babel/helper-module-transforms
-sidebar_label: babel-helper-module-transforms
+sidebar_label: helper-module-transforms
 original_id: babel-helper-module-transforms
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-plugin-test-runner.md
+++ b/website/versioned_docs/version-7.0.0/helper-plugin-test-runner.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-plugin-test-runner
 title: @babel/helper-plugin-test-runner
-sidebar_label: babel-helper-plugin-test-runner
+sidebar_label: helper-plugin-test-runner
 original_id: babel-helper-plugin-test-runner
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-plugin-utils.md
+++ b/website/versioned_docs/version-7.0.0/helper-plugin-utils.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-plugin-utils
 title: @babel/helper-plugin-utils
-sidebar_label: babel-helper-plugin-utils
+sidebar_label: helper-plugin-utils
 original_id: babel-helper-plugin-utils
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-simple-access.md
+++ b/website/versioned_docs/version-7.0.0/helper-simple-access.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-simple-access
 title: @babel/helper-simple-access
-sidebar_label: babel-helper-simple-access
+sidebar_label: helper-simple-access
 original_id: babel-helper-simple-access
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-split-export-declaration.md
+++ b/website/versioned_docs/version-7.0.0/helper-split-export-declaration.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-split-export-declaration
 title: @babel/helper-split-export-declaration
-sidebar_label: babel-helper-split-export-declaration
+sidebar_label: helper-split-export-declaration
 original_id: babel-helper-split-export-declaration
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-transform-fixture-test-runner.md
+++ b/website/versioned_docs/version-7.0.0/helper-transform-fixture-test-runner.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-transform-fixture-test-runner
 title: @babel/helper-transform-fixture-test-runner
-sidebar_label: babel-helper-transform-fixture-test-runner
+sidebar_label: helper-transform-fixture-test-runner
 original_id: babel-helper-transform-fixture-test-runner
 ---
 

--- a/website/versioned_docs/version-7.0.0/helper-wrap-function.md
+++ b/website/versioned_docs/version-7.0.0/helper-wrap-function.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helper-wrap-function
 title: @babel/helper-wrap-function
-sidebar_label: babel-helper-wrap-function
+sidebar_label: helper-wrap-function
 original_id: babel-helper-wrap-function
 ---
 

--- a/website/versioned_docs/version-7.0.0/helpers.md
+++ b/website/versioned_docs/version-7.0.0/helpers.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-helpers
 title: @babel/helpers
-sidebar_label: babel-helpers
+sidebar_label: helpers
 original_id: babel-helpers
 ---
 

--- a/website/versioned_docs/version-7.0.0/highlight.md
+++ b/website/versioned_docs/version-7.0.0/highlight.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-highlight
 title: @babel/highlight
-sidebar_label: babel-highlight
+sidebar_label: highlight
 original_id: babel-highlight
 ---
 

--- a/website/versioned_docs/version-7.0.0/node.md
+++ b/website/versioned_docs/version-7.0.0/node.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-node
 title: @babel/node
-sidebar_label: babel-node
+sidebar_label: node
 original_id: babel-node
 ---
 

--- a/website/versioned_docs/version-7.0.0/parser.md
+++ b/website/versioned_docs/version-7.0.0/parser.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-parser
 title: @babel/parser
-sidebar_label: babel-parser
+sidebar_label: parser
 original_id: babel-parser
 ---
 

--- a/website/versioned_docs/version-7.0.0/polyfill.md
+++ b/website/versioned_docs/version-7.0.0/polyfill.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-polyfill
 title: @babel/polyfill
-sidebar_label: babel-polyfill
+sidebar_label: polyfill
 original_id: babel-polyfill
 ---
 

--- a/website/versioned_docs/version-7.0.0/register.md
+++ b/website/versioned_docs/version-7.0.0/register.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-register
 title: @babel/register
-sidebar_label: babel-register
+sidebar_label: register
 original_id: babel-register
 ---
 

--- a/website/versioned_docs/version-7.0.0/runtime-corejs2.md
+++ b/website/versioned_docs/version-7.0.0/runtime-corejs2.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-runtime-corejs2
 title: @babel/runtime-corejs2
-sidebar_label: babel-runtime-corejs2
+sidebar_label: runtime-corejs2
 original_id: babel-runtime-corejs2
 ---
 

--- a/website/versioned_docs/version-7.0.0/runtime.md
+++ b/website/versioned_docs/version-7.0.0/runtime.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-runtime
 title: @babel/runtime
-sidebar_label: babel-runtime
+sidebar_label: runtime
 original_id: babel-runtime
 ---
 

--- a/website/versioned_docs/version-7.0.0/standalone.md
+++ b/website/versioned_docs/version-7.0.0/standalone.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-standalone
 title: @babel/standalone
-sidebar_label: babel-standalone
+sidebar_label: standalone
 original_id: babel-standalone
 ---
 

--- a/website/versioned_docs/version-7.0.0/template.md
+++ b/website/versioned_docs/version-7.0.0/template.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-template
 title: @babel/template
-sidebar_label: babel-template
+sidebar_label: template
 original_id: babel-template
 ---
 

--- a/website/versioned_docs/version-7.0.0/traverse.md
+++ b/website/versioned_docs/version-7.0.0/traverse.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-traverse
 title: @babel/traverse
-sidebar_label: babel-traverse
+sidebar_label: traverse
 original_id: babel-traverse
 ---
 

--- a/website/versioned_docs/version-7.0.0/types.md
+++ b/website/versioned_docs/version-7.0.0/types.md
@@ -1,7 +1,7 @@
 ---
 id: version-7.0.0-babel-types
 title: @babel/types
-sidebar_label: babel-types
+sidebar_label: types
 original_id: babel-types
 ---
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/cheerio@^0.22.8":
+  version "0.22.9"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.9.tgz#b5990152604c2ada749b7f88cab3476f21f39d7b"
+
 accepts@~1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
@@ -141,10 +145,6 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -176,12 +176,12 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-autoprefixer@^9.1.3:
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.1.3.tgz#bd5940ccb9d1bfa3508308659915f0a14394c8d5"
+autoprefixer@^9.1.5:
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.1.5.tgz#8675fd8d1c0d43069f3b19a2c316f3524e4f6671"
   dependencies:
-    browserslist "^4.0.2"
-    caniuse-lite "^1.0.30000878"
+    browserslist "^4.1.0"
+    caniuse-lite "^1.0.30000884"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^7.0.2"
@@ -906,12 +906,12 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
-browserslist@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.1.0.tgz#81cbb8e52dfa09918f93c6e051d779cb7360785d"
+browserslist@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.1.1.tgz#328eb4ff1215b12df6589e9ab82f8adaa4fc8cd6"
   dependencies:
-    caniuse-lite "^1.0.30000878"
-    electron-to-chromium "^1.3.61"
+    caniuse-lite "^1.0.30000884"
+    electron-to-chromium "^1.3.62"
     node-releases "^1.0.0-alpha.11"
 
 buffer-alloc-unsafe@^1.1.0:
@@ -990,9 +990,9 @@ caniuse-lite@^1.0.30000844:
   version "1.0.30000850"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000850.tgz#e68a88db4ea598b4c33b8419f7385473e4802495"
 
-caniuse-lite@^1.0.30000878:
-  version "1.0.30000878"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz#c644c39588dd42d3498e952234c372e5a40a4123"
+caniuse-lite@^1.0.30000884:
+  version "1.0.30000885"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz#e889e9f8e7e50e769f2a49634c932b8aee622984"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1190,9 +1190,9 @@ commander@^2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
-commander@^2.16.0:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+commander@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
 
 commander@~2.8.1:
   version "2.8.1"
@@ -1241,10 +1241,6 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
@@ -1264,6 +1260,16 @@ cross-spawn@5.1.0, cross-spawn@^5.0.1:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -1483,6 +1489,10 @@ deep-is@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.2.tgz#9ced65ea0bc0b09f42a6d79c1b1903f9d913cc18"
 
+deepmerge@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
@@ -1531,11 +1541,11 @@ diacritics-map@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/diacritics-map/-/diacritics-map-0.1.0.tgz#6dfc0ff9d01000a2edf2865371cac316e94977af"
 
-docusaurus@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.3.3.tgz#bbd8de72c3dc76f587d49a1dc89baeed2b19c0ea"
+docusaurus@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.4.0.tgz#b4e547841178a3229f155d78edfbe96dbd9adaab"
   dependencies:
-    autoprefixer "^9.1.3"
+    autoprefixer "^9.1.5"
     babel-plugin-transform-class-properties "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.26.0"
     babel-polyfill "^6.26.0"
@@ -1547,15 +1557,17 @@ docusaurus@^1.3.3:
     chalk "^2.1.0"
     classnames "^2.2.6"
     color "^2.0.1"
-    commander "^2.16.0"
+    commander "^2.18.0"
+    cross-spawn "^6.0.5"
     crowdin-cli "^0.3.0"
     cssnano "^3.10.0"
+    deepmerge "^2.1.1"
     escape-string-regexp "^1.0.5"
     express "^4.15.3"
     feed "^1.1.0"
     fs-extra "^5.0.0"
     gaze "^1.1.2"
-    glob "^7.1.2"
+    glob "^7.1.3"
     highlight.js "^9.12.0"
     imagemin "^5.3.1"
     imagemin-gifsicle "^5.2.0"
@@ -1567,9 +1579,9 @@ docusaurus@^1.3.3:
     opencollective "^1.0.3"
     postcss "^7.0.1"
     prismjs "^1.15.0"
-    react "^16.4.1"
-    react-dev-utils "^5.0.1"
-    react-dom "^16.4.1"
+    react "^16.5.0"
+    react-dev-utils "^5.0.2"
+    react-dom "^16.5.0"
     remarkable "^1.7.1"
     request "^2.87.0"
     shelljs "^0.7.8"
@@ -1577,7 +1589,7 @@ docusaurus@^1.3.3:
     tcp-port-used "^0.1.2"
     tiny-lr "^1.1.1"
     tree-node-cli "^1.2.5"
-    truncate-html "^1.0.0"
+    truncate-html "^1.0.1"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -1684,9 +1696,9 @@ electron-to-chromium@^1.3.47:
   version "1.3.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
 
-electron-to-chromium@^1.3.61:
-  version "1.3.61"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.61.tgz#a8ac295b28d0f03d85e37326fd16b6b6b17a1795"
+electron-to-chromium@^1.3.62:
+  version "1.3.66"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.66.tgz#1410d8f8768a14dcd09d96222990f43c969af270"
 
 encodeurl@~1.0.1:
   version "1.0.2"
@@ -1916,18 +1928,6 @@ faye-websocket@~0.11.0:
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
   dependencies:
     websocket-driver ">=0.5.1"
-
-fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
 
 fd-slicer@~1.1.0:
   version "1.1.0"
@@ -2159,9 +2159,20 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2806,13 +2817,6 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -3320,16 +3324,13 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
 node-fetch@1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -3565,7 +3566,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -3852,17 +3853,10 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
-    asap "~2.0.3"
-
-prop-types@^15.6.0:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
-  dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -3944,9 +3938,9 @@ rc@^1.1.2:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dev-utils@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.1.tgz#1f396e161fe44b595db1b186a40067289bf06613"
+react-dev-utils@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.2.tgz#7bb68d2c4f6ffe7ed1184c5b0124fcad692774d2"
   dependencies:
     address "1.0.3"
     babel-code-frame "6.26.0"
@@ -3960,34 +3954,34 @@ react-dev-utils@^5.0.1:
     inquirer "3.3.0"
     is-root "1.0.0"
     opn "5.2.0"
-    react-error-overlay "^4.0.0"
+    react-error-overlay "^4.0.1"
     recursive-readdir "2.2.1"
     shell-quote "1.6.1"
-    sockjs-client "1.1.4"
+    sockjs-client "1.1.5"
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@^16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.0.tgz#57704e5718669374b182a17ea79a6d24922cb27d"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
-react-error-overlay@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
+react-error-overlay@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
 
-react@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+react@^16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.5.0.tgz#f2c1e754bf9751a549d9c6d9aca41905beb56575"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -4269,6 +4263,12 @@ sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
+schedule@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.3.0.tgz#1be2ab2fc2e768536269ce7326efb478d6c045e8"
+  dependencies:
+    object-assign "^4.1.1"
+
 seek-bzip@^1.0.3:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
@@ -4296,6 +4296,10 @@ semver-truncate@^1.0.0:
 semver@^4.0.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.5.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 send@0.16.1:
   version "0.16.1"
@@ -4333,10 +4337,6 @@ set-getter@^0.1.0:
 set-immediate-shim@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 setprototypeof@1.0.3:
   version "1.0.3"
@@ -4400,9 +4400,9 @@ sntp@2.x.x:
   dependencies:
     hoek "4.x.x"
 
-sockjs-client@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.4.tgz#5babe386b775e4cf14e7520911452654016c8b12"
+sockjs-client@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.5.tgz#1bb7c0f7222c40f42adf14f4442cbd1269771a83"
   dependencies:
     debug "^2.6.6"
     eventsource "0.1.6"
@@ -4810,10 +4810,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-truncate-html@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/truncate-html/-/truncate-html-1.0.0.tgz#5a0e03c3dbc4bb739f8023629958acf956b94641"
+truncate-html@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/truncate-html/-/truncate-html-1.0.1.tgz#6f1d03cbb2308bfda266f9ce8f25e62c66919d4f"
   dependencies:
+    "@types/cheerio" "^0.22.8"
     cheerio "0.22.0"
 
 tunnel-agent@^0.4.0:
@@ -4840,10 +4841,6 @@ type-is@~1.6.15:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
-ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 underscore.string@~2.4.0:
   version "2.4.0"
@@ -5035,10 +5032,6 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
Fixes #1771

- Update to latest docusaurus release (`v1.4.0`)
- Update sidebar labels of scoped packages (point me if I miss any)

And by this point `i18n/en.json` is getting bigger, and I would like to consider dropping it, and untrack it. Correct me if I'm wrong but this can get messy because of #1619.