### PR TITLE
Fix "specificed" typo in babelrc docs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -212,7 +212,7 @@ naming scheme that is independent of the "babelrc" name.
 ### `babelrc`
 
 Type: `boolean`<br />
-Default: `true` as long as the `filename` option has been specificed<br />
+Default: `true` as long as the `filename` option has been specified<br />
 Placement: Allowed in Babel's programmatic options, or inside of the loaded [`"configFile"`](#configfile). A programmatic option will override a config file one.<br />
 
 `true` will enable searching for [configuration files](config-files.md#file-relative-configuration) relative

--- a/website/versioned_docs/version-7.0.0/options.md
+++ b/website/versioned_docs/version-7.0.0/options.md
@@ -171,7 +171,7 @@ naming scheme that is independent of the "babelrc" name.
 ### `babelrc`
 
 Type: `boolean`<br />
-Default: `true` as long as the `filename` option has been specificed<br />
+Default: `true` as long as the `filename` option has been specified<br />
 Placement: Allowed in Babel's programmatic options, or inside of the loaded [`"configFile"`](#configfile). A programmatic option will override a config file one.<br />
 
 `true` will enable searching for [configuration files](config-files.md#file-relative-configuration) relative

--- a/website/versioned_docs/version-7.1.0/options.md
+++ b/website/versioned_docs/version-7.1.0/options.md
@@ -213,7 +213,7 @@ naming scheme that is independent of the "babelrc" name.
 ### `babelrc`
 
 Type: `boolean`<br />
-Default: `true` as long as the `filename` option has been specificed<br />
+Default: `true` as long as the `filename` option has been specified<br />
 Placement: Allowed in Babel's programmatic options, or inside of the loaded [`"configFile"`](#configfile). A programmatic option will override a config file one.<br />
 
 `true` will enable searching for [configuration files](config-files.md#file-relative-configuration) relative


### PR DESCRIPTION
* Fix "specificed" typo in...
  * babelrc docs options.md
  * babelrc docs for version 7.1
  * babelrc docs for version 7.0