### PR TITLE
Documentation updated with JSitor tool references

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -10,7 +10,7 @@ But why?!
 
 It's true that using Babel through Webpack, Browserify or Gulp should be sufficient for most use cases. However, there are some valid use cases for @babel/standalone:
 
- - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), etc. These sites compile user-provided JavaScript in real-time.
+ - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), [JSitor](https://jsitor.com) etc. These sites compile user-provided JavaScript in real-time.
  - Apps that embed a JavaScript engine such as V8 directly, and want to use Babel for compilation
   - Apps that want to use JavaScript as a scripting language for extending the app itself, including all the goodies that ES2015 provides.
   - Integration of Babel into a non-Node.js environment ([ReactJS.NET](http://reactjs.net/), [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler), [php-babel-transpiler](https://github.com/talyssonoc/php-babel-transpiler), etc).

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -10,7 +10,7 @@ But why?!
 
 It's true that using Babel through Webpack, Browserify or Gulp should be sufficient for most use cases. However, there are some valid use cases for @babel/standalone:
 
- - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), [JSitor](https://jsitor.com) etc. These sites compile user-provided JavaScript in real-time.
+ - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), [JSitor](https://jsitor.com), etc. These sites compile user-provided JavaScript in real-time.
  - Apps that embed a JavaScript engine such as V8 directly, and want to use Babel for compilation
   - Apps that want to use JavaScript as a scripting language for extending the app itself, including all the goodies that ES2015 provides.
   - Integration of Babel into a non-Node.js environment ([ReactJS.NET](http://reactjs.net/), [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler), [php-babel-transpiler](https://github.com/talyssonoc/php-babel-transpiler), etc).

--- a/website/data/tools/browser/install.md
+++ b/website/data/tools/browser/install.md
@@ -18,3 +18,4 @@ Online Editors that run Babel for you:
 - [JSFiddle](https://jsfiddle.net/fh5whLfd/)
 - [JSBin](http://jsbin.com/rokimopuse/edit?html,js,console,output)
 - [Codepen](http://codepen.io/anon/pen/dOGgeO)
+- [JSitor](https://jsitor.com/P1Br0ZbSF)

--- a/website/versioned_docs/version-7.0.0/standalone.md
+++ b/website/versioned_docs/version-7.0.0/standalone.md
@@ -11,7 +11,7 @@ But why?!
 
 It's true that using Babel through Webpack, Browserify or Gulp should be sufficient for most use cases. However, there are some valid use cases for @babel/standalone:
 
- - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), [JSitor](https://jsitor.com) etc. These sites compile user-provided JavaScript in real-time.
+ - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), [JSitor](https://jsitor.com), etc. These sites compile user-provided JavaScript in real-time.
  - Apps that embed a JavaScript engine such as V8 directly, and want to use Babel for compilation
   - Apps that want to use JavaScript as a scripting language for extending the app itself, including all the goodies that ES2015 provides.
   - Integration of Babel into a non-Node.js environment ([ReactJS.NET](http://reactjs.net/), [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler), [php-babel-transpiler](https://github.com/talyssonoc/php-babel-transpiler), etc).

--- a/website/versioned_docs/version-7.0.0/standalone.md
+++ b/website/versioned_docs/version-7.0.0/standalone.md
@@ -11,7 +11,7 @@ But why?!
 
 It's true that using Babel through Webpack, Browserify or Gulp should be sufficient for most use cases. However, there are some valid use cases for @babel/standalone:
 
- - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), etc. These sites compile user-provided JavaScript in real-time.
+ - Sites like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), [JSitor](https://jsitor.com) etc. These sites compile user-provided JavaScript in real-time.
  - Apps that embed a JavaScript engine such as V8 directly, and want to use Babel for compilation
   - Apps that want to use JavaScript as a scripting language for extending the app itself, including all the goodies that ES2015 provides.
   - Integration of Babel into a non-Node.js environment ([ReactJS.NET](http://reactjs.net/), [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler), [php-babel-transpiler](https://github.com/talyssonoc/php-babel-transpiler), etc).


### PR DESCRIPTION
Updated the documentation with JSitor online web development tool details. 
JSitor also supports Babel 7.x versions.

Request you to get this also documented in your website documentation.