### PR TITLE
Add documentation for preset-env modules auto option

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -173,9 +173,11 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 ### `modules`
 
-`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false`, defaults to `"commonjs"`.
+`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
 Enable transformation of ES6 module syntax to another module type.
+
+The default `auto` will automatically select `false` if ES6 module syntax is already supported by the caller, or `"commonjs"` otherwise.
 
 Setting this to `false` will not transform modules.
 

--- a/website/versioned_docs/version-7.0.0/preset-env.md
+++ b/website/versioned_docs/version-7.0.0/preset-env.md
@@ -174,9 +174,11 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 ### `modules`
 
-`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false`, defaults to `"commonjs"`.
+`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
 Enable transformation of ES6 module syntax to another module type.
+
+The default `auto` will automatically select `false` if ES6 module syntax is already supported by the caller, or `"commonjs"` otherwise.
 
 Setting this to `false` will not transform modules.
 

--- a/website/versioned_docs/version-7.1.0/preset-env.md
+++ b/website/versioned_docs/version-7.1.0/preset-env.md
@@ -174,9 +174,11 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 ### `modules`
 
-`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false`, defaults to `"commonjs"`.
+`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
 Enable transformation of ES6 module syntax to another module type.
+
+The default `auto` will automatically select `false` if ES6 module syntax is already supported by the caller, or `"commonjs"` otherwise.
 
 Setting this to `false` will not transform modules.
 


### PR DESCRIPTION
This PR adds missing documentation for preset-env module's `auto` option as brought up [here](https://github.com/babel/website/issues/1852).