### PR TITLE
@babel/preset-env: Clarify `useBuiltIns` usage and purpose

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -266,7 +266,7 @@ import "regenerator-runtime/runtime";
 // If the target envs don't support these methods
 import "core-js/modules/es.string.pad-start";
 import "core-js/modules/es.string.pad-end";
-// If the target envs don't support generators or `async`/`await`
+// If the target envs don't support generators
 import "regenerator-runtime/runtime`;
 ```
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -229,14 +229,14 @@ This option is useful for "blacklisting" a transform like `@babel/plugin-transfo
 
 `"usage"` | `"entry"` | `false`, defaults to `false`.
 
-This option configures how `@babel/preset-env` imports various polyfills in your generated code.
+This option configures how `@babel/preset-env` imports polyfills and runtime support into your generated code.
 
-Specifically, this option supports the following external polyfill packages:
+Specifically, this option supports the following external packages:
 
 - `core-js`: For standard JS built-ins
-- `regenerator`: For generator and `async`/`await` support
+- `regenerator-runtime`: For generator and `async`/`await` support
 
-Since these polyfills do not come with Babel or `@babel/preset-env` itself, they'll need to be installed as production-level dependencies. This way, when the Babel-generated code imports them, they'll be accessible (in `node_modules`).
+Since these packages do not come with Babel or `@babel/preset-env` itself, they'll need to be installed as production-level dependencies. This way, when the Babel-generated code imports them, they'll be accessible (in `node_modules`).
 
 ```sh
 npm install core-js regenerator --save
@@ -251,7 +251,7 @@ npm install core-js regenerator --save
 > Multiple imports or requires of those packages might cause global collisions and other issues that are hard to trace.
 > We recommend creating a single entry file that only contains the `import` statements.
 
-This option enables a new plugin that replaces the `import "core-js";` and `import "regenerator-runtime/runtime"` statements with only what's needed from each of them, depending on the target environments.
+This option enables a new plugin that replaces the `import "core-js"` and `import "regenerator-runtime/runtime"` statements with only what's needed from each of them, depending on the target environments.
 
 **In**
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -234,7 +234,7 @@ This option configures how `@babel/preset-env` imports polyfills and runtime sup
 Specifically, this option supports the following external packages:
 
 - `core-js`: For standard JS built-ins
-- `regenerator-runtime`: For generator and `async`/`await` support (for browsers that lack support)
+- `regenerator-runtime`: For generator and `async`/`await` support (for browsers that lack support for generators)
 
 Since these packages do not come with Babel or `@babel/preset-env` itself, they'll need to be installed as production-level dependencies. This way, when the Babel-generated code imports them, they'll be accessible (in `node_modules`).
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -239,7 +239,7 @@ Specifically, this option supports the following external packages:
 Since these packages do not come with Babel or `@babel/preset-env` itself, they'll need to be installed as production-level dependencies. This way, when the Babel-generated code imports them, they'll be accessible (in `node_modules`).
 
 ```sh
-npm install core-js regenerator --save
+npm install core-js regenerator-runtime --save
 ```
 
 > NOTE: Previously, these would be installed via `@babel/polyfill`, which is now deprecated. The above method of installing these polyfill packages is the recommended way.

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -234,7 +234,7 @@ This option configures how `@babel/preset-env` imports polyfills and runtime sup
 Specifically, this option supports the following external packages:
 
 - `core-js`: For standard JS built-ins
-- `regenerator-runtime`: For generator and `async`/`await` support
+- `regenerator-runtime`: For generator and `async`/`await` support (for browsers that lack support)
 
 Since these packages do not come with Babel or `@babel/preset-env` itself, they'll need to be installed as production-level dependencies. This way, when the Babel-generated code imports them, they'll be accessible (in `node_modules`).
 


### PR DESCRIPTION
This PR clarifies what `useBuiltIns` is for, and how to use it, better (IMO 🙂).

Specifically, I really struggled using this option in one of my projects. It took me a long time to understand:

- That this option only told Babel _how_ to import polyfills, and that it didn't come with them
  - Specifically, that you had to `npm install` them yourself
- `core-js` and `regenerator`/`regenerator-runtime` were exactly the two polyfills it supported
  - The old documentation focuses on `core-js`, and brushes over `regenerator`
- `regenerator-runtime/runtime` was installed via the `regenerator` npm package
  - Just took me a while to figure which exact package to install (`regenerator-runtime`? Just `regenerator`?)

Feedback welcome 😃 