### PR TITLE
Fix babel-plugin-module-resolver info in v7 migration api notes

### DIFF
--- a/docs/v7-migration-api.md
+++ b/docs/v7-migration-api.md
@@ -421,3 +421,4 @@ The two AST-Nodes `RestProperty` and `SpreadProperty` have been removed in favor
 ```
 
 See our [upgrade PR for Babel](https://github.com/babel/babel/pull/5317) and the [Babylon AST spec](https://github.com/babel/babylon/blob/7.0/ast/spec.md) for more information.
+

--- a/docs/v7-migration-api.md
+++ b/docs/v7-migration-api.md
@@ -37,7 +37,7 @@ Calls to `babel.transform` or any other transform function may return `null` if 
 
 The `opts.basename` option exposed on `state.file.opts` has been removed. If you need it, best to build it from `opts.filename` yourself [babel/babel#5467](https://github.com/babel/babel/pull/5467).
 
-Removed `resolveModuleSource`. We recommend using `@babel/plugin-module-resolver`'s 'resolvePath' options [babel/babel#6343](https://github.com/babel/babel/pull/6343)
+Removed `resolveModuleSource`. We recommend using `babel-plugin-module-resolver@3`'s 'resolvePath' options [babel/babel#6343](https://github.com/babel/babel/pull/6343)
 
 Removed `babel.analyse` because it was just an alias for `babel.transform`
 

--- a/website/versioned_docs/version-7.0.0/v7-migration-api.md
+++ b/website/versioned_docs/version-7.0.0/v7-migration-api.md
@@ -38,7 +38,7 @@ Calls to `babel.transform` or any other transform function may return `null` if 
 
 The `opts.basename` option exposed on `state.file.opts` has been removed. If you need it, best to build it from `opts.filename` yourself [babel/babel#5467](https://github.com/babel/babel/pull/5467).
 
-Removed `resolveModuleSource`. We recommend using `@babel/plugin-module-resolver`'s 'resolvePath' options [babel/babel#6343](https://github.com/babel/babel/pull/6343)
+Removed `resolveModuleSource`. We recommend using `babel-plugin-module-resolver@3`'s 'resolvePath' options [babel/babel#6343](https://github.com/babel/babel/pull/6343)
 
 Removed `babel.analyse` because it was just an alias for `babel.transform`
 
@@ -422,3 +422,4 @@ The two AST-Nodes `RestProperty` and `SpreadProperty` have been removed in favor
 ```
 
 See our [upgrade PR for Babel](https://github.com/babel/babel/pull/5317) and the [Babylon AST spec](https://github.com/babel/babylon/blob/7.0/ast/spec.md) for more information.
+


### PR DESCRIPTION
Linked PR states that `babel-plugin-module-resolver@3` should be used, not `@babel/plugin-module-resolver` which haven't been released yet.