### PR TITLE
Updates babel/node docs to include missing flags

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -77,3 +77,5 @@ npx babel-node --debug --presets es2015 -- script.js --debug
 | `-x, --extensions`     | `".js",".jsx",".es6",".es"` | List of extensions to hook into                                                   |
 | `--presets`            | `[]`                        | Comma-separated list of [presets](presets.md) (a set of plugins) to load and use. |
 | `--plugins`            | `[]`                        | Comma-separated list of [plugins](plugins.md) to load and use.                    |
+| `--config-file [path]` | `[]`                        | Path to the babel config file to use. Defaults to working directory babel.config.js|
+| `--env-name [name]`    | `[]`                        | The name of the 'env' to use when loading configs and plugins. Defaults to the value of BABEL_ENV, or else NODE_ENV, or else 'development'.|

--- a/website/versioned_docs/version-7.1.0/node.md
+++ b/website/versioned_docs/version-7.1.0/node.md
@@ -70,11 +70,13 @@ npx babel-node --debug --presets es2015 -- script.js --debug
 
 ### Options
 
-| Option                 | Default                     | Description                                                                       |
-| ---------------------- | --------------------------- | --------------------------------------------------------------------------------- |
-| `-e, --eval [script]`  |                             | Evaluate script                                                                   |
-| `-p, --print`          |                             | Evaluate script and print result                                                  |
-| `-i, --ignore [regex]` | `node_modules`              | Ignore all files that match this regex when using the require hook                |
-| `-x, --extensions`     | `".js",".jsx",".es6",".es"` | List of extensions to hook into                                                   |
-| `--presets`            | `[]`                        | Comma-separated list of [presets](presets.md) (a set of plugins) to load and use. |
-| `--plugins`            | `[]`                        | Comma-separated list of [plugins](plugins.md) to load and use.                    |
+| Option                 | Default                     | Description                                                                        |
+| ---------------------- | --------------------------- | ---------------------------------------------------------------------------------- |
+| `-e, --eval [script]`  |                             | Evaluate script                                                                    |
+| `-p, --print`          |                             | Evaluate script and print result                                                   |
+| `-i, --ignore [regex]` | `node_modules`              | Ignore all files that match this regex when using the require hook                 |
+| `-x, --extensions`     | `".js",".jsx",".es6",".es"` | List of extensions to hook into                                                    |
+| `--presets`            | `[]`                        | Comma-separated list of [presets](presets.md) (a set of plugins) to load and use.  |
+| `--plugins`            | `[]`                        | Comma-separated list of [plugins](plugins.md) to load and use.                     |
+| `--config-file [path]` | `[]`                        | Path to the babel config file to use. Defaults to working directory babel.config.js|
+| `--env-name [name]`    | `[]`                        | The name of the 'env' to use when loading configs and plugins. Defaults to the value of BABEL_ENV, or else NODE_ENV, or else 'development'.|

--- a/website/versioned_docs/version-7.1.0/options.md
+++ b/website/versioned_docs/version-7.1.0/options.md
@@ -18,6 +18,12 @@ Options can be passed to Babel in a variety of ways. When passed directly to Bab
 you can just pass the objects object. When Babel is used via a wrapper, it may also be
 necessary, or at least more useful, to pass the options via [configuration files](config-files.md).
 
+If passing options via `@babel/cli` you'll need to `kebab-case` the names. i.e.
+
+```
+npx babel --root-mode upward file.js # equivalent of passing the rootMode config option
+```
+
 ## Primary options
 
 These options are only allowed as part of Babel's programmatic options, so


### PR DESCRIPTION
The `--config-file` and `--env-name` flags were missing from the `@babel/node` docs pages so I've added them here.

Descriptions taken from the [PR that added them](https://github.com/babel/babel/pull/8010/files).

Doesn't look like any other flags have been added since then either. 👌 

I also updated the 7.1 docs for `options.md`. I recently made a PR that called this out but didn't realise there were versioned docs as well, so I had only updated next. (#1833). 

Give me a yell if that's not right.

Thanks!