### PR TITLE
fix: noted absoluteRuntime option

### DIFF
--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -62,7 +62,7 @@ With options (and their defaults):
         "corejs": false,
         "helpers": true,
         "regenerator": true,
-        "useESModules": false,
+        "useESModules": false
       }
     ]
   ]

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -61,7 +61,8 @@ With options (and their defaults):
         "corejs": false,
         "helpers": true,
         "regenerator": true,
-        "useESModules": false
+        "useESModules": false,
+        "absoluteRuntime": false,
       }
     ]
   ]
@@ -153,6 +154,12 @@ export default function(instance, Constructor) {
   }
 }
 ```
+
+### `absoluteRuntime`
+
+`boolean`, defaults to `false`.
+
+When enabled, the loader will get the path of modules being passed into this module using the `cwd` set by the `babel-loader`. For example, this allows you to run this preset via a CLI tool and specify the `cwd` as the root directory of the CLI tool instead of the `process.cwd`. This is useful when your tool may have references to things like `@babel/runtime` and the `process.cwd` doesn't.
 
 ## Technical details
 

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -58,11 +58,11 @@ With options (and their defaults):
     [
       "@babel/plugin-transform-runtime",
       {
+        "absoluteRuntime": false,
         "corejs": false,
         "helpers": true,
         "regenerator": true,
         "useESModules": false,
-        "absoluteRuntime": false,
       }
     ]
   ]
@@ -157,9 +157,11 @@ export default function(instance, Constructor) {
 
 ### `absoluteRuntime`
 
-`boolean`, defaults to `false`.
+`boolean` or `string`, defaults to `false`.
 
-When enabled, the loader will get the path of modules being passed into this module using the `cwd` set by the `babel-loader`. For example, this allows you to run this preset via a CLI tool and specify the `cwd` as the root directory of the CLI tool instead of the `process.cwd`. This is useful when your tool may have references to things like `@babel/runtime` and the `process.cwd` doesn't.
+This allows users to run `transform-runtime` broadly across a whole project. By default, `transform-runtime` imports from `@babel/runtime/foo directly`, but that only works if `@babel/runtime` is in the `node_modules` of the file that is being compiled. This can be problematic for nested node modules, npm-linked modules, or CLIs that reside outside the user's project, among other cases. To avoid worrying about how the runtime module's location is resolved, this allows users to resolve the runtime once up front, and then insert absolute paths to the runtime into the output code.
+
+Using absolute paths is not desirable if files are compiled for use at a later time, but in contexts where a file is compiled and then immediately consumed, they can be quite helpful.
 
 ## Technical details
 

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -159,7 +159,7 @@ export default function(instance, Constructor) {
 
 `boolean` or `string`, defaults to `false`.
 
-This allows users to run `transform-runtime` broadly across a whole project. By default, `transform-runtime` imports from `@babel/runtime/foo directly`, but that only works if `@babel/runtime` is in the `node_modules` of the file that is being compiled. This can be problematic for nested node modules, npm-linked modules, or CLIs that reside outside the user's project, among other cases. To avoid worrying about how the runtime module's location is resolved, this allows users to resolve the runtime once up front, and then insert absolute paths to the runtime into the output code.
+This allows users to run `transform-runtime` broadly across a whole project. By default, `transform-runtime` imports from `@babel/runtime/foo` directly, but that only works if `@babel/runtime` is in the `node_modules` of the file that is being compiled. This can be problematic for nested `node_modules`, npm-linked modules, or CLIs that reside outside the user's project, among other cases. To avoid worrying about how the runtime module's location is resolved, this allows users to resolve the runtime once up front, and then insert absolute paths to the runtime into the output code.
 
 Using absolute paths is not desirable if files are compiled for use at a later time, but in contexts where a file is compiled and then immediately consumed, they can be quite helpful.
 


### PR DESCRIPTION
Was not specified for plugin-transform-runtime.md. Needed if running babel-loader from a different directory than the current working directory.

See 
https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-runtime/src/index.js#L41
https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-runtime/src/index.js#L130
https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-runtime/src/index.js#L9