### PR TITLE
Fix syntax highlighting in stage presets

### DIFF
--- a/docs/preset-es2015.md
+++ b/docs/preset-es2015.md
@@ -4,7 +4,7 @@ title: @babel/preset-es2015
 sidebar_label: es2015
 ---
 
-> As of Babel v6, all the yearly presets have been deprecated.
+> As of Babel v6, all of the yearly presets have been deprecated.
 > We recommend using [`@babel/preset-env`](preset-env.md) instead.
 
 ## Install

--- a/docs/preset-es2016.md
+++ b/docs/preset-es2016.md
@@ -4,7 +4,7 @@ title: @babel/preset-es2016
 sidebar_label: es2016
 ---
 
-> As of Babel v6, all the yearly presets have been deprecated.
+> As of Babel v6, all of the yearly presets have been deprecated.
 > We recommend using [`@babel/preset-env`](preset-env.md) instead.
 
 ## Install

--- a/docs/preset-es2017.md
+++ b/docs/preset-es2017.md
@@ -4,7 +4,7 @@ title: @babel/preset-es2017
 sidebar_label: es2017
 ---
 
-> As of Babel v6, all the yearly presets have been deprecated.
+> As of Babel v6, all of the yearly presets have been deprecated.
 > We recommend using [`@babel/preset-env`](preset-env.md) instead.
 
 ## Install

--- a/docs/preset-stage-0.md
+++ b/docs/preset-stage-0.md
@@ -4,10 +4,59 @@ title: @babel/preset-stage-0
 sidebar_label: stage-0
 ---
 
-> As of Babel v7, all the stage presets have been deprecated.
+> As of Babel v7, all of the stage-x presets have been deprecated.
 > Check [the blog post](/blog/2018/07/27/removing-babels-stage-presets) for more information.
 >
