### PR TITLE
Always load the last version unless explicitly told otherwise

### DIFF
--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -35,7 +35,15 @@ export const envConfigToTargetsString = (envConfig: EnvConfig): string => {
 //  Repl state stored in Local storage
 const loadPersistedState = (): ReplState => {
   const storageState = StorageService.get("replState");
-  return { ...replDefaults, ...storageState };
+  return {
+    ...replDefaults,
+    ...storageState,
+    // HACK: We don't want to load the Babel version from the
+    // localStorage, otherwise users will use an old version
+    // unless they manually "update" it explicitly loading a
+    // new one via https://babeljs.io/repl/version/7.3.0
+    version: "",
+  };
 };
 
 //  Repl state in query string


### PR DESCRIPTION
https://github.com/babel/website/pull/1915 broke the repl for many users (both on GitHub and Twitter): if someone always used the default repl, they have `version: 6.26.0` (or older) saved in their storage. Explicit version (https://babeljs.io/repl/version/7.2.0 or https://babeljs.io/repl/#?version=7.2.0) still work. If you want to debug this PR, don't trust the version shown in the sidebar since it is wrong (it will be fixed by https://github.com/babel/babel/pull/9467 for new versions) but check the unpkg requests in your browser's devtools.

@existentialism is working on removing the local storage alltogether (since it just causes bugs), but this will fix the repl in the short term.