### PR TITLE
Fix error and info panels to be monospaced in the REPL

### DIFF
--- a/js/repl/CodeMirrorPanel.js
+++ b/js/repl/CodeMirrorPanel.js
@@ -70,6 +70,7 @@ const styles = {
     backgroundColor: colors.errorBackground,
     borderTop: `1px solid ${colors.errorBorder}`,
     color: colors.errorForeground,
+    fontFamily: "monospace",
     ...sharedBoxStyles,
   }),
   info: css({
@@ -77,6 +78,7 @@ const styles = {
     backgroundColor: colors.infoBackground,
     borderTop: `1px solid ${colors.infoBorder}`,
     color: colors.infoForeground,
+    fontFamily: "monospace",
     ...sharedBoxStyles,
   }),
   panel: css({

--- a/js/repl/CodeMirrorPanel.js
+++ b/js/repl/CodeMirrorPanel.js
@@ -53,6 +53,7 @@ const sharedBoxStyles = {
   overflow: "auto",
   margin: 0,
   padding: "0.5rem 0.75rem",
+  fontFamily: "monospace",
   whiteSpace: "pre-wrap",
   "-webkit-overflow-scrolling": "touch",
 };
@@ -70,7 +71,6 @@ const styles = {
     backgroundColor: colors.errorBackground,
     borderTop: `1px solid ${colors.errorBorder}`,
     color: colors.errorForeground,
-    fontFamily: "monospace",
     ...sharedBoxStyles,
   }),
   info: css({
@@ -78,7 +78,6 @@ const styles = {
     backgroundColor: colors.infoBackground,
     borderTop: `1px solid ${colors.infoBorder}`,
     color: colors.infoForeground,
-    fontFamily: "monospace",
     ...sharedBoxStyles,
   }),
   panel: css({


### PR DESCRIPTION
Due to a CSS reset (I can't quite track down where it's coming from), `pre` tags aren't automatically styled as monospaced.  This causes the error and info panel to not be monospaced, which is especially annoying since the caret doesn't line up properly for parse errors:

Before:

<img width="434" alt="screen shot 2018-10-09 at 4 33 38 pm" src="https://user-images.githubusercontent.com/2281166/46696896-53465b00-cbe1-11e8-9b23-ebc68b828101.png">

After:

<img width="435" alt="screen shot 2018-10-09 at 4 33 52 pm" src="https://user-images.githubusercontent.com/2281166/46696856-3a3daa00-cbe1-11e8-9ddc-4f180c679627.png">
