### PR TITLE
Minor update to plugin-transform-typescript.md

### DIFF
--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -8,10 +8,17 @@ Does not type-check its input. For that, you will need to install and set up Typ
 
 ## Caveats
 
-* Does not support [`namespace`][namespace]s. **Workaround**: Move to using [file exports][fm], or migrate to using the `module { }` syntax instead.
+* Does not support [`namespace`][namespace]s. 
+
+  **Workaround**: Move to using [file exports][fm], or migrate to using the `module { }` syntax instead.
+  
 * Does not support [`const enum`][const_enum]s because those require type information to compile.
-**Workaround**: Remove the `const`, which makes it available at runtime.
-* Does not support [`export =`][exin] and [`import =`][exin], because those cannot be compiled to ES.next. **Workaround**: Convert to using `export default` and `export const`, and `import x, {y} from "z"`.
+
+  **Workaround**: Remove the `const`, which makes it available at runtime.
+  
+* Does not support [`export =`][exin] and [`import =`][exin], because those cannot be compiled to ES.next. 
+
+  **Workaround**: Convert to using `export default` and `export const`, and `import x, {y} from "z"`.
 
 ## Example
 

--- a/website/versioned_docs/version-7.0.0/plugin-transform-typescript.md
+++ b/website/versioned_docs/version-7.0.0/plugin-transform-typescript.md
@@ -9,10 +9,17 @@ Does not type-check its input. For that, you will need to install and set up Typ
 
 ## Caveats
 
-* Does not support [`namespace`][namespace]s. **Workaround**: Move to using [file exports][fm], or migrate to using the `module { }` syntax instead.
+* Does not support [`namespace`][namespace]s.
+
+  **Workaround**: Move to using [file exports][fm], or migrate to using the `module { }` syntax instead.
+
 * Does not support [`const enum`][const_enum]s because those require type information to compile.
-**Workaround**: Remove the `const`, which makes it available at runtime.
-* Does not support [`export =`][exin] and [`import =`][exin], because those cannot be compiled to ES.next. **Workaround**: Convert to using `export default` and `export const`, and `import x, {y} from "z"`.
+
+  **Workaround**: Remove the `const`, which makes it available at runtime.
+
+* Does not support [`export =`][exin] and [`import =`][exin], because those cannot be compiled to ES.next.
+
+  **Workaround**: Convert to using `export default` and `export const`, and `import x, {y} from "z"`.
 
 ## Example
 


### PR DESCRIPTION
Moves the workarounds to their own line (but still inside the `<li>` ) - it makes the section read better.