### PR TITLE
docs(caveats): update IE transform classes plugin

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -44,7 +44,7 @@ this is widely supported but you may run into problems with much older browsers.
 around.
 
 For classes that have `super`s, the super class won't resolve correctly. You can
-get around this by enabling the `loose` option in the [es2015-classes](plugin-transform-es2015-classes.md) plugin.
+get around this by enabling the `loose` option in the [transform-classes](plugin-transform-classes.md) plugin.
 
 ### Getters/setters (8 and below)
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -21,7 +21,7 @@ There is also the `loose` option for some of these plugins.
 ## Classes
 
 Built-in classes such as `Date`, `Array`, `DOM` etc cannot be properly subclassed
-due to limitations in ES5 (for the [es2015-classes](plugin-transform-es2015-classes.md) plugin).
+due to limitations in ES5 (for the [transform-classes](plugin-transform-classes.md) plugin).
 You can try to use [babel-plugin-transform-builtin-extend](https://github.com/loganfsmyth/babel-plugin-transform-builtin-extend) based on `Object.setPrototypeOf` and `Reflect.construct`, but it also has some limitations.
 
 ## ES5

--- a/website/versioned_docs/version-7.0.0/caveats.md
+++ b/website/versioned_docs/version-7.0.0/caveats.md
@@ -45,7 +45,7 @@ this is widely supported but you may run into problems with much older browsers.
 around.
 
 For classes that have `super`s, the super class won't resolve correctly. You can
-get around this by enabling the `loose` option in the [es2015-classes](plugin-transform-es2015-classes.md) plugin.
+get around this by enabling the `loose` option in the [transform-classes](plugin-transform-classes.md) plugin.
 
 ### Getters/setters (8 and below)
 


### PR DESCRIPTION
As mentioned on the upgrade guide:
> Some of the plugins had `-es3-` or `-es2015-` in the names, but these were unnecessary
https://babeljs.io/docs/en/v7-migration#remove-the-year-from-package-names-blog-2017-12-27-nearing-the-70-releasehtml-renames-drop-the-year-from-the-plugin-name