### PR TITLE
update cli examples for specifying plugins & presets

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,7 +126,7 @@ npx babel --out-file script-compiled.js < script.js
 Use the `--plugins` option to specify plugins to use in compilation
 
 ```sh
-npx babel script.js --out-file script-compiled.js --plugins=transform-runtime,transform-es2015-modules-amd
+npx babel script.js --out-file script-compiled.js --plugins=@babel/proposal-class-properties,@babel/transform-modules-amd
 ```
 
 ### Using Presets
@@ -134,7 +134,7 @@ npx babel script.js --out-file script-compiled.js --plugins=transform-runtime,tr
 Use the `--presets` option to specify plugins to use in compilation
 
 ```sh
-npx babel script.js --out-file script-compiled.js --presets=es2015,react
+npx babel script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/flow
 ```
 
 ### Ignoring .babelrc


### PR DESCRIPTION
I was having trouble trying to follow the docs examples here:

https://babeljs.io/docs/en/babel-cli#using-plugins
https://babeljs.io/docs/en/babel-cli#using-presets

I couldn't get things to work correctly until I started specifying plugins and presets like `@babel/preset-env` instead of just `env`.

So, I'm guessing the recommended way to pass these cli args changed at some point and the docs weren't updated?

Hopefully these examples are a) correct, and b) will help someone else out. Let me know if I'm just a noob and am misunderstanding something basic.  Thanks!