### PR TITLE
Add "Decorators version" to REPL options

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -122,7 +122,7 @@ const replDefaults: ReplState = {
   shippedProposals: false,
   targets: "",
   version: "",
-  decoratorsLegacy: false,
+  decoratorsVersion: "nov-2018",
   decoratorsBeforeExport: false,
   pipelineProposal: "minimal",
 };

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -122,7 +122,7 @@ const replDefaults: ReplState = {
   shippedProposals: false,
   targets: "",
   version: "",
-  decoratorsVersion: "nov-2018",
+  decoratorsVersion: "jan-2019",
   decoratorsBeforeExport: false,
   pipelineProposal: "minimal",
 };

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -588,7 +588,7 @@ class Repl extends React.Component<Props, State> {
       showSidebar: state.isSidebarExpanded,
       targets: envConfigToTargetsString(envConfig),
       version: state.babel.version,
-      decoratorsLegacy: state.presetsOptions.decoratorsLegacy,
+      decoratorsVersion: state.presetsOptions.decoratorsVersion,
       decoratorsBeforeExport: state.presetsOptions.decoratorsBeforeExport,
       pipelineProposal: state.presetsOptions.pipelineProposal,
     };

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -220,6 +220,8 @@ class ExpandedContainer extends Component<Props, State> {
     const isStage1Enabled =
       presetState["stage-0"].isEnabled || presetState["stage-1"].isEnabled;
 
+    const isDecoratorsNov2018 = presetsOptions.decoratorsVersion === "nov-2018";
+
     return (
       <div className={styles.expandedContainer}>
         <div className={styles.sectionsWrapper}>
@@ -317,29 +319,29 @@ class ExpandedContainer extends Component<Props, State> {
               </span>
               <PresetOption
                 when={isStage2Enabled}
-                option="decoratorsLegacy"
+                option="decoratorsVersion"
+                comment={
+                  "The date-based versions repreent the status of the proposal" +
+                  " at a given time. You should be always be using the latest" +
+                  " version, but be careful when upgrading since they can contain" +
+                  " breaking changes."
+                }
                 presets={["stage-0", "stage-1", "stage-2"]}
               >
                 <span className={styles.presetsOptionsLabel}>
-                  Decorators mode
+                  Decorators version
                 </span>
                 <select
                   className={cx(styles.optionSelect, styles.presetOptionSelect)}
                   onChange={this._onPresetOptionChange(
-                    "decoratorsLegacy",
-                    t => t.value === "legacy"
+                    "decoratorsVersion",
+                    t => t.value
                   )}
                 >
-                  <option
-                    vale="modern"
-                    selected={!presetsOptions.decoratorsLegacy}
-                  >
-                    Current Proposal
+                  <option value="nov-2018" selected={isDecoratorsNov2018}>
+                    November 2018
                   </option>
-                  <option
-                    value="legacy"
-                    selected={presetsOptions.decoratorsLegacy}
-                  >
+                  <option value="legacy" selected={!isDecoratorsNov2018}>
                     Legacy
                   </option>
                 </select>
@@ -348,18 +350,21 @@ class ExpandedContainer extends Component<Props, State> {
                 when={isStage2Enabled}
                 option="decoratorsBeforeExport"
                 presets={["stage-0", "stage-1", "stage-2"]}
-                comment="Only works when legacy decorators are not enabled"
-                enabled={!presetsOptions.decoratorsLegacy}
+                comment={
+                  "Only works with November 2018 decorators." +
+                  " It defaults to 'true' with legacy decorators."
+                }
+                enabled={isDecoratorsNov2018}
               >
                 <span className={styles.presetsOptionsLabel}>
                   Decorators before
                   <code>export</code>
                 </span>
                 <input
-                  enabled={!presetsOptions.decoratorsLegacy}
+                  enabled={isDecoratorsNov2018}
                   checked={presetsOptions.decoratorsBeforeExport}
                   ref={el => {
-                    if (el) el.indeterminate = presetsOptions.decoratorsLegacy;
+                    if (el) el.indeterminate = !isDecoratorsNov2018;
                   }}
                   className={styles.envPresetCheckbox}
                   type="checkbox"
@@ -656,7 +661,6 @@ class ExpandedContainer extends Component<Props, State> {
   _onPresetOptionChange = (type: string, getValue: (target: *) => *) => (
     event: SyntheticInputEvent<*>
   ) => {
-    console.log("CHANGE", type, getValue(event.target));
     this.props.onPresetOptionChange(type, getValue(event.target));
   };
 

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { css, cx } from "emotion";
-import React, { Component } from "react";
+import React, { Component, type Node as ReactChildren } from "react";
 import { envPresetDefaults, pluginConfigs } from "./PluginConfig";
 import AccordionTab from "./AccordionTab";
 import PresetLoadingAnimation from "./PresetLoadingAnimation";
@@ -127,6 +127,18 @@ const PresetOption = ({
   );
 };
 
+type SelectOptionProps = {
+  value: string,
+  actual: string,
+  children: ReactChildren,
+};
+
+const SelectOption = ({ value, actual, children }: SelectOptionProps) => (
+  <option value={value} selected={value === actual}>
+    {children}
+  </option>
+);
+
 export default function ReplOptions(props: Props) {
   return (
     <div className={`${styles.wrapper} ${props.className}`}>
@@ -220,7 +232,7 @@ class ExpandedContainer extends Component<Props, State> {
     const isStage1Enabled =
       presetState["stage-0"].isEnabled || presetState["stage-1"].isEnabled;
 
-    const isDecoratorsNov2018 = presetsOptions.decoratorsVersion === "nov-2018";
+    const { decoratorsVersion } = presetsOptions;
 
     return (
       <div className={styles.expandedContainer}>
@@ -338,12 +350,15 @@ class ExpandedContainer extends Component<Props, State> {
                     t => t.value
                   )}
                 >
-                  <option value="nov-2018" selected={isDecoratorsNov2018}>
+                  <SelectOption value="jan-2019" actual={decoratorsVersion}>
+                    January 2019
+                  </SelectOption>
+                  <SelectOption value="nov-2018" actual={decoratorsVersion}>
                     November 2018
-                  </option>
-                  <option value="legacy" selected={!isDecoratorsNov2018}>
+                  </SelectOption>
+                  <SelectOption value="legacy" actual={decoratorsVersion}>
                     Legacy
-                  </option>
+                  </SelectOption>
                 </select>
               </PresetOption>
               <PresetOption
@@ -354,17 +369,17 @@ class ExpandedContainer extends Component<Props, State> {
                   "Only works with November 2018 decorators." +
                   " It defaults to 'true' with legacy decorators."
                 }
-                enabled={isDecoratorsNov2018}
+                enabled={decoratorsVersion === "nov-2018"}
               >
                 <span className={styles.presetsOptionsLabel}>
                   Decorators before
                   <code>export</code>
                 </span>
                 <input
-                  enabled={isDecoratorsNov2018}
+                  enabled={decoratorsVersion === "nov-2018"}
                   checked={presetsOptions.decoratorsBeforeExport}
                   ref={el => {
-                    if (el) el.indeterminate = !isDecoratorsNov2018;
+                    if (el) el.indeterminate = decoratorsVersion !== "nov-2018";
                   }}
                   className={styles.envPresetCheckbox}
                   type="checkbox"

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -94,14 +94,33 @@ export default function compile(code: string, config: CompileConfig): Return {
 
       presets: config.presets.map(preset => {
         if (typeof preset === "string" && /^stage-[0-2]$/.test(preset)) {
-          const decoratorsLegacy = presetsOptions.decoratorsLegacy;
-          const decoratorsBeforeExport = decoratorsLegacy
-            ? undefined
-            : presetsOptions.decoratorsBeforeExport;
+          let decoratorsLegacy, decoratorsVersion, decoratorsBeforeExport;
+
+          switch (presetsOptions.decoratorsVersion) {
+            // Use the decoratorsLegacy option for legacy and nov-2018 decorators
+            // for compatibility with older Babel versions.
+            case "legacy":
+              decoratorsLegacy = true;
+              break;
+            case "nov-2018":
+              decoratorsLegacy = false;
+              decoratorsBeforeExport = presetsOptions.decoratorsBeforeExport;
+              break;
+            default:
+              ({ decoratorsVersion } = presetsOptions);
+          }
+
+          console.log({
+            decoratorsVersion,
+            decoratorsLegacy,
+            decoratorsBeforeExport,
+            pipelineProposal: presetsOptions.pipelineProposal,
+          });
 
           return [
             preset,
             {
+              decoratorsVersion,
               decoratorsLegacy,
               decoratorsBeforeExport,
               pipelineProposal: presetsOptions.pipelineProposal,

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -110,13 +110,6 @@ export default function compile(code: string, config: CompileConfig): Return {
               ({ decoratorsVersion } = presetsOptions);
           }
 
-          console.log({
-            decoratorsVersion,
-            decoratorsLegacy,
-            decoratorsBeforeExport,
-            pipelineProposal: presetsOptions.pipelineProposal,
-          });
-
           return [
             preset,
             {

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -125,9 +125,9 @@ export const persistedStateToPresetsOptions = (
   persistedState: ReplState
 ): PresetsOptions => {
   return {
-    decoratorsVersion: persistedState.decoratorsVersion || "nov-2018",
+    decoratorsVersion: persistedState.decoratorsVersion || "jan-2019",
     decoratorsBeforeExport:
-      persistedState.decoratorsVersion === "nov-2018" &&
+      persistedState.decoratorsVersion === "jan-2019" &&
       !!persistedState.decoratorsBeforeExport,
     pipelineProposal: persistedState.pipelineProposal || "minimal",
   };

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -125,9 +125,9 @@ export const persistedStateToPresetsOptions = (
   persistedState: ReplState
 ): PresetsOptions => {
   return {
-    decoratorsLegacy: !!persistedState.decoratorsLegacy,
+    decoratorsVersion: persistedState.decoratorsVersion || "nov-2018",
     decoratorsBeforeExport:
-      !persistedState.decoratorsLegacy &&
+      persistedState.decoratorsVersion === "nov-2018" &&
       !!persistedState.decoratorsBeforeExport,
     pipelineProposal: persistedState.pipelineProposal || "minimal",
   };

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -4,7 +4,7 @@ export type BabelPresets = Array<string | Array<string | Object>>;
 export type BabelPlugins = Array<string>;
 
 export type PresetsOptions = {
-  decoratorsLegacy: boolean,
+  decoratorsVersion: "legacy" | "nov-2018",
   decoratorsBeforeExport: boolean,
   pipelineProposal: "smart" | "minimal",
 };
@@ -123,7 +123,7 @@ export type ReplState = {
   showSidebar: boolean,
   targets: string,
   version: any,
-  decoratorsLegacy: boolean,
+  decoratorsVersion: "legacy" | "nov-2018",
   decoratorsBeforeExport: boolean,
   pipelineProposal: "minimal" | "smart",
 };

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -4,7 +4,7 @@ export type BabelPresets = Array<string | Array<string | Object>>;
 export type BabelPlugins = Array<string>;
 
 export type PresetsOptions = {
-  decoratorsVersion: "legacy" | "nov-2018",
+  decoratorsVersion: "legacy" | "nov-2018" | "jan-2019",
   decoratorsBeforeExport: boolean,
   pipelineProposal: "smart" | "minimal",
 };
@@ -123,7 +123,7 @@ export type ReplState = {
   showSidebar: boolean,
   targets: string,
   version: any,
-  decoratorsVersion: "legacy" | "nov-2018",
+  decoratorsVersion: "legacy" | "nov-2018" | "jan-2019",
   decoratorsBeforeExport: boolean,
   pipelineProposal: "minimal" | "smart",
 };


### PR DESCRIPTION
This PR adds support for babel/babel#9360 to the REPL.

Demo: [https://deploy-preview-1970--babel.netlify.com/repl#?build=10089](https://deploy-preview-1970--babel.netlify.com/repl#?build=10089&code_lz=AIEwpgxg9gUBA2BDAzsgBAMSlNBvAvjDAHZgDum2AFAJQDcRAZgK7EQAuAllMWuNFXDIINPDDR8wwgHRh4YALZhi7ZNIAOzZAAsqucRLQBrTsRAAuNACJt2I1YA0BieqQRFy9patQyxR85oyOyIAE7stHhoiPLhVFYAkuxoZFChRsgAhFai-E4S-PQwhEA&debug=false&evaluate=true&presets=stage-2&version=7.3.2%2Bpr.9360)