### PR TITLE
Fix typo

### DIFF
--- a/website/blog/2019-03-19-7.4.0.md
+++ b/website/blog/2019-03-19-7.4.0.md
@@ -124,7 +124,7 @@ Since versions `2` and `3` of `core-js` are incompatible with each other (we don
   ```
   You can remove `@babel/runtime-corejs2`, but you need to install `@babel/runtime-corejs3`!
   ```
-  npm remove @babel/runtime-corejs3
+  npm remove @babel/runtime-corejs2
   npm install --save @babel/runtime-corejs3
   ```
 


### PR DESCRIPTION
Snippet is meant to show replacing @babel/runtime-corejs**2** for @babel/runtime-corejs3. See the line above for context.