### PR TITLE
Fix docs for static property builder

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -386,7 +386,7 @@ Aliases: `Property`, `Private`
 
 ### classProperty
 ```javascript
-t.classProperty(key, value, typeAnnotation, decorators, computed)
+t.classProperty(key, value, typeAnnotation, decorators, computed, static)
 ```
 
 See also `t.isClassProperty(node, opts)` and `t.assertClassProperty(node, opts)`.


### PR DESCRIPTION
Fix docs for `t.classProperty` builder to accept `static` argument
```js
t.classProperty(key, value, typeAnnotation, decorators, computed, static);
```