### PR TITLE
Update new default value

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -173,7 +173,7 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 ### `modules`
 
-`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | false`, defaults to `"commonjs"`.
+`"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
 Enable transformation of ES6 module syntax to another module type.
 


### PR DESCRIPTION
This bit me while upgrading to babel 7 w/ present-env.

It says the default is commonjs, however that's not true. When I turn debug on and I don't specify a modules value it says it defaults to auto.

This adds auto as an option and denotes it being the default value.