### PR TITLE
babylon docs link broken.

### DIFF
--- a/docs/babylon.md
+++ b/docs/babylon.md
@@ -1,0 +1,5 @@
+# Babylon is now [moved into the main Babel mono-repo](https://github.com/babel/website/tree/master/docs/parser.md) `babel-parser`.
+
+The move makes it much easier to release and develop in sync with the rest of Babel!
+
+## Check out the 6.x README [here](https://github.com/babel/babylon/blob/6.x/README.md)


### PR DESCRIPTION
Hi, babel team!
babel is a great tool, thank you :)

## What does this change?

Since link is broken, I will fix it so that I can redirect it.
The cause of the problem is a missing document accompanying babylon rename to parser.
I think that placing `docs/babylon.md` and redirecting is a good way to reduce the scope of the impact, rather than touching the tool that produces the documentation.

## Problematic URL

https://babeljs.io/docs/en/6.26.3/babylon

The link to `docs/babylon.md` on the edit button on this page does not work.

## Points to be careful

Is the content of the document the quality of the document of babel?

If you need to change, please tell me where to change.
