### PR TITLE
repl: improve UX for plugins

### DIFF
--- a/js/repl/ExternalPlugins.js
+++ b/js/repl/ExternalPlugins.js
@@ -65,7 +65,8 @@ export default class ExternalPlugins extends React.Component<Props, State> {
         {plugins.map(p => (
           <li key={p.name}>
             <span className={currentStyles.pluginName}>
-              {p.name} v{p.version}
+              {p.name}{" "}
+              <span className={currentStyles.pluginVersion}>v{p.version}</span>
             </span>
             <div className={currentStyles.pluginActions}>
               <a onClick={() => onRemove(p.name)}>✕</a>
@@ -152,6 +153,9 @@ const currentStyles = {
   `,
   pluginName: css`
     flex: 1;
+  `,
+  pluginVersion: css`
+    color: #61656e;
   `,
   pluginActions: css`
     align-items: center;

--- a/js/repl/ExternalPlugins.js
+++ b/js/repl/ExternalPlugins.js
@@ -5,7 +5,7 @@ import * as React from "react";
 import AccordionTab from "./AccordionTab";
 import ExternalPluginsModal from "./ExternalPluginsModal";
 import PresetLoadingAnimation from "./PresetLoadingAnimation";
-import type { SidebarTabSection } from "./types";
+import type { SidebarTabSection, BabelPlugin } from "./types";
 
 type Props = {
   _pluginChanged: any,
@@ -13,7 +13,7 @@ type Props = {
   isLoading: boolean,
   onRemove: (pluginName: string) => void,
   onToggleExpanded: (key: SidebarTabSection) => mixed,
-  plugins: Array<string>,
+  plugins: Array<BabelPlugin>,
   styles: Object,
 };
 
@@ -63,10 +63,12 @@ export default class ExternalPlugins extends React.Component<Props, State> {
     return (
       <ul className={currentStyles.pluginList}>
         {plugins.map(p => (
-          <li key={p}>
-            {p}
+          <li key={p.name}>
+            <span className={currentStyles.pluginName}>
+              {p.name} v{p.version}
+            </span>
             <div className={currentStyles.pluginActions}>
-              <a onClick={() => onRemove(p)}>✕</a>
+              <a onClick={() => onRemove(p.name)}>✕</a>
             </div>
           </li>
         ))}
@@ -81,6 +83,7 @@ export default class ExternalPlugins extends React.Component<Props, State> {
       onToggleExpanded,
       plugins,
       styles,
+      isLoading,
     } = this.props;
 
     return (
@@ -90,7 +93,7 @@ export default class ExternalPlugins extends React.Component<Props, State> {
         label={
           <span className={styles.pluginsHeader}>
             Plugins
-            {false && <PresetLoadingAnimation />}
+            {isLoading && <PresetLoadingAnimation />}
           </span>
         }
         onToggleExpanded={onToggleExpanded}
@@ -122,7 +125,7 @@ const currentStyles = {
   `,
   pluginList: css`
     font-size: 0.75rem;
-    margin: 0.5rem -0.5rem 1rem;
+    margin: 0.5rem 0 1rem;
 
     > li {
       align-items: center;
@@ -147,16 +150,16 @@ const currentStyles = {
     font-size: 0.875rem;
     margin: 0.5rem 0.5rem 1rem;
   `,
+  pluginName: css`
+    flex: 1;
+  `,
   pluginActions: css`
     align-items: center;
     background: #23252b;
     bottom: 0;
-    display: flex;
+    flex-shrink: 0;
     padding-left: 1rem;
-    position: absolute;
-    right: 1rem;
-    top: 0;
-
+    cursor: pointer;
     a,
     a:visited {
       color: #fff;

--- a/js/repl/ExternalPlugins.js
+++ b/js/repl/ExternalPlugins.js
@@ -19,6 +19,7 @@ type Props = {
 
 type State = {
   modalOpen: boolean,
+  officialOnly: boolean,
 };
 
 export default class ExternalPlugins extends React.Component<Props, State> {
@@ -29,6 +30,7 @@ export default class ExternalPlugins extends React.Component<Props, State> {
 
   state = {
     modalOpen: false,
+    officialOnly: false,
   };
 
   handleOpenModal = () => {
@@ -37,6 +39,12 @@ export default class ExternalPlugins extends React.Component<Props, State> {
 
   handleCloseModal = () => {
     this.setState({ modalOpen: false });
+  };
+
+  handleOfficialOnlyToggle = () => {
+    this.setState(({ officialOnly }) => ({
+      officialOnly: !officialOnly,
+    }));
   };
 
   renderButton() {
@@ -86,6 +94,7 @@ export default class ExternalPlugins extends React.Component<Props, State> {
       styles,
       isLoading,
     } = this.props;
+    const { officialOnly } = this.state;
 
     return (
       <AccordionTab
@@ -108,6 +117,8 @@ export default class ExternalPlugins extends React.Component<Props, State> {
             onClose={this.handleCloseModal}
             onPluginSelect={_pluginChanged}
             plugins={plugins}
+            officialOnly={officialOnly}
+            handleOfficialOnlyToggle={this.handleOfficialOnlyToggle}
           />
         )}
       </AccordionTab>

--- a/js/repl/ExternalPluginsModal.js
+++ b/js/repl/ExternalPluginsModal.js
@@ -39,20 +39,11 @@ type Props = {
   onClose: () => void,
   onPluginSelect: any, // TODO
   plugins: Array<BabelPlugin>,
-};
-
-type State = {
   officialOnly: boolean,
+  handleOfficialOnlyToggle: boolean => void,
 };
 
-export default class ExternalPluginsModal extends React.Component<
-  Props,
-  State
-> {
-  state = {
-    officialOnly: false,
-  };
-
+export default class ExternalPluginsModal extends React.Component<Props> {
   _input: ?HTMLInputElement;
 
   componentDidMount() {
@@ -64,12 +55,6 @@ export default class ExternalPluginsModal extends React.Component<
   handleSelectPlugin = (hit: SearchHit) => {
     this.props.onPluginSelect(hit);
     this.props.onClose();
-  };
-
-  handleOfficialOnlyToggle = () => {
-    this.setState(({ officialOnly }) => ({
-      officialOnly: !officialOnly,
-    }));
   };
 
   renderHit = ({ hit }: RenderHitProps) => {
@@ -97,8 +82,7 @@ export default class ExternalPluginsModal extends React.Component<
   };
 
   render() {
-    const { onClose, plugins } = this.props;
-    const { officialOnly } = this.state;
+    const { onClose, plugins, officialOnly } = this.props;
 
     let filters = "computedKeywords:babel-plugin";
 
@@ -129,7 +113,7 @@ export default class ExternalPluginsModal extends React.Component<
               <label>
                 <input
                   checked={officialOnly}
-                  onChange={this.handleOfficialOnlyToggle}
+                  onChange={this.props.handleOfficialOnlyToggle}
                   type="checkbox"
                 />
                 Only official plugins

--- a/js/repl/ExternalPluginsModal.js
+++ b/js/repl/ExternalPluginsModal.js
@@ -11,6 +11,7 @@ import {
 import SearchBox from "./ExternalPluginsSearchBox";
 import Modal from "./Modal";
 import { colors, media } from "./styles";
+import type { BabelPlugin } from "./types";
 
 const config = {
   apiKey: "1f0cc4b7da241f62651b85531d788fbd",
@@ -37,7 +38,7 @@ type RenderHitProps = {
 type Props = {
   onClose: () => void,
   onPluginSelect: any, // TODO
-  plugins: Array<string>,
+  plugins: Array<BabelPlugin>,
 };
 
 type State = {
@@ -106,7 +107,7 @@ export default class ExternalPluginsModal extends React.Component<
     }
 
     if (plugins.length) {
-      plugins.forEach(p => (filters += ` AND NOT objectID:${p}`));
+      plugins.forEach(p => (filters += ` AND NOT objectID:${p.name}`));
     }
 
     return (

--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -1,11 +1,6 @@
 // @flow
 import camelCase from "lodash.camelcase";
-import type {
-  PluginConfig,
-  MultiPackagesConfig,
-  ReplState,
-  EnvFeatures,
-} from "./types";
+import type { PluginConfig, MultiPackagesConfig, ReplState } from "./types";
 
 const normalizePluginName = pluginName =>
   `_babel_${camelCase(`plugin-${pluginName}`)}`;
@@ -125,6 +120,7 @@ const replDefaults: ReplState = {
   decoratorsLegacy: false,
   decoratorsBeforeExport: false,
   pipelineProposal: "minimal",
+  externalPlugins: "",
 };
 
 export {

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -11,6 +11,7 @@ import { colors, media } from "./styles";
 import { joinListEnglish } from "./Utils";
 
 import type {
+  BabelPlugin,
   EnvConfig,
   EnvState,
   PluginConfig,
@@ -51,7 +52,7 @@ type Props = {
   pluginValue: ?string,
   showOfficialExternalPlugins: boolean,
   pluginChange: PluginChange,
-  externalPlugins: Array<string>,
+  externalPlugins: Array<BabelPlugin>,
   showOfficialExternalPluginsChanged: ShowOfficialExternalPluginsChanged,
   envConfig: EnvConfig,
   pluginSearch: PluginSearch,

--- a/js/repl/UriUtils.js
+++ b/js/repl/UriUtils.js
@@ -25,6 +25,7 @@ const URL_KEYS = [
   "prettier",
   "targets",
   "version",
+  "externalPlugins",
 ];
 
 const compress = (string: string) =>

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -6,6 +6,7 @@ import UriUtils from "./UriUtils";
 
 import type {
   BabelState,
+  BabelPlugin,
   EnvState,
   EnvConfig,
   PresetsOptions,
@@ -186,4 +187,19 @@ export const persistedStateToEnvConfig = (
     });
 
   return envConfig;
+};
+
+export const persistedStateToExternalPluginsState = (
+  persistedState: ReplState
+): Array<BabelPlugin> => {
+  const { externalPlugins } = persistedState;
+  if (!externalPlugins) {
+    return [];
+  }
+  return externalPlugins.split(",").map(plugin => {
+    const separator = plugin.lastIndexOf("@");
+    const name = plugin.slice(0, separator);
+    const version = plugin.slice(separator + 1);
+    return { name, version };
+  });
 };

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -2,6 +2,10 @@
 
 export type BabelPresets = Array<string | Array<string | Object>>;
 export type BabelPlugins = Array<string>;
+export type BabelPlugin = {
+  name: string,
+  version: string,
+};
 
 export type PresetsOptions = {
   decoratorsLegacy: boolean,
@@ -126,6 +130,7 @@ export type ReplState = {
   decoratorsLegacy: boolean,
   decoratorsBeforeExport: boolean,
   pipelineProposal: "minimal" | "smart",
+  externalPlugins: ?string,
 };
 
 export type SidebarTabSection = "env" | "plugins" | "presets" | "settings";


### PR DESCRIPTION
Improvements on plugins selections:
- [x] Added plugins into the query params, so that can share the repl with the plugin selection, fix #1976 
- [x] Show version of plugin
- [x] Fix plugin text overflow
- [x] keep officialOnly state when reopen plugin modal, possibly #1649