### PR TITLE
Simplify checkdocs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ You might want to make yourself familiar with [docusaurus](https://docusaurus.io
 #### Versioned docs
 
 - `/docs` - the files in here are responsible for the "next" version at https://babeljs.io/docs/en/next.
-- `/website/versioned_docs/version-7.1.0` - these are the docs for the currently published version at https://babeljs.io/docs/en
+- `/website/versioned_docs/version-*` - these are the docs for the past versions, the latest one being the currently published version at https://babeljs.io/docs/en
 
-To make a fix to the published site you must edit the corresponding markdown file at both folders.
+After making your changes to the markdown files in the `/docs` folder, a git hook script will suggest files from the past versions folders that you might also need to apply your changes to.
 
 #### Looking for support?
 

--- a/scripts/checkdocs.js
+++ b/scripts/checkdocs.js
@@ -7,18 +7,15 @@ const path = require("path");
 const sgf = require("staged-git-files");
 const chalk = require("chalk");
 
-sgf.includeContent = true;
-
 // Even though we don't care for renamed files, 'R' in filter
 // is needed to recognize them as renamed instead of deleted + added
-sgf("AMR", function(err, results) {
-  const version = "7.1.0";
-  const versionFolder = `website/versioned_docs/version-${version}/`;
+sgf("AMR", function(err, staged) {
+  const versionFolders = require("../website/versions.json").map(
+    version => `website/versioned_docs/version-${version}/`
+  );
+  const pastDocs = [];
 
-  const versionedDocs = {};
-  const nextDocs = [];
-
-  results.forEach(file => {
+  staged.forEach(file => {
     const { status, filename } = file;
 
     if (status == "Renamed") return;
@@ -28,117 +25,36 @@ sgf("AMR", function(err, results) {
       return;
     }
 
-    if (filename.startsWith(versionFolder)) {
-      versionedDocs[path.basename(filename)] = true;
-    } else if (filename.startsWith("docs/")) {
-      nextDocs.push(file);
+    if (filename.includes("/tools/")) return;
+
+    if (filename.startsWith("docs/")) {
+      versionFolders.forEach(folder => {
+        const pastDoc = folder + path.basename(filename);
+        if (
+          fs.existsSync(pastDoc) &&
+          !staged.some(stagedFile => stagedFile.filename === pastDoc)
+        )
+          pastDocs.push(pastDoc);
+      });
+      if (pastDocs.length) pastDocs.push("");
     }
   });
 
-  const changedDocs = [];
-  nextDocs.forEach(({ filename, status, content }) => {
-    if (versionedDocs[path.basename(filename)]) return;
-
-    const doc = docusaurusUtils.extractMetadata(content);
-    const metadata = doc.metadata;
-    const rawContent = doc.rawContent;
-
-    metadata.original_id = metadata.id;
-    metadata.id = `version-${version}-${metadata.id}`;
-    const newFilename = versionFolder + path.basename(filename);
-    const newContent = docusaurusUtils.makeHeader(metadata) + rawContent;
-
-    fs.writeFileSync(newFilename, newContent);
-    changedDocs.push({ status, filename: newFilename });
-  });
-
-  if (!changedDocs.length) return;
+  if (!pastDocs.length) return;
 
   console.log(
     chalk`
+> versioned docs check:
 We noticed changes to some markdown files in the {yellow docs/} folder but no
-corresponding changes in {yellow ${versionFolder}}
+corresponding changes in {yellow website/versioned_docs/}.
 
-The following changes have been replicated automatically:
-  {green ${changedDocs
-    .map(
-      ({ status, filename }) =>
-        status + " ".repeat(10 - status.length) + filename
-    )
-    .join("\n  ")}}
-    
-Please review and stage them, or, if you're sure you only want to modify the
-unpublished docs, ignore these files and set the NEXT_DOCS env variable before
-commiting again.`
+If this was a fix to the existing documentation please consider applying the
+same fix to these files from the past versions:
+
+  {red ${pastDocs.join("\n  ")}}
+If you're sure you only want to modify the unpublished docs, ignore this and
+set the {yellow NEXT_DOCS} env variable before committing again.`
   );
 
   process.exit(1);
 });
-
-const docusaurusUtils = {
-  makeHeader(metadata) {
-    let header = "---\n";
-    Object.keys(metadata).forEach(key => {
-      header += `${key}: ${metadata[key]}\n`;
-    });
-    header += "---\n";
-    return header;
-  },
-
-  // split markdown header
-  splitHeader(content) {
-    // New line characters need to handle all operating systems.
-    const lines = content.split(/\r?\n/);
-    if (lines[0] !== "---") {
-      return {};
-    }
-    let i = 1;
-    for (; i < lines.length - 1; ++i) {
-      if (lines[i] === "---") {
-        break;
-      }
-    }
-    return {
-      header: lines.slice(1, i + 1).join("\n"),
-      content: lines.slice(i + 1).join("\n"),
-    };
-  },
-
-  // Extract markdown metadata header
-  extractMetadata(content) {
-    const metadata = {};
-    const both = this.splitHeader(content);
-
-    // if no content returned, then that means there was no header, and both.header is the content
-    if (!both.content) {
-      if (!both.header) {
-        return { metadata, rawContent: content };
-      }
-      return { metadata, rawContent: both.header };
-    }
-
-    // New line characters => to handle all operating systems.
-    const lines = both.header.split(/\r?\n/);
-
-    // Loop that add to metadata the current content of the fields of the header
-    // Like the format:
-    // id:
-    // title:
-    // original_id:
-    for (let i = 0; i < lines.length - 1; ++i) {
-      const keyvalue = lines[i].split(":");
-      const key = keyvalue[0].trim();
-      let value = keyvalue
-        .slice(1)
-        .join(":")
-        .trim();
-      try {
-        value = JSON.parse(value);
-      } catch (err) {
-        // Ignore the error as it means it's not a JSON value.
-      }
-      metadata[key] = value;
-    }
-    return { metadata, rawContent: both.content };
-  },
-};


### PR DESCRIPTION
Looks like versioning is going to be rethought in docusaurus v2. Until then I think we should keep telling contributors to apply changes to the correct version(s) depending on whether it's a typo/fix or a new version-specific feature. That way we keep the versioned docs folders clean thanks to that fallback feature (and @existentialism's awesome backport PRs before cutting new versions).

The script I wrote to help with that was stuck on 7.1.0 for some time. This was creating more problems than it was solving, and it's a process that can't really be completely automated anyway. I'm changing it here so it doesn't copy files anymore, and just reminds the contributor that there are other files in the `versioned_docs` folders with the same filename as the one they edited at `docs/`.