### PR TITLE
Fix name conflict

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -105,10 +105,10 @@ would be a chain of multiple transform passes, along the lines of
 
 ```js
 const filename = "example.js";
-const code = fs.readFileSync(filename, "utf8");
+const source = fs.readFileSync(filename, "utf8");
 
 // Load and compile file normally, but skip code generation.
-const { ast } = babel.transformSync(code, { filename, ast: true, code: false });
+const { ast } = babel.transformSync(source, { filename, ast: true, code: false });
 
 // Minify the file in a second pass and generate the output code here.
 const { code, map } = babel.transformFromAstSync(ast, code, {

--- a/docs/options.md
+++ b/docs/options.md
@@ -111,7 +111,7 @@ const source = fs.readFileSync(filename, "utf8");
 const { ast } = babel.transformSync(source, { filename, ast: true, code: false });
 
 // Minify the file in a second pass and generate the output code here.
-const { code, map } = babel.transformFromAstSync(ast, code, {
+const { code, map } = babel.transformFromAstSync(ast, source, {
   filename,
   presets: ["minify"],
   babelrc: false,


### PR DESCRIPTION
I copy notices while i was copy pasting the code that it was declared two times in the scope. 

Now the code is `copy-past` ready :smile: 