### PR TITLE
Fix linting for page files

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       "eslint --format=codeframe --fix",
       "git add"
     ],
-    "website/pages/en": [
+    "website/pages/en/*.js": [
       "eslint --format=codeframe --fix",
       "git add"
     ],


### PR DESCRIPTION
Hey, folks, I've noticed that the js files under `pages` weren't being linted. I've made this change and now it works for me. Please check if this is useful for anyone else.