### PR TITLE
Typo fix in doc

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -187,7 +187,7 @@ require("@babel/parser").parse("code", {
 
 - `flow`:
   - `all` (`boolean`, default: `false`)
-    Some code has different meaning in Flow and in vanilla JavaScript. For example, `foo<T>(x)` is parsed as a call expression with a type argument in Flow, but as a comparsion (`foo < T > x`) accordingly to the ECMAScript specification. By default, `babel-parser` parses those ambigous constructs as Flow types only if the file starts with a `// @flow` pragma.
+    Some code has different meaning in Flow and in vanilla JavaScript. For example, `foo<T>(x)` is parsed as a call expression with a type argument in Flow, but as a comparison (`foo < T > x`) accordingly to the ECMAScript specification. By default, `babel-parser` parses those ambiguous constructs as Flow types only if the file starts with a `// @flow` pragma.
     Set this option to `true` to always parse files as if `// @flow` was specified.
 
 ### FAQ


### PR DESCRIPTION
- "comparison" instead of "comparsion"
- "ambiguous" instead of "ambigous"