-> For upgrade instructions, see [the README](https://github.com/babel/babel/blob/master/packages/babel-preset-stage-0/README.md).
+> For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
+>
+> If you want the same configuration as before:
+>
+> ```json5
+> {
+>   "plugins": [
+>     // Stage 0
+>     "@babel/plugin-proposal-function-bind",
+>
+>     // Stage 1
+>     "@babel/plugin-proposal-export-default-from",
+>     "@babel/plugin-proposal-logical-assignment-operators",
+>     ["@babel/plugin-proposal-optional-chaining", { loose: false }],
+>     ["@babel/plugin-proposal-pipeline-operator", { proposal: "minimal" }],
+>     ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: false }],
+>     "@babel/plugin-proposal-do-expressions",
+>
+>     // Stage 2
+>     ["@babel/plugin-proposal-decorators", { legacy: true }],
+>     "@babel/plugin-proposal-function-sent",
+>     "@babel/plugin-proposal-export-namespace-from",
+>     "@babel/plugin-proposal-numeric-separator",
+>     "@babel/plugin-proposal-throw-expressions",
+>
+>     // Stage 3
+>     "@babel/plugin-syntax-dynamic-import",
+>     "@babel/plugin-syntax-import-meta",
+>     ["@babel/plugin-proposal-class-properties", { loose: false }],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
+> }
+> ```
+>
+> If you're using the same configuration across many separate projects, keep in mind that you can also create your own custom presets with whichever plugins and presets you're looking to use.
+>
+> ```js
+> module.exports = function() {
+>   return {
+>     plugins: [
+>       require("@babel/plugin-syntax-dynamic-import"),
+>       [require("@babel/plugin-proposal-decorators"), { legacy: true }],
+>       [require("@babel/plugin-proposal-class-properties"), { loose: false }],
+>     ],
+>     presets: [
+>       // ...
+>     ],
+>   };
+> };
+> ```
 
 ## Install
 

--- a/docs/preset-stage-1.md
+++ b/docs/preset-stage-1.md
@@ -4,10 +4,56 @@ title: @babel/preset-stage-1
 sidebar_label: stage-1
 ---
 
-> As of Babel v7, all the stage presets have been deprecated.
+> As of Babel v7, all of the stage-x presets have been deprecated.
 > Check [the blog post](/blog/2018/07/27/removing-babels-stage-presets) for more information.
 >
-> For upgrade instructions, see [the README](https://github.com/babel/babel/blob/master/packages/babel-preset-stage-1/README.md).
+> For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
+>
+> If you want the same configuration as before:
+>
+> ```json5
+> {
+>   "plugins": [
+>     // Stage 1
+>     "@babel/plugin-proposal-export-default-from",
+>     "@babel/plugin-proposal-logical-assignment-operators",
+>     ["@babel/plugin-proposal-optional-chaining", { loose: false }],
+>     ["@babel/plugin-proposal-pipeline-operator", { proposal: "minimal" }],
+>     ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: false }],
+>     "@babel/plugin-proposal-do-expressions",
+>
+>     // Stage 2
+>     ["@babel/plugin-proposal-decorators", { legacy: true }],
+>     "@babel/plugin-proposal-function-sent",
+>     "@babel/plugin-proposal-export-namespace-from",
+>     "@babel/plugin-proposal-numeric-separator",
+>     "@babel/plugin-proposal-throw-expressions",
+>
+>     // Stage 3
+>     "@babel/plugin-syntax-dynamic-import",
+>     "@babel/plugin-syntax-import-meta",
+>     ["@babel/plugin-proposal-class-properties", { loose: false }],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
+> }
+> ```
+>
+> If you're using the same configuration across many separate projects, keep in mind that you can also create your own custom presets with whichever plugins and presets you're looking to use.
+>
+> ```js
+> module.exports = function() {
+>   return {
+>     plugins: [
+>       require("@babel/plugin-syntax-dynamic-import"),
+>       [require("@babel/plugin-proposal-decorators"), { legacy: true }],
+>       [require("@babel/plugin-proposal-class-properties"), { loose: false }],
+>     ],
+>     presets: [
+>       // ...
+>     ],
+>   };
+> };
+> ```
 
 The gist of Stage 1 is:
 

--- a/docs/preset-stage-2.md
+++ b/docs/preset-stage-2.md
@@ -4,10 +4,48 @@ title: @babel/preset-stage-2
 sidebar_label: stage-2
 ---
 
-> As of Babel v7, all the stage presets have been deprecated.
+> As of Babel v7, all of the stage-x presets have been deprecated.
 > Check [the blog post](/blog/2018/07/27/removing-babels-stage-presets) for more information.
 >
-> For upgrade instructions, see [the README](https://github.com/babel/babel/blob/master/packages/babel-preset-stage-2/README.md).
+> For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
+>
+> If you want the same configuration as before:
+>
+> ```json5
+> {
+>   "plugins": [
+>     // Stage 2
+>     ["@babel/plugin-proposal-decorators", { legacy: true }],
+>     "@babel/plugin-proposal-function-sent",
+>     "@babel/plugin-proposal-export-namespace-from",
+>     "@babel/plugin-proposal-numeric-separator",
+>     "@babel/plugin-proposal-throw-expressions",
+>
+>     // Stage 3
+>     "@babel/plugin-syntax-dynamic-import",
+>     "@babel/plugin-syntax-import-meta",
+>     ["@babel/plugin-proposal-class-properties", { loose: false }],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
+> }
+> ```
+>
+> If you're using the same configuration across many separate projects, keep in mind that you can also create your own custom presets with whichever plugins and presets you're looking to use.
+>
+> ```js
+> module.exports = function() {
+>   return {
+>     plugins: [
+>       require("@babel/plugin-syntax-dynamic-import"),
+>       [require("@babel/plugin-proposal-decorators"), { legacy: true }],
+>       [require("@babel/plugin-proposal-class-properties"), { loose: false }],
+>     ],
+>     presets: [
+>       // ...
+>     ],
+>   };
+> };
+> ```
 
 The gist of Stage 2 is:
 

--- a/docs/preset-stage-3.md
+++ b/docs/preset-stage-3.md
@@ -4,10 +4,40 @@ title: @babel/preset-stage-3
 sidebar_label: stage-3
 ---
 
-> As of Babel v7, all the stage presets have been deprecated.
+> As of Babel v7, all of the stage-x presets have been deprecated.
 > Check [the blog post](/blog/2018/07/27/removing-babels-stage-presets) for more information.
 >
-> For upgrade instructions, see [the README](https://github.com/babel/babel/blob/master/packages/babel-preset-stage-3/README.md).
+> For a more automatic migration, we have updated [babel-upgrade](https://github.com/babel/babel-upgrade) to do this for you (you can run `npx babel-upgrade`).
+>
+> If you want the same configuration as before:
+>
+> ```json5
+> {
+>   "plugins": [
+>     // Stage 3
+>     "@babel/plugin-syntax-dynamic-import",
+>     "@babel/plugin-syntax-import-meta",
+>     ["@babel/plugin-proposal-class-properties", { loose: false }],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
+> }
+> ```
+>
+> If you're using the same configuration across many separate projects, keep in mind that you can also create your own custom presets with whichever plugins and presets you're looking to use.
+>
+> ```js
+> module.exports = function() {
+>   return {
+>     plugins: [
+>       require("@babel/plugin-syntax-dynamic-import"),
+>       [require("@babel/plugin-proposal-class-properties"), { loose: false }],
+>     ],
+>     presets: [
+>       // ...
+>     ],
+>   };
+> };
+> ```
 
 The gist of Stage 3 is:
 

--- a/website/versioned_docs/version-7.0.0/preset-es2015.md
+++ b/website/versioned_docs/version-7.0.0/preset-es2015.md
@@ -5,7 +5,7 @@ sidebar_label: es2015
 original_id: babel-preset-es2015
 ---
 
-> As of Babel v6, all the yearly presets have been deprecated.
+> As of Babel v6, all of the yearly presets have been deprecated.
 > We recommend using [`@babel/preset-env`](preset-env.md) instead.
 
 ## Install

--- a/website/versioned_docs/version-7.0.0/preset-es2016.md
+++ b/website/versioned_docs/version-7.0.0/preset-es2016.md
@@ -5,7 +5,7 @@ sidebar_label: es2016
 original_id: babel-preset-es2016
 ---
 
-> As of Babel v6, all the yearly presets have been deprecated.
+> As of Babel v6, all of the yearly presets have been deprecated.
 > We recommend using [`@babel/preset-env`](preset-env.md) instead.
 
 ## Install

--- a/website/versioned_docs/version-7.0.0/preset-es2017.md
+++ b/website/versioned_docs/version-7.0.0/preset-es2017.md
@@ -5,7 +5,7 @@ sidebar_label: es2017
 original_id: babel-preset-es2017
 ---
 
-> As of Babel v6, all the yearly presets have been deprecated.
+> As of Babel v6, all of the yearly presets have been deprecated.
 > We recommend using [`@babel/preset-env`](preset-env.md) instead.
 
 ## Install

--- a/website/versioned_docs/version-7.0.0/preset-stage-0.md
+++ b/website/versioned_docs/version-7.0.0/preset-stage-0.md
@@ -14,7 +14,7 @@ original_id: babel-preset-stage-0
 >
 > ```json5
 > {
->   plugins: [
+>   "plugins": [
 >     // Stage 0
 >     "@babel/plugin-proposal-function-bind",
 >
@@ -37,8 +37,8 @@ original_id: babel-preset-stage-0
 >     "@babel/plugin-syntax-dynamic-import",
 >     "@babel/plugin-syntax-import-meta",
 >     ["@babel/plugin-proposal-class-properties", { loose: false }],
->     "@babel/plugin-proposal-json-strings",
->   ],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
 > }
 > ```
 >

--- a/website/versioned_docs/version-7.0.0/preset-stage-1.md
+++ b/website/versioned_docs/version-7.0.0/preset-stage-1.md
@@ -14,7 +14,7 @@ original_id: babel-preset-stage-1
 >
 > ```json5
 > {
->   plugins: [
+>   "plugins": [
 >     // Stage 1
 >     "@babel/plugin-proposal-export-default-from",
 >     "@babel/plugin-proposal-logical-assignment-operators",
@@ -34,8 +34,8 @@ original_id: babel-preset-stage-1
 >     "@babel/plugin-syntax-dynamic-import",
 >     "@babel/plugin-syntax-import-meta",
 >     ["@babel/plugin-proposal-class-properties", { loose: false }],
->     "@babel/plugin-proposal-json-strings",
->   ],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
 > }
 > ```
 >

--- a/website/versioned_docs/version-7.0.0/preset-stage-2.md
+++ b/website/versioned_docs/version-7.0.0/preset-stage-2.md
@@ -14,7 +14,7 @@ original_id: babel-preset-stage-2
 >
 > ```json5
 > {
->   plugins: [
+>   "plugins": [
 >     // Stage 2
 >     ["@babel/plugin-proposal-decorators", { legacy: true }],
 >     "@babel/plugin-proposal-function-sent",
@@ -26,8 +26,8 @@ original_id: babel-preset-stage-2
 >     "@babel/plugin-syntax-dynamic-import",
 >     "@babel/plugin-syntax-import-meta",
 >     ["@babel/plugin-proposal-class-properties", { loose: false }],
->     "@babel/plugin-proposal-json-strings",
->   ],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
 > }
 > ```
 >

--- a/website/versioned_docs/version-7.0.0/preset-stage-3.md
+++ b/website/versioned_docs/version-7.0.0/preset-stage-3.md
@@ -14,13 +14,13 @@ original_id: babel-preset-stage-3
 >
 > ```json5
 > {
->   plugins: [
+>   "plugins": [
 >     // Stage 3
 >     "@babel/plugin-syntax-dynamic-import",
 >     "@babel/plugin-syntax-import-meta",
 >     ["@babel/plugin-proposal-class-properties", { loose: false }],
->     "@babel/plugin-proposal-json-strings",
->   ],
+>     "@babel/plugin-proposal-json-strings"
+>   ]
 > }
 > ```
 >


### PR DESCRIPTION
- Fix syntax highlighting errors for JSON5 on stage preset docs created in #1864 by adding quotes around keys, and removing trailing commas
- Updated `docs/`
- Add "of" to `preset-es*` docs since they were added to `preset-stage-*` docs in #1864