### PR TITLE
Modernize examples for plugin-transform-react-jsx

### DIFF
--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -33,9 +33,9 @@ const profile = React.createElement("div", null,
 **In**
 
 ```javascript
-/** @jsx jsx */
+/** @jsx Preact.h */
 
-import { jsx } from '@emotion/core';
+import Preact from 'preact';
 
 const profile = (
   <div>
@@ -48,13 +48,13 @@ const profile = (
 **Out**
 
 ```javascript
-/** @jsx jsx */
+/** @jsx Preact.h */
 
-import { jsx } from '@emotion/core';
+import Preact from 'preact';
 
-const profile = jsx("div", null,
-  jsx("img", { src: "avatar.png", className: "profile" }),
-  jsx("h3", null, [user.firstName, user.lastName].join(" "))
+const profile = h("div", null,
+  Preact.h("img", { src: "avatar.png", className: "profile" }),
+  Preact.h("h3", null, [user.firstName, user.lastName].join(" "))
 );
 ```
 
@@ -91,10 +91,10 @@ const descriptions = items.map(item => React.createElement(
 **In**
 
 ```javascript
-/** @jsx jsx */
-/** @jsxFrag JsxFrag */
+/** @jsx Preact.h */
+/** @jsxFrag Preact.Fragment */
 
-import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
+import Preact from 'preact';
 
 var descriptions = items.map(item => (
   <>
@@ -107,16 +107,16 @@ var descriptions = items.map(item => (
 **Out**
 
 ```javascript
-/** @jsx jsx */
-/** @jsxFrag JsxFrag */
+/** @jsx Preact.h */
+/** @jsxFrag Preact.Fragment */
 
-import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
+import Preact from 'preact';
 
-var descriptions = items.map(item => jsx(
-  JsxFrag,
+var descriptions = items.map(item => Preact.h(
+  Preact.Fragment,
   null,
-  jsx("dt", null, item.name),
-  jsx("dd", null, item.value)
+  Preact.h("dt", null, item.name),
+  Preact.h("dd", null, item.value)
 ));
 ```
 
@@ -148,8 +148,8 @@ With options:
 {
   "plugins": [
     ["@babel/plugin-transform-react-jsx", {
-      "pragma": "jsx", // default pragma is React.createElement
-      "pragmaFrag": "JsxFrag", // default is React.Fragment
+      "pragma": "Preact.h", // default pragma is React.createElement
+      "pragmaFrag": "Preact.Fragment", // default is React.Fragment
       "throwIfNamespace": false // defaults to true
     }]
   ]

--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -11,16 +11,18 @@ sidebar_label: transform-react-jsx
 **In**
 
 ```javascript
-var profile = <div>
-  <img src="avatar.png" className="profile" />
-  <h3>{[user.firstName, user.lastName].join(' ')}</h3>
-</div>;
+const profile = (
+  <div>
+    <img src="avatar.png" className="profile" />
+    <h3>{[user.firstName, user.lastName].join(' ')}</h3>
+  </div>
+);
 ```
 
 **Out**
 
 ```javascript
-var profile = React.createElement("div", null,
+const profile = React.createElement("div", null,
   React.createElement("img", { src: "avatar.png", className: "profile" }),
   React.createElement("h3", null, [user.firstName, user.lastName].join(" "))
 );
@@ -31,26 +33,28 @@ var profile = React.createElement("div", null,
 **In**
 
 ```javascript
-/** @jsx dom */
+/** @jsx jsx */
 
-var { dom } = require("deku");
+import { jsx } from '@emotion/core';
 
-var profile = <div>
-  <img src="avatar.png" className="profile" />
-  <h3>{[user.firstName, user.lastName].join(' ')}</h3>
-</div>;
+const profile = (
+  <div>
+    <img src="avatar.png" className="profile" />
+    <h3>{[user.firstName, user.lastName].join(' ')}</h3>
+  </div>
+);
 ```
 
 **Out**
 
 ```javascript
-/** @jsx dom */
+/** @jsx jsx */
 
-var dom = require("deku").dom;
+import { jsx } from '@emotion/core';
 
-var profile = dom("div", null,
-  dom("img", { src: "avatar.png", className: "profile" }),
-  dom("h3", null, [user.firstName, user.lastName].join(" "))
+const profile = jsx("div", null,
+  jsx("img", { src: "avatar.png", className: "profile" }),
+  jsx("h3", null, [user.firstName, user.lastName].join(" "))
 );
 ```
 
@@ -63,7 +67,7 @@ Fragments are a feature available in React 16.2.0+.
 **In**
 
 ```javascript
-var descriptions = items.map(item => (
+const descriptions = items.map(item => (
   <>
     <dt>{item.name}</dt>
     <dd>{item.value}</dd>
@@ -74,7 +78,7 @@ var descriptions = items.map(item => (
 **Out**
 
 ```javascript
-var descriptions = items.map(item => React.createElement(
+const descriptions = items.map(item => React.createElement(
   React.Fragment,
   null,
   React.createElement("dt", null, item.name),
@@ -87,10 +91,10 @@ var descriptions = items.map(item => React.createElement(
 **In**
 
 ```javascript
-/** @jsx dom */
-/** @jsxFrag DomFrag */
+/** @jsx jsx */
+/** @jsxFrag JsxFrag */
 
-var { dom, DomFrag } = require("deku"); // DomFrag is fictional!
+import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
 
 var descriptions = items.map(item => (
   <>
@@ -103,16 +107,16 @@ var descriptions = items.map(item => (
 **Out**
 
 ```javascript
-/** @jsx dom */
-/** @jsxFrag DomFrag */
+/** @jsx jsx */
+/** @jsxFrag JsxFrag */
 
-var { dom, DomFrag } = require("deku"); // DomFrag is fictional!
+import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
 
-var descriptions = items.map(item => dom(
-  DomFrag,
+var descriptions = items.map(item => jsx(
+  JsxFrag,
   null,
-  dom("dt", null, item.name),
-  dom("dd", null, item.value)
+  jsx("dt", null, item.name),
+  jsx("dd", null, item.value)
 ));
 ```
 
@@ -144,8 +148,8 @@ With options:
 {
   "plugins": [
     ["@babel/plugin-transform-react-jsx", {
-      "pragma": "dom", // default pragma is React.createElement
-      "pragmaFrag": "DomFrag", // default is React.Fragment
+      "pragma": "jsx", // default pragma is React.createElement
+      "pragmaFrag": "JsxFrag", // default is React.Fragment
       "throwIfNamespace": false // defaults to true
     }]
   ]

--- a/website/versioned_docs/version-7.0.0/plugin-transform-react-jsx.md
+++ b/website/versioned_docs/version-7.0.0/plugin-transform-react-jsx.md
@@ -34,9 +34,9 @@ const profile = React.createElement("div", null,
 **In**
 
 ```javascript
-/** @jsx jsx */
+/** @jsx Preact.h */
 
-import { jsx } from '@emotion/core';
+import Preact from 'preact';
 
 const profile = (
   <div>
@@ -49,13 +49,13 @@ const profile = (
 **Out**
 
 ```javascript
-/** @jsx jsx */
+/** @jsx Preact.h */
 
-import { jsx } from '@emotion/core';
+import Preact from 'preact';
 
-const profile = jsx("div", null,
-  jsx("img", { src: "avatar.png", className: "profile" }),
-  jsx("h3", null, [user.firstName, user.lastName].join(" "))
+const profile = h("div", null,
+  Preact.h("img", { src: "avatar.png", className: "profile" }),
+  Preact.h("h3", null, [user.firstName, user.lastName].join(" "))
 );
 ```
 
@@ -92,10 +92,10 @@ const descriptions = items.map(item => React.createElement(
 **In**
 
 ```javascript
-/** @jsx jsx */
-/** @jsxFrag JsxFrag */
+/** @jsx Preact.h */
+/** @jsxFrag Preact.Fragment */
 
-import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
+import Preact from 'preact';
 
 var descriptions = items.map(item => (
   <>
@@ -108,16 +108,16 @@ var descriptions = items.map(item => (
 **Out**
 
 ```javascript
-/** @jsx jsx */
-/** @jsxFrag JsxFrag */
+/** @jsx Preact.h */
+/** @jsxFrag Preact.Fragment */
 
-import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
+import Preact from 'preact';
 
-var descriptions = items.map(item => jsx(
-  JsxFrag,
+var descriptions = items.map(item => Preact.h(
+  Preact.Fragment,
   null,
-  jsx("dt", null, item.name),
-  jsx("dd", null, item.value)
+  Preact.h("dt", null, item.name),
+  Preact.h("dd", null, item.value)
 ));
 ```
 
@@ -149,8 +149,8 @@ With options:
 {
   "plugins": [
     ["@babel/plugin-transform-react-jsx", {
-      "pragma": "jsx", // default pragma is React.createElement
-      "pragmaFrag": "JsxFrag", // default is React.Fragment
+      "pragma": "Preact.h", // default pragma is React.createElement
+      "pragmaFrag": "Preact.Fragment", // default is React.Fragment
       "throwIfNamespace": false // defaults to true
     }]
   ]

--- a/website/versioned_docs/version-7.0.0/plugin-transform-react-jsx.md
+++ b/website/versioned_docs/version-7.0.0/plugin-transform-react-jsx.md
@@ -12,16 +12,18 @@ original_id: babel-plugin-transform-react-jsx
 **In**
 
 ```javascript
-var profile = <div>
-  <img src="avatar.png" className="profile" />
-  <h3>{[user.firstName, user.lastName].join(' ')}</h3>
-</div>;
+const profile = (
+  <div>
+    <img src="avatar.png" className="profile" />
+    <h3>{[user.firstName, user.lastName].join(' ')}</h3>
+  </div>
+);
 ```
 
 **Out**
 
 ```javascript
-var profile = React.createElement("div", null,
+const profile = React.createElement("div", null,
   React.createElement("img", { src: "avatar.png", className: "profile" }),
   React.createElement("h3", null, [user.firstName, user.lastName].join(" "))
 );
@@ -32,26 +34,28 @@ var profile = React.createElement("div", null,
 **In**
 
 ```javascript
-/** @jsx dom */
+/** @jsx jsx */
 
-var { dom } = require("deku");
+import { jsx } from '@emotion/core';
 
-var profile = <div>
-  <img src="avatar.png" className="profile" />
-  <h3>{[user.firstName, user.lastName].join(' ')}</h3>
-</div>;
+const profile = (
+  <div>
+    <img src="avatar.png" className="profile" />
+    <h3>{[user.firstName, user.lastName].join(' ')}</h3>
+  </div>
+);
 ```
 
 **Out**
 
 ```javascript
-/** @jsx dom */
+/** @jsx jsx */
 
-var dom = require("deku").dom;
+import { jsx } from '@emotion/core';
 
-var profile = dom("div", null,
-  dom("img", { src: "avatar.png", className: "profile" }),
-  dom("h3", null, [user.firstName, user.lastName].join(" "))
+const profile = jsx("div", null,
+  jsx("img", { src: "avatar.png", className: "profile" }),
+  jsx("h3", null, [user.firstName, user.lastName].join(" "))
 );
 ```
 
@@ -64,7 +68,7 @@ Fragments are a feature available in React 16.2.0+.
 **In**
 
 ```javascript
-var descriptions = items.map(item => (
+const descriptions = items.map(item => (
   <>
     <dt>{item.name}</dt>
     <dd>{item.value}</dd>
@@ -75,7 +79,7 @@ var descriptions = items.map(item => (
 **Out**
 
 ```javascript
-var descriptions = items.map(item => React.createElement(
+const descriptions = items.map(item => React.createElement(
   React.Fragment,
   null,
   React.createElement("dt", null, item.name),
@@ -88,10 +92,10 @@ var descriptions = items.map(item => React.createElement(
 **In**
 
 ```javascript
-/** @jsx dom */
-/** @jsxFrag DomFrag */
+/** @jsx jsx */
+/** @jsxFrag JsxFrag */
 
-var { dom, DomFrag } = require("deku"); // DomFrag is fictional!
+import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
 
 var descriptions = items.map(item => (
   <>
@@ -104,16 +108,16 @@ var descriptions = items.map(item => (
 **Out**
 
 ```javascript
-/** @jsx dom */
-/** @jsxFrag DomFrag */
+/** @jsx jsx */
+/** @jsxFrag JsxFrag */
 
-var { dom, DomFrag } = require("deku"); // DomFrag is fictional!
+import { jsx, JsxFrag } from '@emotion/core'; // JsxFrag is fictional!
 
-var descriptions = items.map(item => dom(
-  DomFrag,
+var descriptions = items.map(item => jsx(
+  JsxFrag,
   null,
-  dom("dt", null, item.name),
-  dom("dd", null, item.value)
+  jsx("dt", null, item.name),
+  jsx("dd", null, item.value)
 ));
 ```
 
@@ -145,8 +149,8 @@ With options:
 {
   "plugins": [
     ["@babel/plugin-transform-react-jsx", {
-      "pragma": "dom", // default pragma is React.createElement
-      "pragmaFrag": "DomFrag", // default is React.Fragment
+      "pragma": "jsx", // default pragma is React.createElement
+      "pragmaFrag": "JsxFrag", // default is React.Fragment
       "throwIfNamespace": false // defaults to true
     }]
   ]


### PR DESCRIPTION
👋

I think the code examples for `@babel/plugin-transform-react-jsx` could benefit from a small update, to keep them relevant!

* `deku` → `@emotion/core`
* es5 + cjs → esnext + esm

Let me know if this change would be undesirable, cheers!