### PR TITLE
Add `api.cache( true ) to example configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,10 @@ All Babel API [options](options.md) are allowed. However, if the option requires
 Create a file called `babel.config.js` with the following content at the root of your project (where the `package.json` is).
 
 ```js
-module.exports = function () {
+module.exports = function ( api ) {
+  // Cache returned configuration.
+  api.cache( true )
+
   const presets = [ ... ];
   const plugins = [ ... ];
 


### PR DESCRIPTION
Babel requires a cache setting, so the example config is updated to reflect that.