### PR TITLE
feat: add v8intrinsic language extensions

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -146,6 +146,7 @@ require("@babel/parser").parse("code", {
 | `flowComments` ([docs](https://flow.org/en/docs/types/comments/)) | `/*:: type Foo = {...}; */` |
 | `jsx` ([repo](https://facebook.github.io/jsx/)) | `<a attr="b">{s}</a>` |
 | `typescript` ([repo](https://github.com/Microsoft/TypeScript)) | `var a: string = "";` |
+| `v8intrinsic` | `%DebugPrint(foo);` |
 
 #### ECMAScript [proposals](https://github.com/babel/proposals)
 


### PR DESCRIPTION
Related: https://github.com/babel/babel/pull/10148

/cc @mathiasbynens I couldn't find any official docs on v8 Compiler Intrinsics other than the source code you provided before. Could you spare some time write about it? I am more than happy to reference one in our docs.