### PR TITLE
Document mixin pattern caveat when extending builtin classes

### DIFF
--- a/docs/plugin-transform-classes.md
+++ b/docs/plugin-transform-classes.md
@@ -16,7 +16,8 @@ needs to be wrapped. This is needed to workaround two problems:
 The wrapper works on IE11 and every other browser with `Object.setPrototypeOf` or `__proto__` as fallback.
 There is **NO IE <= 10 support**. If you need IE <= 10 it's recommended that you don't extend natives.
 
-Babel needs to statically know if you are extending a builtin class. For this reason, the "mixin pattern" doesn't work:
+Babel needs to statically know if you are extending a built-in class. For this reason, the "mixin pattern" doesn't work:
+
 ```js
 class Foo extends mixin(Array) {}
 
@@ -26,6 +27,7 @@ function mixin(Super) {
 ```
 
 To workaround this limitation, you can add another class in the inheritance chain so that Babel can wrap the native class:
+
 ```js
 const ExtensibleArray = class extends Array {}
 

--- a/docs/plugin-transform-classes.md
+++ b/docs/plugin-transform-classes.md
@@ -16,6 +16,22 @@ needs to be wrapped. This is needed to workaround two problems:
 The wrapper works on IE11 and every other browser with `Object.setPrototypeOf` or `__proto__` as fallback.
 There is **NO IE <= 10 support**. If you need IE <= 10 it's recommended that you don't extend natives.
 
+Babel needs to statically know if you are extending a builtin class. For this reason, the "mixin pattern" doesn't work:
+```js
+class Foo extends mixin(Array) {}
+
+function mixin(Super) {
+  return class extends Super { mix() {} };
+}
+```
+
+To workaround this limitation, you can add another class in the inheritance chain so that Babel can wrap the native class:
+```js
+const ExtensibleArray = class extends Array {}
+
+class Foo extends mixin(ExtensibleArray) {}
+```
+
 ## Examples
 
 **In**

--- a/website/versioned_docs/version-7.0.0/plugin-transform-classes.md
+++ b/website/versioned_docs/version-7.0.0/plugin-transform-classes.md
@@ -17,7 +17,8 @@ needs to be wrapped. This is needed to workaround two problems:
 The wrapper works on IE11 and every other browser with `Object.setPrototypeOf` or `__proto__` as fallback.
 There is **NO IE <= 10 support**. If you need IE <= 10 it's recommended that you don't extend natives.
 
-Babel needs to statically know if you are extending a builtin class. For this reason, the "mixin pattern" doesn't work:
+Babel needs to statically know if you are extending a built-in class. For this reason, the "mixin pattern" doesn't work:
+
 ```js
 class Foo extends mixin(Array) {}
 
@@ -27,6 +28,7 @@ function mixin(Super) {
 ```
 
 To workaround this limitation, you can add another class in the inheritance chain so that Babel can wrap the native class:
+
 ```js
 const ExtensibleArray = class extends Array {}
 

--- a/website/versioned_docs/version-7.0.0/plugin-transform-classes.md
+++ b/website/versioned_docs/version-7.0.0/plugin-transform-classes.md
@@ -17,6 +17,22 @@ needs to be wrapped. This is needed to workaround two problems:
 The wrapper works on IE11 and every other browser with `Object.setPrototypeOf` or `__proto__` as fallback.
 There is **NO IE <= 10 support**. If you need IE <= 10 it's recommended that you don't extend natives.
 
+Babel needs to statically know if you are extending a builtin class. For this reason, the "mixin pattern" doesn't work:
+```js
+class Foo extends mixin(Array) {}
+
+function mixin(Super) {
+  return class extends Super { mix() {} };
+}
+```
+
+To workaround this limitation, you can add another class in the inheritance chain so that Babel can wrap the native class:
+```js
+const ExtensibleArray = class extends Array {}
+
+class Foo extends mixin(ExtensibleArray) {}
+```
+
 ## Examples
 
 **In**


### PR DESCRIPTION
Closes https://github.com/babel/babel/issues/9183