### PR TITLE
Add link to `babeljs.io/env` reference

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -14,7 +14,7 @@ If you are using Babel version 7 you will need to run `npm install @babel/preset
 
 You might end up on this page because you saw a message in the terminal like this:
 
-> 🙌 Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
+> 🙌 Thanks for using Babel: we recommend using babel-preset-env now: please read [babeljs.io/env](https://babeljs.io/env) to update!
 
 Before you proceed further, ask yourself: are you _using_ Babel? Check your `package.json` and look for `babel-preset-es2015` or a similar preset there. If you see a preset like this in your `package.json`, read on!
 


### PR DESCRIPTION
Docs tells the user to go to `babeljs.io/env` but does not provide a clickable link.

Note: `https://babeljs.io/env` actually redirects to `https://babeljs.io/docs/en/env/`, but I believe it's the expected behavior.