### PR TITLE
docs(v7-migration): Fixed typo in V7 migration docs

### DIFF
--- a/docs/v7-migration.md
+++ b/docs/v7-migration.md
@@ -22,7 +22,7 @@ This just means Babel _itself_ won't run on older versions of Node. It can still
 
 For more info, read our [6.x vs 7.x comparison](config-files.md#6x-vs-7x-babelrc-loading).
 
-Babel has had issues previously with handling `node_modules`, symlinks, and monorepos. We've made some changes to account for this: Babel will stop lookup at the `package.json` boundary instead of looking up the chain. For monorepo's we have added a new `babel.config.js` file that centralizes our config across all the packages (alternatively you could make a config per package). In 7.1, we've introduced a [`rootMode`](options.md#rootmode) option for further lookup if necessary.
+Babel has had issues previously with handling `node_modules`, symlinks, and monorepos. We've made some changes to account for this: Babel will stop lookup at the `package.json` boundary instead of looking up the chain. For monorepos we have added a new `babel.config.js` file that centralizes our config across all the packages (alternatively you could make a config per package). In 7.1, we've introduced a [`rootMode`](options.md#rootmode) option for further lookup if necessary.
 
 ## [Yearly Preset Deprecations](/blog/2017/12/27/nearing-the-7.0-release.html#deprecated-yearly-presets-eg-babel-preset-es20xx)
 
@@ -230,7 +230,7 @@ If you were relying on Babel to inject `"use strict"` into all of your CommonJS 
 
 ## Separation of the React and Flow presets
 
-`babel-preset-react` has always included the flow plugin. This has caused a lot of issues with users that accidently use `flow` syntax unintentionally due to a typo, or adding it in without typechecking with `flow` itself, resulting in errors.
+`babel-preset-react` has always included the flow plugin. This has caused a lot of issues with users that accidentally use `flow` syntax unintentionally due to a typo, or adding it in without typechecking with `flow` itself, resulting in errors.
 
 This issue was compounded when we decided to support TypeScript. If you wanted to use the React and TypeScript presets, we would have to figure out a way to turn on/off the syntax, automatically, via file type or the directive. In the end, it was easier to separate the presets entirely.
 


### PR DESCRIPTION
Found couple of possible typos in V7 migration docs:
* `monorepo's` -> `monorepos`
Previously: `For monorepo's we have added`
Now: `For monorepos we have added`

* `accidently` -> `accidentally`

In case these changes are inaccurate please let me know and I'll make the necessary changes. (^_^)