### PR TITLE
Fix `npx babel-node` usage

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -35,7 +35,7 @@ npx babel-node
 
 If you prefer not to install `@babel/node` and `@babel/core`, you can install them on-the-fly:
 ```sh
-npx --package=@babel/{core,node,preset-env} babel-node
+npx -p @babel/core -p @babel/node babel-node
 ```
 
 Evaluate code.

--- a/docs/node.md
+++ b/docs/node.md
@@ -27,8 +27,15 @@ it will compile ES6 code before running it.
 
 Launch a REPL (Read-Eval-Print-Loop).
 
+> You should install `@babel/node` and `@babel/core` first before `npx babel-node`, otherwise `npx` will install out-of-dated legacy `babel-node` 6.x.
+
 ```sh
 npx babel-node
+```
+
+Install basic dependencies on-the-fly and launch a REPL
+```sh
+npx --package=@babel/{core,node,preset-env} babel-node
 ```
 
 Evaluate code.

--- a/docs/node.md
+++ b/docs/node.md
@@ -33,7 +33,7 @@ Launch a REPL (Read-Eval-Print-Loop).
 npx babel-node
 ```
 
-Install basic dependencies on-the-fly and launch a REPL
+If you prefer not to install `@babel/node` and `@babel/core`, you can install them on-the-fly:
 ```sh
 npx --package=@babel/{core,node,preset-env} babel-node
 ```

--- a/docs/node.md
+++ b/docs/node.md
@@ -53,13 +53,13 @@ npx babel-node test
 > **Tip:** Use `rlwrap` to get a REPL with input history
 >
 > ```sh
-> npx rlwrap babel-node
+> rlwrap npx babel-node
 > ```
 >
 > On some platforms (like OSX), extra arguments may be required for `rlwrap` to function properly, eg:
 >
 > ```sh
-> NODE_NO_READLINE=1 npx rlwrap --always-readline babel-node
+> NODE_NO_READLINE=1 rlwrap --always-readline npx babel-node
 > ```
 
 ### Usage

--- a/docs/node.md
+++ b/docs/node.md
@@ -28,31 +28,31 @@ it will compile ES6 code before running it.
 Launch a REPL (Read-Eval-Print-Loop).
 
 ```sh
-npx @babel/node
+npx babel-node
 ```
 
 Evaluate code.
 
 ```sh
-npx @babel/node -e "class Test { }"
+npx babel-node -e "class Test { }"
 ```
 
 Compile and run `test.js`.
 
 ```sh
-npx @babel/node test
+npx babel-node test
 ```
 
 > **Tip:** Use `rlwrap` to get a REPL with input history
 >
 > ```sh
-> npx rlwrap @babel/node
+> npx rlwrap babel-node
 > ```
 >
 > On some platforms (like OSX), extra arguments may be required for `rlwrap` to function properly, eg:
 >
 > ```sh
-> NODE_NO_READLINE=1 npx rlwrap --always-readline @babel/node
+> NODE_NO_READLINE=1 npx rlwrap --always-readline babel-node
 > ```
 
 ### Usage
@@ -64,7 +64,7 @@ babel-node [options] [ -e script | script.js ] [arguments]
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-npx @babel/node --debug --presets es2015 -- script.js --debug
+npx babel-node --debug --presets es2015 -- script.js --debug
 ```
 
 ### Options

--- a/website/versioned_docs/version-7.0.0/node.md
+++ b/website/versioned_docs/version-7.0.0/node.md
@@ -54,14 +54,14 @@ npx babel-node test
 > **Tip:** Use `rlwrap` to get a REPL with input history
 >
 > ```sh
-> npx rlwrap babel-node
+> rlwrap npx babel-node
 > ```
 >
 > On some platforms (like OSX), extra arguments may be required for `rlwrap` to function properly, eg:
 >
 > ```sh
-> NODE_NO_READLINE=1 npx rlwrap --always-readline babel-node
-> ```
+> NODE_NO_READLINE=1 rlwrap --always-readline npx babel-node
+> 
 
 ### Usage
 

--- a/website/versioned_docs/version-7.0.0/node.md
+++ b/website/versioned_docs/version-7.0.0/node.md
@@ -29,31 +29,31 @@ it will compile ES6 code before running it.
 Launch a REPL (Read-Eval-Print-Loop).
 
 ```sh
-npx @babel/node
+npx babel-node
 ```
 
 Evaluate code.
 
 ```sh
-npx @babel/node -e "class Test { }"
+npx babel-node -e "class Test { }"
 ```
 
 Compile and run `test.js`.
 
 ```sh
-npx @babel/node test
+npx babel-node test
 ```
 
 > **Tip:** Use `rlwrap` to get a REPL with input history
 >
 > ```sh
-> npx rlwrap @babel/node
+> npx rlwrap babel-node
 > ```
 >
 > On some platforms (like OSX), extra arguments may be required for `rlwrap` to function properly, eg:
 >
 > ```sh
-> NODE_NO_READLINE=1 npx rlwrap --always-readline @babel/node
+> NODE_NO_READLINE=1 npx rlwrap --always-readline babel-node
 > ```
 
 ### Usage
@@ -65,7 +65,7 @@ babel-node [options] [ -e script | script.js ] [arguments]
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-npx @babel/node --debug --presets es2015 -- script.js --debug
+npx babel-node --debug --presets es2015 -- script.js --debug
 ```
 
 ### Options

--- a/website/versioned_docs/version-7.0.0/node.md
+++ b/website/versioned_docs/version-7.0.0/node.md
@@ -28,8 +28,15 @@ it will compile ES6 code before running it.
 
 Launch a REPL (Read-Eval-Print-Loop).
 
+> You should install `@babel/node` and `@babel/core` first before `npx babel-node`, otherwise `npx` will install out-of-dated legacy `babel-node` 6.x.
+
 ```sh
 npx babel-node
+```
+
+Install basic dependencies on-the-fly and launch a REPL
+```sh
+npx --package=@babel/{core,node,preset-env} babel-node
 ```
 
 Evaluate code.

--- a/website/versioned_docs/version-7.0.0/node.md
+++ b/website/versioned_docs/version-7.0.0/node.md
@@ -34,9 +34,9 @@ Launch a REPL (Read-Eval-Print-Loop).
 npx babel-node
 ```
 
-Install basic dependencies on-the-fly and launch a REPL
+If you prefer not to install `@babel/node` and `@babel/core`, you can install them on-the-fly:
 ```sh
-npx --package=@babel/{core,node,preset-env} babel-node
+npx -p @babel/core -p @babel/node babel-node
 ```
 
 Evaluate code.


### PR DESCRIPTION
Fixes #2083 

This PR reverts #2016, and deals with an [issue](https://github.com/babel/babel/issues/10246) reported on babel.

Per [npx synopsis](https://github.com/npm/npx#description), `npx` will execute the `<command>` from `node_modules/.bin`, if the command is not found, it will query `<command>` package from npm registry and install it. When `<command>` contains `@scope`, it will [strip off](https://github.com/npm/npx/blob/latest/parse-args.js#L138) the `@scope`. Therefore `npx @babel/node` simply run `node` without any babel-register hooks.

As `@babel/node` provides binary command `babel-node`, we should run `npx babel-node` to invoke it.

For those prefer to install dependencies on the fly, another example is offered:
```
npx --package=@babel/{core,node,preset-env} babel-node
```

cc @Banou26 @soulofmischief

Unrelated: we also correct the `rlwrap` usage here: `rlwrap` is not a npm package so we cannot invoke `rlwrap` from `npx`.