### PR TITLE
Replace the babel-preset-env documentation links on the repl page

### DIFF
--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -576,7 +576,7 @@ class ExpandedContainer extends Component<Props, State> {
                 ) : (
                   <LinkToDocs
                     className={`${styles.envPresetLabel} ${styles.highlight}`}
-                    section="shippedProposals"
+                    section="shippedproposals"
                   >
                     Shipped Proposals
                   </LinkToDocs>

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -86,7 +86,7 @@ const LinkToDocs = ({ className, children, section }: LinkProps) => (
   <a
     className={className}
     target="_blank"
-    href={`https://github.com/babel/babel/tree/master/packages/babel-preset-env#${section}`}
+    href={`/docs/en/next/babel-preset-env.html#${section}`}
   >
     {children}
   </a>

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -433,7 +433,7 @@ class ExpandedContainer extends Component<Props, State> {
                   className={`${styles.envPresetColumnLabel} ${
                     styles.envPresetLabel
                   } ${styles.highlight}`}
-                  section="browserslist-support"
+                  section="browserslist-integration"
                 >
                   Browsers
                 </LinkToDocs>


### PR DESCRIPTION
At the moment, the links of the babel-preset-env on the repl page redirects to the github repository which does not contain the necessary documentation.

## What I did

I replaced the babel-preset-env documentation links on the repl page.

## How to test

1. Go to the repl page
2. Go to the env preset section
3. Click on any option