### PR TITLE
docs: fix preset-env options misleading

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -370,8 +370,8 @@ The following are currently supported:
 
 **Builtins**
 
-- None
+- [es7.array.flat-map](https://github.com/tc39/proposal-flatMap)
 
 **Features**
 
-- [Optional catch binding](https://github.com/tc39/proposal-optional-catch-binding)
+- None


### PR DESCRIPTION
Since publishing [@babel/preset-env@7.0.0-rc.2](https://github.com/babel/babel/blob/v7.0.0-rc.2/packages/babel-preset-env/data/shipped-proposals.js#L4-L8), `optional-catch-binding` was included by default due to `stage-4`, and `es7.array.flat-map` was shipped by browser. The documentation is out of date.