### PR TITLE
Fix polyfill loading

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -73,7 +73,7 @@ const envPresetDefaults = {
 const runtimePolyfillConfig: PluginConfig = {
   label: "Runtime Polyfill",
   package: "@babel/polyfill",
-  version: "^7.0.0",
+  version: "7",
 };
 
 const pluginConfigs: Array<PluginConfig> = [


### PR DESCRIPTION
This broke during the repl v7 update. If you enable the `Evaluate` option you'll see an "Unexpected identifer" error from `@babel/polyfill`: that file's contents are
```js
invalid tag
```

This is because bundle.run (which we use to load `@babel/polyfill`) doesn't support version ranges like `^7.0.0`: https://bundle.run/@babel/polyfill@^7.0.0. https://bundle.run/@babel/polyfill@7 works and has the same meaning.