### PR TITLE
Use checksum to avoid regenerating file every time

### DIFF
--- a/website/pages/en/setup.js
+++ b/website/pages/en/setup.js
@@ -1,4 +1,7 @@
 const React = require("react");
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
 
 const CompLibrary = require("../../core/CompLibrary.js");
 const translate = require("../../server/translate.js").translate;
@@ -7,6 +10,17 @@ const MarkdownBlock = CompLibrary.MarkdownBlock;
 const siteConfig = require(process.cwd() + "/siteConfig.js");
 const setupBabelrc = siteConfig.setupBabelrc;
 const toolsMD = siteConfig.toolsMD;
+
+function checksumTools() {
+  const str = fs.readFileSync(
+    path.join(process.cwd(), "static/scripts/tools.js"),
+    "utf8"
+  );
+  return crypto
+    .createHash("md5")
+    .update(str, "utf8")
+    .digest("hex");
+}
 
 const SetupHeader = () => {
   return (
@@ -120,7 +134,9 @@ class Setup extends React.Component {
       <div className="mainContainer">
         <SetupHeader />
         <SetupContent />
-        <script src={`${siteConfig.baseUrl}scripts/tools.js?t=${time}`} />
+        <script
+          src={`${siteConfig.baseUrl}scripts/tools.js?t=${checksumTools()}`}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Switch from a timestamp to a checksum, so that netlify does not see this file changed on every deployment.