### PR TITLE
Fix typos across babel website repository

### DIFF
--- a/docs/v7-migration-api.md
+++ b/docs/v7-migration-api.md
@@ -150,7 +150,7 @@ See Babylon's [plugin options](parser.md#plugins).
 
 It has been renamed to align with the `legacy` option of `@babel/plugin-proposal-decorators`. A new `decorators` plugin has been implemented, which implements the new decorators proposal.
 
-The two versions of the proposals have different syntaxes, so it is highly reccomended to use `decorators-legacy` until the new semantics are implemented by Babel.
+The two versions of the proposals have different syntaxes, so it is highly recommended to use `decorators-legacy` until the new semantics are implemented by Babel.
 
 > Removed `classConstructorCall` plugin [#291](https://github.com/babel/babylon/pull/291) ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 

--- a/website/blog/2016-08-26-babili.md
+++ b/website/blog/2016-08-26-babili.md
@@ -191,7 +191,7 @@ module: {
 }
 ```
 
-Or use it seperately with the [babili-webpack-plugin](https://github.com/boopathi/babili-webpack-plugin) (made by [@boopathi](https://github.com/boopathi/), who also works on Babili).
+Or use it separately with the [babili-webpack-plugin](https://github.com/boopathi/babili-webpack-plugin) (made by [@boopathi](https://github.com/boopathi/), who also works on Babili).
 
 ```bash
 $ npm install babili-webpack-plugin --save-dev

--- a/website/blog/2017-12-27-nearing-the-7.0-release.md
+++ b/website/blog/2017-12-27-nearing-the-7.0-release.md
@@ -43,7 +43,7 @@ The best thing we can get on this project are people committed to helping out wi
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Company: &quot;We&#39;d like to use SQL Server Enterprise&quot;<br>MS: &quot;That&#39;ll be a quarter million dollars + $20K/month&quot;<br>Company: &quot;Ok!&quot;<br>...<br>Company: &quot;We&#39;d like to use Babel&quot;<br>Babel: &quot;Ok! npm i babel --save&quot;<br>Company: &quot;Cool&quot;<br>Babel: &quot;Would you like to help contribute financially?&quot;<br>Company: &quot;lol no&quot;</p>&mdash; Adam Rackis (@AdamRackis) <a href="https://twitter.com/AdamRackis/status/931195056479965185?ref_src=twsrc%5Etfw">November 16, 2017</a></blockquote>
 
-We are definetely looking to be able to fund people on the team to work full-time. Logan in particular left his job a while ago and is using our current funds to work on Babel part time at the moment!
+We are definitely looking to be able to fund people on the team to work full-time. Logan in particular left his job a while ago and is using our current funds to work on Babel part time at the moment!
 
 #### #3 Contribute in other ways 😊
 
@@ -88,7 +88,7 @@ Even though the amount of work that goes into maintaining the lists of data is h
 
 [![npm presets](https://i.imgur.com/nNKKFcp.png)](https://npm-stat.com/charts.html?package=babel-preset-env&package=babel-preset-es2015&package=babel-preset-es2016&package=babel-preset-es2017&package=babel-preset-latest&from=2016-11-21&to=2017-11-21)
 
-It compiles the latest yearly release of JavaScript (whatever is in Stage 4) which replaces all the old presets. But it also has the abilitiy to compile according to target environments you specify: whether that is for development mode, like the latest version of a browser, or for multiple builds, like a version for IE, and then another version for evergreen browsers.
+It compiles the latest yearly release of JavaScript (whatever is in Stage 4) which replaces all the old presets. But it also has the ability to compile according to target environments you specify: whether that is for development mode, like the latest version of a browser, or for multiple builds, like a version for IE, and then another version for evergreen browsers.
 
 ### ~~Not removing the Stage presets (babel-preset-stage-x)~~
 
@@ -98,7 +98,7 @@ EDIT: We removed them, explained [here](https://babeljs.io/blog/2018/07/27/remov
 
 We can always keep it up to date, and maybe we just need to determine a better system than what these presets are currently.
 
-Right now, stage presets are literally just a list of plugins that we manually update after TC39 meetings. To make this managable, we need to allow major version bumps for these "unstable" packages. Part of the reason for this is because the community will re-create these packages anyway, so we might as well do it from an official package and then have the ability to provide better messaging, etc.
+Right now, stage presets are literally just a list of plugins that we manually update after TC39 meetings. To make this manageable, we need to allow major version bumps for these "unstable" packages. Part of the reason for this is because the community will re-create these packages anyway, so we might as well do it from an official package and then have the ability to provide better messaging, etc.
 
 ### Renames: Scoped Packages (`@babel/x`)
 
@@ -259,7 +259,7 @@ With type inference we can know if an instance method like `.includes` is for an
 
 ### Thanks
 
-Shoutout to our team of volunteers: [Logan](https://twitter.com/loganfsmyth) who has been really pushing hard to fix a lot of our core issues regarding configs and more and the one doing all of that hard work, [Brian](https://twitter.com/existentialism) who has been taking over maintainence of a lot of preset-env work and just whatever I was doing before 😛, and [Daniel](https://twitter.com/TschinderDaniel) who has always been stepping in when we need the help whether it be maintaining babel-loader or helping move the babylon/babel-preset-env repo's over. And same with [Nicolo](https://twitter.com/NicoloRibaudo), [Sven](https://twitter.com/svensauleau), [Artem](https://twitter.com/yavorsky_), and [Diogo](https://twitter.com/kovnsk) for stepping up in the last year to help out.
+Shoutout to our team of volunteers: [Logan](https://twitter.com/loganfsmyth) who has been really pushing hard to fix a lot of our core issues regarding configs and more and the one doing all of that hard work, [Brian](https://twitter.com/existentialism) who has been taking over maintenance of a lot of preset-env work and just whatever I was doing before 😛, and [Daniel](https://twitter.com/TschinderDaniel) who has always been stepping in when we need the help whether it be maintaining babel-loader or helping move the babylon/babel-preset-env repo's over. And same with [Nicolo](https://twitter.com/NicoloRibaudo), [Sven](https://twitter.com/svensauleau), [Artem](https://twitter.com/yavorsky_), and [Diogo](https://twitter.com/kovnsk) for stepping up in the last year to help out.
 
 I'm really looking forward to a release (I'm tired too; it's almost been a year 😝), but also don't want to rush anything just because! Been a lot of ups and downs throughout this release but I've certainly learned a lot and I'm sure the rest of the team has as well.
 

--- a/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
+++ b/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md
@@ -98,7 +98,7 @@ An example of an issue is how [`this` gets converted to `undefined`](https://git
 
 This was [changed in v7](https://github.com/babel/babel/pull/6280) so that it won't auto-inject the `"use strict"` directive unless the source file is a `module`.
 
-It was also not in Babel's original scope to compile dependencies: we actually got issue reports that people would accidently do it, making the build slower. There is a lot of defaults and documentation in the tooling that purposely disable compiling `node_modules`.
+It was also not in Babel's original scope to compile dependencies: we actually got issue reports that people would accidentally do it, making the build slower. There is a lot of defaults and documentation in the tooling that purposely disable compiling `node_modules`.
 
 ### Using Non-Standard Syntax
 

--- a/website/blog/2018-07-19-whats-happening-with-the-pipeline-proposal.md
+++ b/website/blog/2018-07-19-whats-happening-with-the-pipeline-proposal.md
@@ -85,7 +85,7 @@ let newScore = person.score
   |> (_ => boundScore(0, 100, _));
 ```
 
-Exploration is underway to determine whether it would be feasible to enable arrow functions to be used without parentheses, as they are a signficant syntactical burden.
+Exploration is underway to determine whether it would be feasible to enable arrow functions to be used without parentheses, as they are a significant syntactical burden.
 
 On the question of async, F# Pipelines treat `await` similar to a unary function:
 
@@ -117,7 +117,7 @@ The special casing of `await` could potentially enable other unary operators to 
 
 ### [Smart Pipelines](https://github.com/js-choi/proposal-smart-pipelines/)
 
-Smart Pipelines takes the idea of the placeholder to its logical conclusion, enabling it to manage partial application as well as arbitary expressions in a pipeline. The above long chain would be written thus:
+Smart Pipelines takes the idea of the placeholder to its logical conclusion, enabling it to manage partial application as well as arbitrary expressions in a pipeline. The above long chain would be written thus:
 
 ```js
 promise

--- a/website/blog/2018-08-27-7.0.0.md
+++ b/website/blog/2018-08-27-7.0.0.md
@@ -379,7 +379,7 @@ Once `babel-plugin-macros` has been installed and [added to your config](https:/
 
 Learn more about `babel-plugin-macros` in our original post ["Zero-config code transformation with babel-plugin-macros"](https://babeljs.io/blog/2017/09/11/zero-config-with-babel-macros).
 
-### Module Targetting
+### Module Targeting
 
 Babel has always attempted to balance the size impact of transformations and capabilities they provide to JavaScript authors. In Babel 7, it has become much easier to configure Babel to support the growing popularity of the [module/nomodule pattern](https://github.com/kristoferbaxter/preset-env-modules).
 

--- a/website/blog/2019-01-21-7.3.0.md
+++ b/website/blog/2019-01-21-7.3.0.md
@@ -110,7 +110,7 @@ Thanks to the work by [Armano](https://github.com/armano2) on `@babel/parser` an
 
 Thanks to [Kai](https://github.com/kaicataldo) (also on the ESLint TSC) for finishing this work!
 
-Up until now, `babel-eslint` has manually enabled all syntax plugins (with the list falling out of date frequently). It also meant that it could parse syntax that a configured instance of Babel itself didn't allow at compile time. We now require `@babel/core` as a peerDependency and assume that a Babel config exists when using `babel-eslint` and use that same config to modify itself (making this a breaking change). This change will hopefully make maintaining the module itself more managable as well as re-using Babel's config which is a reasonable assumption for a user making use of `babel-eslint`.
+Up until now, `babel-eslint` has manually enabled all syntax plugins (with the list falling out of date frequently). It also meant that it could parse syntax that a configured instance of Babel itself didn't allow at compile time. We now require `@babel/core` as a peerDependency and assume that a Babel config exists when using `babel-eslint` and use that same config to modify itself (making this a breaking change). This change will hopefully make maintaining the module itself more manageable as well as re-using Babel's config which is a reasonable assumption for a user making use of `babel-eslint`.
 
 You can help us by checking if this beta release works for your project 🙂
 

--- a/website/blog/2019-07-02-the-babel-podcast.md
+++ b/website/blog/2019-07-02-the-babel-podcast.md
@@ -62,7 +62,7 @@ What else do you want to hear about? Who do you want to hear from?
 - Chatting with various Babel plugin authors? [babel-macros](https://github.com/kentcdodds/babel-plugin-macros), i18n
 - Babel alternatives: [traceur](https://github.com/google/traceur-compiler), [buble](https://github.com/bublejs/buble), [sucrase](https://github.com/alangpierce/sucrase), [swc](https://github.com/swc-project/swc)
     - It would be fun to chat about why the projects were made, what the differences/tradeoffs are, etc!
-- Compile to JavaScript langauges
+- Compile to JavaScript languages
     - Elm/Reason/etc (standalone language)
     - Coffeescript/Dart (explicitly recommends Babel for compiling down to ES5)
     - Fable (F#) (uses Babel itself)


### PR DESCRIPTION
:blue_heart: Fix typos across **babel website repository**

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
website/docs/v7-migration-api.md:153:75: "reccomended" is a misspelling of "recommended"
website/website/blog/2016-08-26-babili.md:194:10: "seperately" is a misspelling of "separately"
website/website/blog/2017-12-27-nearing-the-7.0-release.md:46:7: "definetely" is a misspelling of "definitely"
website/website/blog/2017-12-27-nearing-the-7.0-release.md:91:133: "abilitiy" is a misspelling of "ability"
website/website/blog/2017-12-27-nearing-the-7.0-release.md:101:120: "managable" is a misspelling of "manageable"
website/website/blog/2017-12-27-nearing-the-7.0-release.md:262:279: "maintainence" is a misspelling of "maintenance"
website/website/blog/2018-06-26-on-consuming-and-publishing-es2015+-packages.md:101:115: "accidently" is a misspelling of "accidentally"
website/website/blog/2018-07-19-whats-happening-with-the-pipeline-proposal.md:88:138: "signficant" is a misspelling of "significant"
website/website/blog/2018-07-19-whats-happening-with-the-pipeline-proposal.md:120:130: "arbitary" is a misspelling of "arbitrary"
website/website/blog/2018-08-27-7.0.0.md:382:11: "Targetting" is a misspelling of "Targeting"
website/website/blog/2019-01-21-7.3.0.md:113:486: "managable" is a misspelling of "manageable"
website/website/blog/2019-07-02-the-babel-podcast.md:65:24: "langauges" is a misspelling of "languages"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: