### PR TITLE
Correction in plugin-proposal-decorators.md

### DIFF
--- a/docs/plugin-proposal-decorators.md
+++ b/docs/plugin-proposal-decorators.md
@@ -82,15 +82,15 @@ require("@babel/core").transform("code", {
 
 ### `decoratorsBeforeExport`
 
-`boolean`, defaults to `false`.
+`boolean`
 
 ```js
+// decoratorsBeforeExport: false
+export @decorator class Bar {}
+
 // decoratorsBeforeExport: true
 @decorator
 export class Foo {}
-
-// decoratorsBeforeExport: false
-export @decorator class Bar {}
 ```
 
 This option was added to help tc39 collect feedback from the community by allowing experimentation with both possible syntaxes.


### PR DESCRIPTION
The `decoratorsBeforeExport` option is actually required, so I think the mention of a default is out-of-date - I removed it. I also moved the `false` example before the `true` version so it's easier to see when reading this for the first time that this option only applies to exports and doesn't make a difference otherwise.