### PR TITLE
Fix regex for circleci

### DIFF
--- a/js/repl/loadBundle.js
+++ b/js/repl/loadBundle.js
@@ -64,8 +64,8 @@ export default async function loadBundle(
           build === "7.0" ? "master" : build
         );
       }
-      const packageName = config.package;
-      const packageFile = `${packageName.replace(/-standalone/, "")}.js`;
+      const packageName = config.package.replace("@", "").replace("/", "-");
+      const packageFile = packageName.replace("-standalone", ".js");
       const regExp = new RegExp(`${packageName}/${packageFile}$`);
       const url = await loadBuildArtifacts(
         state.circleciRepo,


### PR DESCRIPTION
The v7 PR broke it.

It should match these files:
https://circleci.com/api/v1.1/project/github/babel/babel/10000/artifacts