### PR TITLE
Added docs for forwardEnv option.

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -356,6 +356,12 @@ environment that only supports ES5.
 
 The starting point where the config search for browserslist will start, and ascend to the system root until found.
 
+### `forwardEnv`
+
+`boolean`, defaults to `false`
+
+Toggles whether or not the internal *Babel* environment `envName` setting will be passed to the `env` option of *Browserslist*. This allows setting the *Browserslist* environment without touching global environment settings like `BROWSERSLIST_ENV`. Enabling this flag has the benefit of selecting different environments as needed when using more complex tooling setups like a multi compiler Webpack setup.
+
 ### `ignoreBrowserslistConfig`
 
 `boolean`, defaults to `false`


### PR DESCRIPTION
This is the website documentation part of the new `forwardEnv` option in `babel-preset-env`: https://github.com/babel/babel/pull/9161