### PR TITLE
Update Setup documentation for sprockets and rails

### DIFF
--- a/docs/tools/rails/install.md
+++ b/docs/tools/rails/install.md
@@ -1,3 +1,13 @@
+<a href="https://github.com/rails/webpacker">webpacker</a> is the new default
+javascript compiler for Rails 6. It comes with built-in support for transpiling
+with babel. To use it in earlier versions of Rails:
+
+```rb
+# Gemfile
+gem 'webpacker'
+```
+
 ```sh
-gem install sprockets-es6
+bundle install
+bundle exec rails webpacker:install
 ```

--- a/docs/tools/rails/usage.md
+++ b/docs/tools/rails/usage.md
@@ -1,15 +1,12 @@
-```rb
-# Gemfile
-gem "sprockets"
-gem "sprockets-es6"
-```
-
-```rb
-require "sprockets/es6"
-```
+That's it!
 
 <blockquote class="babel-callout babel-callout-info">
   <p>
-    For more information see the <a href="https://github.com/TannerRogalsky/sprockets-es6">TannerRogalsky/sprockets-es6 repo</a>.
+    For more information see the <a href="https://github.com/rails/webpacker">rails/webpacker repo</a>.
   </p>
 </blockquote>
+
+Alternatively, if you need babel to transpile javascript that's processed
+through <a href="https://github.com/rails/sprockets">sprockets</a>, refer to the
+setup instructions for
+<a href="#installation" onclick="event.preventDefault(); document.querySelector('.tools-button[data-title=sprockets]').click()">integrating babel with sprockets</a>.

--- a/docs/tools/sprockets/install.md
+++ b/docs/tools/sprockets/install.md
@@ -1,3 +1,10 @@
+```rb
+# Gemfile
+gem "sprockets"
+gem "sprockets-bumble_d"
+```
+
 ```sh
-gem install sprockets-es6
+bundle install
+npm install --save @babel/core @babel/plugin-external-helpers @babel/plugin-transform-modules-umd @babel/preset-env
 ```

--- a/docs/tools/sprockets/usage.md
+++ b/docs/tools/sprockets/usage.md
@@ -1,15 +1,14 @@
 ```rb
-# Gemfile
-gem "sprockets"
-gem "sprockets-es6"
-```
+# config/application.rb
+extend Sprockets::BumbleD::DSL
 
-```rb
-require "sprockets/es6"
+configure_sprockets_bumble_d do |config|
+  config.babel_config_version = 1
+end
 ```
 
 <blockquote class="babel-callout babel-callout-info">
   <p>
-    For more information see the <a href="https://github.com/TannerRogalsky/sprockets-es6">TannerRogalsky/sprockets-es6 repo</a>.
+    For more information see the <a href="https://github.com/rmacklin/sprockets-bumble_d">rmacklin/sprockets-bumble_d repo</a>.
   </p>
 </blockquote>


### PR DESCRIPTION
The [Setup page](https://babeljs.io/setup) had some outdated documentation about integrating babel with the sprockets library and the rails framework. The sprockets plugin it was mentioning was stuck on babel 5 with no support for custom plugins/presets. I've updated both pages to link to more modern integrations that support the latest version of babel and arbitrary plugins/presets.