### PR TITLE
typo

### DIFF
--- a/docs/core.md
+++ b/docs/core.md
@@ -180,7 +180,7 @@ Given an [AST](https://astexplorer.net/), transform it.
 const sourceCode = "if (true) return;";
 babel.parseAsync(sourceCode, { allowReturnOutsideFunction: true })
   .then(parsedAst => {
-    return babel.transformFromAstSync(parsedAst, sourceCode, options);
+    return babel.transformFromAstAsync(parsedAst, sourceCode, options);
   })
   .then(({ code, map, ast }) => {
     // ...

--- a/docs/core.md
+++ b/docs/core.md
@@ -147,7 +147,7 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-const parsedAst = babel.parse(sourceCode, { allowReturnOutsideFunction: true });
+const parsedAst = babel.parse(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
 babel.transformFromAst(parsedAst, sourceCode, options, function(err, result) {
   const { code, map, ast } = result;
 });
@@ -166,7 +166,7 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-const parsedAst = babel.parse(sourceCode, { allowReturnOutsideFunction: true });
+const parsedAst = babel.parse(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
 const { code, map, ast } = babel.transformFromAstSync(parsedAst, sourceCode, options);
 ```
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -178,7 +178,7 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-babel.parseAsync(sourceCode, { allowReturnOutsideFunction: true })
+babel.parseAsync(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } })
   .then(parsedAst => {
     return babel.transformFromAstAsync(parsedAst, sourceCode, options);
   })


### PR DESCRIPTION
other more important thing:

```js
const babel=require('@babel/core')
const babelParser=require('@babel/parser')

await babel.parseAsync('11', {allowReturnOutsideFunction: true}) // throw Unknown option: .allowReturnOutsideFunction
babelParser.parse('11', {allowReturnOutsideFunction: true}) // works 
```

maybe those options are not enabled yet in babel.parseAsync ?

but the docs for transformFromAstAsync are cuurently incorrect, there's a workaround with @babel/parser https://github.com/babel/babel/issues/10256