### PR TITLE
Each stage preset enables the more advanced stages

### DIFF
--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -529,6 +529,13 @@ class Repl extends React.Component<Props, State> {
         return {
           runtimePolyfillState,
         };
+      } else if (/^stage-[0-3]$/.test(name)) {
+        const changedStage = Number(name.slice(-1));
+        const stage = value ? changedStage : changedStage + 1;
+        for (let i = 0; i <= 3; i++) {
+          presets[`stage-${i}`].isEnabled = stage <= i;
+        }
+        return { presets };
       } else if (state.hasOwnProperty(name)) {
         return {
           [name]: value,


### PR DESCRIPTION
Show all the enabled stages in the UI, and don't enable them twice since it causes problems*

Demo: https://deploy-preview-1971--babel.netlify.com/repl#?presets=

\* Try enabling both the stage-2 and stage-3 presets in the current repl, using legacy decorators: it will throw an error about plugin ordering.