### PR TITLE
Add F# option to pipeline proposal

### DIFF
--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -397,6 +397,12 @@ class ExpandedContainer extends Component<Props, State> {
                   >
                     Smart
                   </option>
+                  <option
+                    value="fsharp"
+                    selected={presetsOptions.pipelineProposal === "fsharp"}
+                  >
+                    F#
+                  </option>
                 </select>
               </PresetOption>
             </AccordionTab>

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -10,7 +10,7 @@ export type BabelPlugin = {
 export type PresetsOptions = {
   decoratorsLegacy: boolean,
   decoratorsBeforeExport: boolean,
-  pipelineProposal: "smart" | "minimal",
+  pipelineProposal: "smart" | "minimal" | "fsharp",
 };
 
 export type EnvConfig = {
@@ -129,7 +129,7 @@ export type ReplState = {
   version: any,
   decoratorsLegacy: boolean,
   decoratorsBeforeExport: boolean,
-  pipelineProposal: "minimal" | "smart",
+  pipelineProposal: "minimal" | "smart" | "fsharp",
   externalPlugins: ?string,
 };
 


### PR DESCRIPTION
This adds the F# plugin proposal option. Should be usable as soon as 7.5.0 ships.

cc @nicolo-ribaudo @mAAdhaTTah 