### PR TITLE
fix(docs): update regenerator import path

### DIFF
--- a/website/blog/2019-03-19-7.4.0.md
+++ b/website/blog/2019-03-19-7.4.0.md
@@ -136,7 +136,7 @@ Since versions `2` and `3` of `core-js` are incompatible with each other (we don
   
   // after
   import "core-js/stable";
-  import "regenerator-runtime/regenerator";
+  import "regenerator-runtime/runtime";
   ```
 
   This gives you the ability to load any version you want, and to update those two package independently.


### PR DESCRIPTION
Correct the import path to the correct package as noted in the core-js docs. https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#babelpolyfill