### PR TITLE
Fix documentation of sourceFileName option, fixes #1890

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -453,7 +453,7 @@ This is an synonym for `sourceMaps`. Using `sourceMaps` is recommended.
 ### `sourceFileName`
 
 Type: `string`<br />
-Default: `opts.filenameRelative` when available, or `"unknown"`<br />
+Default: `path.basename(opts.filenameRelative)` when available, or `"unknown"`<br />
 
 The name to use for the file inside the source map object.
 

--- a/website/versioned_docs/version-7.0.0/options.md
+++ b/website/versioned_docs/version-7.0.0/options.md
@@ -412,7 +412,7 @@ This is an synonym for `sourceMaps`. Using `sourceMaps` is recommended.
 ### `sourceFileName`
 
 Type: `string`<br />
-Default: `opts.filenameRelative` when available, or `"unknown"`<br />
+Default: `path.basename(opts.filenameRelative)` when available, or `"unknown"`<br />
 
 The name to use for the file inside the source map object.
 

--- a/website/versioned_docs/version-7.1.0/options.md
+++ b/website/versioned_docs/version-7.1.0/options.md
@@ -448,7 +448,7 @@ This is an synonym for `sourceMaps`. Using `sourceMaps` is recommended.
 ### `sourceFileName`
 
 Type: `string`<br />
-Default: `opts.filenameRelative` when available, or `"unknown"`<br />
+Default: `path.basename(opts.filenameRelative)` when available, or `"unknown"`<br />
 
 The name to use for the file inside the source map object.
 


### PR DESCRIPTION
Fixes #1890

I also verified babel sources at 7.0.0 to fix that version of the doc.