### PR TITLE
Fix logic error in plugin-transform-strict-mode.md

### DIFF
--- a/docs/plugin-transform-strict-mode.md
+++ b/docs/plugin-transform-strict-mode.md
@@ -5,8 +5,8 @@ sidebar_label: transform-strict-mode
 ---
 
 This plugin may be enabled via `@babel/plugin-transform-modules-commonjs`.
-If you wish to disable it you can either turn `strict` off or pass
-`strictMode: false` as an option to the commonjs transform.
+To do this you can pass `strict: true` as an option to the commonjs transform.
+This option defaults to `false`.
 
 ## Example
 


### PR DESCRIPTION
- `strictMode` is not an option of `@babel/plugin-transform-modules-commonjs` (https://bit.ly/2W0gv15).
`strict` defaults to `false` so to disable, no action is required (https://bit.ly/2VYMLSs).