### PR TITLE
Script to generate docs for types and updated docs/types.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ website/i18n/*
 website/translated_docs
 
 package-lock.json
+
+# generated using script/generate-docs-types-versions.js
+scripts/tmp

--- a/docs/types.md
+++ b/docs/types.md
@@ -11,6 +11,7 @@ npm install --save-dev @babel/types
 ```
 
 ## API
+
 ### anyTypeAnnotation
 ```javascript
 t.anyTypeAnnotation()
@@ -18,21 +19,7 @@ t.anyTypeAnnotation()
 
 See also `t.isAnyTypeAnnotation(node, opts)` and `t.assertAnyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
-
----
-
-### arrayExpression
-```javascript
-t.arrayExpression(elements)
-```
-
-See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `elements`: `Array<null | Expression | SpreadElement>` (default: `[]`)
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -47,6 +34,19 @@ Aliases: none
 
 ---
 
+### arrayExpression
+```javascript
+t.arrayExpression()
+```
+
+See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `elements`: `Array<null | Expression | SpreadElement>` (default: `[]`)
+
+---
+
 ### arrayPattern
 ```javascript
 t.arrayPattern(elements)
@@ -54,10 +54,10 @@ t.arrayPattern(elements)
 
 See also `t.isArrayPattern(node, opts)` and `t.assertArrayPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `elements`: `Array<PatternLike>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -77,17 +77,17 @@ Aliases: `Flow`, `FlowType`
 
 ### arrowFunctionExpression
 ```javascript
-t.arrowFunctionExpression(params, body, async)
+t.arrowFunctionExpression(params, body)
 ```
 
 See also `t.isArrowFunctionExpression(node, opts)` and `t.assertArrowFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement | Expression` (required)
  - `async`: `boolean` (default: `false`)
- - `expression`: `boolean` (default: `null`)
+ - `expression`: `boolean` (default: `false`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -116,11 +116,11 @@ t.assignmentPattern(left, right)
 
 See also `t.isAssignmentPattern(node, opts)` and `t.assertAssignmentPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
- - `left`: `Identifier | ObjectPattern | ArrayPattern` (required)
+ - `left`: `Identifier | ObjectPattern | ArrayPattern | MemberExpression` (required)
  - `right`: `Expression` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -145,7 +145,7 @@ t.bigIntLiteral(value)
 
 See also `t.isBigIntLiteral(node, opts)` and `t.assertBigIntLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -175,19 +175,19 @@ See also `t.isBindExpression(node, opts)` and `t.assertBindExpression(node, opts
 
 Aliases: `Expression`
 
- - `object` (required)
- - `callee` (required)
+ - `object`: `any` (required)
+ - `callee`: `any` (required)
 
 ---
 
 ### blockStatement
 ```javascript
-t.blockStatement(body, directives)
+t.blockStatement(body)
 ```
 
 See also `t.isBlockStatement(node, opts)` and `t.assertBlockStatement(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`, `Statement`
+Aliases: `Block`, `BlockParent`, `Scopable`, `Statement`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
@@ -201,7 +201,7 @@ t.booleanLiteral(value)
 
 See also `t.isBooleanLiteral(node, opts)` and `t.assertBooleanLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `boolean` (required)
 
@@ -227,19 +227,18 @@ t.booleanTypeAnnotation()
 
 See also `t.isBooleanTypeAnnotation(node, opts)` and `t.assertBooleanTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
 ### breakStatement
 ```javascript
-t.breakStatement(label)
+t.breakStatement()
 ```
 
 See also `t.isBreakStatement(node, opts)` and `t.assertBreakStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -255,7 +254,7 @@ See also `t.isCallExpression(node, opts)` and `t.assertCallExpression(node, opts
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -269,9 +268,9 @@ t.catchClause(param, body)
 
 See also `t.isCatchClause(node, opts)` and `t.assertCatchClause(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`
+Aliases: `BlockParent`, `Scopable`
 
- - `param`: `Identifier` (default: `null`)
+ - `param`: `Identifier` (required)
  - `body`: `BlockStatement` (required)
 
 ---
@@ -283,27 +282,29 @@ t.classBody(body)
 
 See also `t.isClassBody(node, opts)` and `t.assertClassBody(node, opts)`.
 
- - `body`: `Array<ClassMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
+Aliases: none
+
+ - `body`: `Array<ClassMethod | ClassPrivateMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
 
 ---
 
 ### classDeclaration
 ```javascript
-t.classDeclaration(id, superClass, body, decorators)
+t.classDeclaration(id, superClass, body)
 ```
 
 See also `t.isClassDeclaration(node, opts)` and `t.assertClassDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
+Aliases: `Class`, `Declaration`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `abstract`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -311,19 +312,19 @@ Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
 
 ### classExpression
 ```javascript
-t.classExpression(id, superClass, body, decorators)
+t.classExpression(id, superClass, body)
 ```
 
 See also `t.isClassExpression(node, opts)` and `t.assertClassExpression(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
+Aliases: `Class`, `Expression`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -331,7 +332,7 @@ Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
 
 ### classImplements
 ```javascript
-t.classImplements(id, typeParameters)
+t.classImplements(id)
 ```
 
 See also `t.isClassImplements(node, opts)` and `t.assertClassImplements(node, opts)`.
@@ -345,39 +346,66 @@ Aliases: `Flow`
 
 ### classMethod
 ```javascript
-t.classMethod(kind, key, params, body, computed, static)
+t.classMethod(kind, key, params, body)
 ```
 
 See also `t.isClassMethod(node, opts)` and `t.assertClassMethod(node, opts)`.
 
-Aliases: `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Scopable`
 
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `method`)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
- - `static`: `boolean` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
  - `access`: `"public" | "private" | "protected"` (default: `null`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
+### classPrivateMethod
+```javascript
+t.classPrivateMethod(kind, key, params, body)
+```
+
+See also `t.isClassPrivateMethod(node, opts)` and `t.assertClassPrivateMethod(node, opts)`.
+
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Private`, `Scopable`
+
+ - `kind`: `"get" | "set" | "method" | "constructor"` (required)
+ - `key`: `PrivateName` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `body`: `BlockStatement` (required)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `generator`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `returnType`: `any` (default: `null`)
+ - `typeParameters`: `any` (default: `null`)
+
+---
+
 ### classPrivateProperty
 ```javascript
-t.classPrivateProperty(key, value)
+t.classPrivateProperty(key)
 ```
 
 See also `t.isClassPrivateProperty(node, opts)` and `t.assertClassPrivateProperty(node, opts)`.
 
-Aliases: `Property`, `Private`
+Aliases: `Private`, `Property`
 
  - `key`: `PrivateName` (required)
  - `value`: `Expression` (default: `null`)
@@ -386,7 +414,7 @@ Aliases: `Property`, `Private`
 
 ### classProperty
 ```javascript
-t.classProperty(key, value, typeAnnotation, decorators, computed)
+t.classProperty(key)
 ```
 
 See also `t.isClassProperty(node, opts)` and `t.assertClassProperty(node, opts)`.
@@ -396,14 +424,14 @@ Aliases: `Property`
  - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
  - `value`: `Expression` (default: `null`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `computed`: `boolean` (default: `false`)
- - `abstract`: `boolean` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `definite`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -414,7 +442,7 @@ t.conditionalExpression(test, consequent, alternate)
 
 See also `t.isConditionalExpression(node, opts)` and `t.assertConditionalExpression(node, opts)`.
 
-Aliases: `Expression`, `Conditional`
+Aliases: `Conditional`, `Expression`
 
  - `test`: `Expression` (required)
  - `consequent`: `Expression` (required)
@@ -424,12 +452,12 @@ Aliases: `Expression`, `Conditional`
 
 ### continueStatement
 ```javascript
-t.continueStatement(label)
+t.continueStatement()
 ```
 
 See also `t.isContinueStatement(node, opts)` and `t.assertContinueStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -444,7 +472,6 @@ See also `t.isDebuggerStatement(node, opts)` and `t.assertDebuggerStatement(node
 
 Aliases: `Statement`
 
-
 ---
 
 ### declareClass
@@ -454,147 +481,14 @@ t.declareClass(id, typeParameters, extends, body)
 
 See also `t.isDeclareClass(node, opts)` and `t.assertDeclareClass(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareExportAllDeclaration
-```javascript
-t.declareExportAllDeclaration(source)
-```
-
-See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `source`: `StringLiteral` (required)
- - `exportKind`: `["type","value"]` (default: `null`)
-
----
-
-### declareExportDeclaration
-```javascript
-t.declareExportDeclaration(declaration, specifiers, source)
-```
-
-See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `declaration`: `Flow` (default: `null`)
- - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `null`)
- - `source`: `StringLiteral` (default: `null`)
- - `default`: `boolean` (default: `null`)
-
----
-
-### declareFunction
-```javascript
-t.declareFunction(id)
-```
-
-See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `predicate`: `DeclaredPredicate` (default: `null`)
-
----
-
-### declareInterface
-```javascript
-t.declareInterface(id, typeParameters, extends, body)
-```
-
-See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareModule
-```javascript
-t.declareModule(id, body, kind)
-```
-
-See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `BlockStatement` (required)
- - `kind`: `"CommonJS" | "ES"` (default: `null`)
-
----
-
-### declareModuleExports
-```javascript
-t.declareModuleExports(typeAnnotation)
-```
-
-See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `typeAnnotation`: `TypeAnnotation` (required)
-
----
-
-### declareOpaqueType
-```javascript
-t.declareOpaqueType(id, typeParameters, supertype)
-```
-
-See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
-
----
-
-### declareTypeAlias
-```javascript
-t.declareTypeAlias(id, typeParameters, right)
-```
-
-See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `FlowType` (required)
-
----
-
-### declareVariable
-```javascript
-t.declareVariable(id)
-```
-
-See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
@@ -611,12 +505,147 @@ Aliases: `Flow`, `FlowPredicate`
 
 ---
 
+### declareExportAllDeclaration
+```javascript
+t.declareExportAllDeclaration(source)
+```
+
+See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `source`: `StringLiteral` (required)
+ - `exportKind`: `"type" | "value"` (default: `null`)
+
+---
+
+### declareExportDeclaration
+```javascript
+t.declareExportDeclaration()
+```
+
+See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `declaration`: `Flow` (default: `null`)
+ - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `[]`)
+ - `source`: `StringLiteral` (default: `null`)
+ - `default`: `boolean` (default: `false`)
+
+---
+
+### declareFunction
+```javascript
+t.declareFunction(id)
+```
+
+See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `predicate`: `DeclaredPredicate` (default: `null`)
+
+---
+
+### declareInterface
+```javascript
+t.declareInterface(id, typeParameters, extends, body)
+```
+
+See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
+ - `body`: `ObjectTypeAnnotation` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
+
+---
+
+### declareModule
+```javascript
+t.declareModule(id, body)
+```
+
+See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `BlockStatement` (required)
+ - `kind`: `"CommonJS" | "ES"` (default: `null`)
+
+---
+
+### declareModuleExports
+```javascript
+t.declareModuleExports(typeAnnotation)
+```
+
+See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `typeAnnotation`: `TypeAnnotation` (required)
+
+---
+
+### declareOpaqueType
+```javascript
+t.declareOpaqueType(id)
+```
+
+See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `supertype`: `FlowType` (default: `null`)
+
+---
+
+### declareTypeAlias
+```javascript
+t.declareTypeAlias(id, typeParameters, right)
+```
+
+See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `right`: `FlowType` (required)
+
+---
+
+### declareVariable
+```javascript
+t.declareVariable(id)
+```
+
+See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
 ### decorator
 ```javascript
 t.decorator(expression)
 ```
 
 See also `t.isDecorator(node, opts)` and `t.assertDecorator(node, opts)`.
+
+Aliases: none
 
  - `expression`: `Expression` (required)
 
@@ -629,6 +658,8 @@ t.directive(value)
 
 See also `t.isDirective(node, opts)` and `t.assertDirective(node, opts)`.
 
+Aliases: none
+
  - `value`: `DirectiveLiteral` (required)
 
 ---
@@ -639,6 +670,8 @@ t.directiveLiteral(value)
 ```
 
 See also `t.isDirectiveLiteral(node, opts)` and `t.assertDirectiveLiteral(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -664,7 +697,7 @@ t.doWhileStatement(test, body)
 
 See also `t.isDoWhileStatement(node, opts)` and `t.assertDoWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `Statement` (required)
@@ -680,7 +713,6 @@ See also `t.isEmptyStatement(node, opts)` and `t.assertEmptyStatement(node, opts
 
 Aliases: `Statement`
 
-
 ---
 
 ### emptyTypeAnnotation
@@ -690,8 +722,7 @@ t.emptyTypeAnnotation()
 
 See also `t.isEmptyTypeAnnotation(node, opts)` and `t.assertEmptyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -704,7 +735,6 @@ See also `t.isExistsTypeAnnotation(node, opts)` and `t.assertExistsTypeAnnotatio
 
 Aliases: `Flow`, `FlowType`
 
-
 ---
 
 ### exportAllDeclaration
@@ -714,7 +744,7 @@ t.exportAllDeclaration(source)
 
 See also `t.isExportAllDeclaration(node, opts)` and `t.assertExportAllDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `source`: `StringLiteral` (required)
 
@@ -727,7 +757,7 @@ t.exportDefaultDeclaration(declaration)
 
 See also `t.isExportDefaultDeclaration(node, opts)` and `t.assertExportDefaultDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `declaration`: `FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression` (required)
 
@@ -748,16 +778,17 @@ Aliases: `ModuleSpecifier`
 
 ### exportNamedDeclaration
 ```javascript
-t.exportNamedDeclaration(declaration, specifiers, source)
+t.exportNamedDeclaration(declaration, specifiers)
 ```
 
 See also `t.isExportNamedDeclaration(node, opts)` and `t.assertExportNamedDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
- - `declaration`: `Declaration` (default: `null`)
+ - `declaration`: `Declaration` (required)
  - `specifiers`: `Array<ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (default: `null`)
+ - `exportKind`: `"type" | "value"` (default: `null`)
 
 ---
 
@@ -795,7 +826,7 @@ t.expressionStatement(expression)
 
 See also `t.isExpressionStatement(node, opts)` and `t.assertExpressionStatement(node, opts)`.
 
-Aliases: `Statement`, `ExpressionWrapper`
+Aliases: `ExpressionWrapper`, `Statement`
 
  - `expression`: `Expression` (required)
 
@@ -808,9 +839,11 @@ t.file(program, comments, tokens)
 
 See also `t.isFile(node, opts)` and `t.assertFile(node, opts)`.
 
+Aliases: none
+
  - `program`: `Program` (required)
- - `comments` (required)
- - `tokens` (required)
+ - `comments`: `any` (required)
+ - `tokens`: `any` (required)
 
 ---
 
@@ -821,7 +854,7 @@ t.forInStatement(left, right, body)
 
 See also `t.isForInStatement(node, opts)` and `t.assertForInStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -836,7 +869,7 @@ t.forOfStatement(left, right, body)
 
 See also `t.isForOfStatement(node, opts)` and `t.assertForOfStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -852,30 +885,30 @@ t.forStatement(init, test, update, body)
 
 See also `t.isForStatement(node, opts)` and `t.assertForStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`
+Aliases: `BlockParent`, `For`, `Loop`, `Scopable`, `Statement`
 
- - `init`: `VariableDeclaration | Expression` (default: `null`)
- - `test`: `Expression` (default: `null`)
- - `update`: `Expression` (default: `null`)
+ - `init`: `VariableDeclaration | Expression` (required)
+ - `test`: `Expression` (required)
+ - `update`: `Expression` (required)
  - `body`: `Statement` (required)
 
 ---
 
 ### functionDeclaration
 ```javascript
-t.functionDeclaration(id, params, body, generator, async)
+t.functionDeclaration(id, params, body)
 ```
 
 See also `t.isFunctionDeclaration(node, opts)` and `t.assertFunctionDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `Pureish`, `Declaration`
+Aliases: `BlockParent`, `Declaration`, `Function`, `FunctionParent`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -883,15 +916,15 @@ Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `
 
 ### functionExpression
 ```javascript
-t.functionExpression(id, params, body, generator, async)
+t.functionExpression(id, params, body)
 ```
 
 See also `t.isFunctionExpression(node, opts)` and `t.assertFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
@@ -909,9 +942,9 @@ See also `t.isFunctionTypeAnnotation(node, opts)` and `t.assertFunctionTypeAnnot
 
 Aliases: `Flow`, `FlowType`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `params`: `Array<FunctionTypeParam>` (required)
- - `rest`: `FunctionTypeParam` (default: `null`)
+ - `rest`: `FunctionTypeParam` (required)
  - `returnType`: `FlowType` (required)
 
 ---
@@ -925,22 +958,22 @@ See also `t.isFunctionTypeParam(node, opts)` and `t.assertFunctionTypeParam(node
 
 Aliases: `Flow`
 
- - `name`: `Identifier` (default: `null`)
+ - `name`: `Identifier` (required)
  - `typeAnnotation`: `FlowType` (required)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
 
 ---
 
 ### genericTypeAnnotation
 ```javascript
-t.genericTypeAnnotation(id, typeParameters)
+t.genericTypeAnnotation(id)
 ```
 
 See also `t.isGenericTypeAnnotation(node, opts)` and `t.assertGenericTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -952,39 +985,27 @@ t.identifier(name)
 
 See also `t.isIdentifier(node, opts)` and `t.assertIdentifier(node, opts)`.
 
-Aliases: `Expression`, `PatternLike`, `LVal`, `TSEntityName`
+Aliases: `Expression`, `LVal`, `PatternLike`, `TSEntityName`
 
  - `name`: `string` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `optional`: `boolean` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `optional`: `boolean` (default: `false`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### ifStatement
 ```javascript
-t.ifStatement(test, consequent, alternate)
+t.ifStatement(test, consequent)
 ```
 
 See also `t.isIfStatement(node, opts)` and `t.assertIfStatement(node, opts)`.
 
-Aliases: `Statement`, `Conditional`
+Aliases: `Conditional`, `Statement`
 
  - `test`: `Expression` (required)
  - `consequent`: `Statement` (required)
  - `alternate`: `Statement` (default: `null`)
-
----
-
-### import
-```javascript
-t.import()
-```
-
-See also `t.isImport(node, opts)` and `t.assertImport(node, opts)`.
-
-Aliases: `Expression`
-
 
 ---
 
@@ -995,10 +1016,11 @@ t.importDeclaration(specifiers, source)
 
 See also `t.isImportDeclaration(node, opts)` and `t.assertImportDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`
+Aliases: `Declaration`, `ModuleDeclaration`, `Statement`
 
  - `specifiers`: `Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (required)
+ - `importKind`: `"type" | "typeof" | "value"` (default: `null`)
 
 ---
 
@@ -1039,7 +1061,7 @@ Aliases: `ModuleSpecifier`
 
  - `local`: `Identifier` (required)
  - `imported`: `Identifier` (required)
- - `importKind`: `null | "type" | "typeof"` (default: `null`)
+ - `importKind`: `"type" | "typeof"` (default: `null`)
 
 ---
 
@@ -1052,7 +1074,6 @@ See also `t.isInferredPredicate(node, opts)` and `t.assertInferredPredicate(node
 
 Aliases: `Flow`, `FlowPredicate`
 
-
 ---
 
 ### interfaceDeclaration
@@ -1062,27 +1083,27 @@ t.interfaceDeclaration(id, typeParameters, extends, body)
 
 See also `t.isInterfaceDeclaration(node, opts)` and `t.assertInterfaceDeclaration(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
 ### interfaceExtends
 ```javascript
-t.interfaceExtends(id, typeParameters)
+t.interfaceExtends(id)
 ```
 
 See also `t.isInterfaceExtends(node, opts)` and `t.assertInterfaceExtends(node, opts)`.
 
 Aliases: `Flow`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -1096,7 +1117,7 @@ See also `t.isInterfaceTypeAnnotation(node, opts)` and `t.assertInterfaceTypeAnn
 
 Aliases: `Flow`, `FlowType`
 
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
 
 ---
@@ -1107,6 +1128,8 @@ t.interpreterDirective(value)
 ```
 
 See also `t.isInterpreterDirective(node, opts)` and `t.assertInterpreterDirective(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -1125,62 +1148,61 @@ Aliases: `Flow`, `FlowType`
 
 ---
 
-### jSXAttribute
+### jsxAttribute
 ```javascript
-t.jsxAttribute(name, value)
+t.jsxAttribute(name)
 ```
 
 See also `t.isJSXAttribute(node, opts)` and `t.assertJSXAttribute(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXNamespacedName` (required)
  - `value`: `JSXElement | JSXFragment | StringLiteral | JSXExpressionContainer` (default: `null`)
 
 ---
 
-### jSXClosingElement
+### jsxClosingElement
 ```javascript
 t.jsxClosingElement(name)
 ```
 
 See also `t.isJSXClosingElement(node, opts)` and `t.assertJSXClosingElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
 
 ---
 
-### jSXClosingFragment
+### jsxClosingFragment
 ```javascript
 t.jsxClosingFragment()
 ```
 
 See also `t.isJSXClosingFragment(node, opts)` and `t.assertJSXClosingFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXElement
+### jsxElement
 ```javascript
 t.jsxElement(openingElement, closingElement, children, selfClosing)
 ```
 
 See also `t.isJSXElement(node, opts)` and `t.assertJSXElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingElement`: `JSXOpeningElement` (required)
- - `closingElement`: `JSXClosingElement` (default: `null`)
+ - `closingElement`: `JSXClosingElement` (required)
  - `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
- - `selfClosing` (required)
+ - `selfClosing`: `any` (required)
 
 ---
 
-### jSXEmptyExpression
+### jsxEmptyExpression
 ```javascript
 t.jsxEmptyExpression()
 ```
@@ -1189,30 +1211,29 @@ See also `t.isJSXEmptyExpression(node, opts)` and `t.assertJSXEmptyExpression(no
 
 Aliases: `JSX`
 
-
 ---
 
-### jSXExpressionContainer
+### jsxExpressionContainer
 ```javascript
 t.jsxExpressionContainer(expression)
 ```
 
 See also `t.isJSXExpressionContainer(node, opts)` and `t.assertJSXExpressionContainer(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
- - `expression`: `Expression` (required)
+ - `expression`: `Expression | JSXEmptyExpression` (required)
 
 ---
 
-### jSXFragment
+### jsxFragment
 ```javascript
 t.jsxFragment(openingFragment, closingFragment, children)
 ```
 
 See also `t.isJSXFragment(node, opts)` and `t.assertJSXFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingFragment`: `JSXOpeningFragment` (required)
  - `closingFragment`: `JSXClosingFragment` (required)
@@ -1220,7 +1241,7 @@ Aliases: `JSX`, `Immutable`, `Expression`
 
 ---
 
-### jSXIdentifier
+### jsxIdentifier
 ```javascript
 t.jsxIdentifier(name)
 ```
@@ -1233,7 +1254,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXMemberExpression
+### jsxMemberExpression
 ```javascript
 t.jsxMemberExpression(object, property)
 ```
@@ -1247,7 +1268,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXNamespacedName
+### jsxNamespacedName
 ```javascript
 t.jsxNamespacedName(namespace, name)
 ```
@@ -1261,34 +1282,34 @@ Aliases: `JSX`
 
 ---
 
-### jSXOpeningElement
+### jsxOpeningElement
 ```javascript
-t.jsxOpeningElement(name, attributes, selfClosing)
+t.jsxOpeningElement(name, attributes)
 ```
 
 See also `t.isJSXOpeningElement(node, opts)` and `t.assertJSXOpeningElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
  - `attributes`: `Array<JSXAttribute | JSXSpreadAttribute>` (required)
  - `selfClosing`: `boolean` (default: `false`)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
-### jSXOpeningFragment
+### jsxOpeningFragment
 ```javascript
 t.jsxOpeningFragment()
 ```
 
 See also `t.isJSXOpeningFragment(node, opts)` and `t.assertJSXOpeningFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXSpreadAttribute
+### jsxSpreadAttribute
 ```javascript
 t.jsxSpreadAttribute(argument)
 ```
@@ -1301,27 +1322,27 @@ Aliases: `JSX`
 
 ---
 
-### jSXSpreadChild
+### jsxSpreadChild
 ```javascript
 t.jsxSpreadChild(expression)
 ```
 
 See also `t.isJSXSpreadChild(node, opts)` and `t.assertJSXSpreadChild(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `expression`: `Expression` (required)
 
 ---
 
-### jSXText
+### jsxText
 ```javascript
 t.jsxText(value)
 ```
 
 See also `t.isJSXText(node, opts)` and `t.assertJSXText(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `value`: `string` (required)
 
@@ -1358,7 +1379,7 @@ Aliases: `Binary`, `Expression`
 
 ### memberExpression
 ```javascript
-t.memberExpression(object, property, computed, optional)
+t.memberExpression(object, property)
 ```
 
 See also `t.isMemberExpression(node, opts)` and `t.assertMemberExpression(node, opts)`.
@@ -1393,8 +1414,7 @@ t.mixedTypeAnnotation()
 
 See also `t.isMixedTypeAnnotation(node, opts)` and `t.assertMixedTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1408,7 +1428,7 @@ See also `t.isNewExpression(node, opts)` and `t.assertNewExpression(node, opts)`
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -1422,30 +1442,7 @@ t.noop()
 
 See also `t.isNoop(node, opts)` and `t.assertNoop(node, opts)`.
 
-
----
-
-### nullLiteral
-```javascript
-t.nullLiteral()
-```
-
-See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
-
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
-
-
----
-
-### nullLiteralTypeAnnotation
-```javascript
-t.nullLiteralTypeAnnotation()
-```
-
-See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: none
 
 ---
 
@@ -1459,6 +1456,28 @@ See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnot
 Aliases: `Flow`, `FlowType`
 
  - `typeAnnotation`: `FlowType` (required)
+
+---
+
+### nullLiteral
+```javascript
+t.nullLiteral()
+```
+
+See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
+
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
+
+---
+
+### nullLiteralTypeAnnotation
+```javascript
+t.nullLiteralTypeAnnotation()
+```
+
+See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1482,8 +1501,7 @@ t.numberTypeAnnotation()
 
 See also `t.isNumberTypeAnnotation(node, opts)` and `t.assertNumberTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1494,7 +1512,7 @@ t.numericLiteral(value)
 
 See also `t.isNumericLiteral(node, opts)` and `t.assertNumericLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `number` (required)
 
@@ -1515,20 +1533,20 @@ Aliases: `Expression`
 
 ### objectMethod
 ```javascript
-t.objectMethod(kind, key, params, body, computed)
+t.objectMethod(kind, key, params, body)
 ```
 
 See also `t.isObjectMethod(node, opts)` and `t.assertObjectMethod(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`, `ObjectMember`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `ObjectMember`, `Scopable`, `UserWhitespacable`
 
- - `kind`: `"method" | "get" | "set"` (default: `'method'`)
+ - `kind`: `"method" | "get" | "set"` (required)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -1542,34 +1560,34 @@ t.objectPattern(properties)
 
 See also `t.isObjectPattern(node, opts)` and `t.assertObjectPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `properties`: `Array<RestElement | ObjectProperty>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### objectProperty
 ```javascript
-t.objectProperty(key, value, computed, shorthand, decorators)
+t.objectProperty(key, value)
 ```
 
 See also `t.isObjectProperty(node, opts)` and `t.assertObjectProperty(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Property`, `ObjectMember`
+Aliases: `ObjectMember`, `Property`, `UserWhitespacable`
 
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
  - `value`: `Expression | PatternLike` (required)
  - `computed`: `boolean` (default: `false`)
  - `shorthand`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
 
 ---
 
 ### objectTypeAnnotation
 ```javascript
-t.objectTypeAnnotation(properties, indexers, callProperties, internalSlots, exact)
+t.objectTypeAnnotation(properties)
 ```
 
 See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotation(node, opts)`.
@@ -1577,10 +1595,11 @@ See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotatio
 Aliases: `Flow`, `FlowType`
 
  - `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
- - `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
- - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `null`)
- - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `null`)
+ - `indexers`: `Array<ObjectTypeIndexer>` (default: `[]`)
+ - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `[]`)
+ - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `[]`)
  - `exact`: `boolean` (default: `false`)
+ - `inexact`: `boolean` (default: `false`)
 
 ---
 
@@ -1594,24 +1613,24 @@ See also `t.isObjectTypeCallProperty(node, opts)` and `t.assertObjectTypeCallPro
 Aliases: `Flow`, `UserWhitespacable`
 
  - `value`: `FlowType` (required)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
 ### objectTypeIndexer
 ```javascript
-t.objectTypeIndexer(id, key, value, variance)
+t.objectTypeIndexer(id, key, value)
 ```
 
 See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `id`: `Identifier` (default: `null`)
+ - `id`: `Identifier` (required)
  - `key`: `FlowType` (required)
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1634,7 +1653,7 @@ Aliases: `Flow`, `UserWhitespacable`
 
 ### objectTypeProperty
 ```javascript
-t.objectTypeProperty(key, value, variance)
+t.objectTypeProperty(key, value)
 ```
 
 See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(node, opts)`.
@@ -1645,9 +1664,9 @@ Aliases: `Flow`, `UserWhitespacable`
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
  - `kind`: `"init" | "get" | "set"` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `proto`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `proto`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1671,11 +1690,11 @@ t.opaqueType(id, typeParameters, supertype, impltype)
 
 See also `t.isOpaqueType(node, opts)` and `t.assertOpaqueType(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `supertype`: `FlowType` (required)
  - `impltype`: `FlowType` (required)
 
 ---
@@ -1708,7 +1727,7 @@ Aliases: `Expression`
 
  - `object`: `Expression` (required)
  - `property`: `any` (required)
- - `computed`: `boolean` (default: `false`)
+ - `computed`: `boolean` (required)
  - `optional`: `boolean` (required)
 
 ---
@@ -1723,6 +1742,57 @@ See also `t.isParenthesizedExpression(node, opts)` and `t.assertParenthesizedExp
 Aliases: `Expression`, `ExpressionWrapper`
 
  - `expression`: `Expression` (required)
+
+---
+
+### pipelineBareFunction
+```javascript
+t.pipelineBareFunction(callee)
+```
+
+See also `t.isPipelineBareFunction(node, opts)` and `t.assertPipelineBareFunction(node, opts)`.
+
+Aliases: none
+
+ - `callee`: `Expression` (required)
+
+---
+
+### pipelinePrimaryTopicReference
+```javascript
+t.pipelinePrimaryTopicReference()
+```
+
+See also `t.isPipelinePrimaryTopicReference(node, opts)` and `t.assertPipelinePrimaryTopicReference(node, opts)`.
+
+Aliases: `Expression`
+
+---
+
+### pipelineTopicExpression
+```javascript
+t.pipelineTopicExpression(expression)
+```
+
+See also `t.isPipelineTopicExpression(node, opts)` and `t.assertPipelineTopicExpression(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `Expression` (required)
+
+---
+
+### placeholder
+```javascript
+t.placeholder(expectedNode, name)
+```
+
+See also `t.isPlaceholder(node, opts)` and `t.assertPlaceholder(node, opts)`.
+
+Aliases: none
+
+ - `expectedNode`: `"Identifier" | "StringLiteral" | "Expression" | "Statement" | "Declaration" | "BlockStatement" | "ClassBody" | "Pattern"` (required)
+ - `name`: `Identifier` (required)
 
 ---
 
@@ -1741,18 +1811,18 @@ Aliases: `Private`
 
 ### program
 ```javascript
-t.program(body, directives, sourceType, interpreter)
+t.program(body)
 ```
 
 See also `t.isProgram(node, opts)` and `t.assertProgram(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`
+Aliases: `Block`, `BlockParent`, `Scopable`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
  - `sourceType`: `"script" | "module"` (default: `'script'`)
  - `interpreter`: `InterpreterDirective` (default: `null`)
- - `sourceFile`: `string` (default: `null`)
+ - `sourceFile`: `string` (default: `""`)
 
 ---
 
@@ -1772,7 +1842,7 @@ Aliases: `Flow`
 
 ### regExpLiteral
 ```javascript
-t.regExpLiteral(pattern, flags)
+t.regExpLiteral(pattern)
 ```
 
 See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`.
@@ -1780,7 +1850,7 @@ See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`
 Aliases: `Expression`, `Literal`
 
  - `pattern`: `string` (required)
- - `flags`: `string` (default: `''`)
+ - `flags`: `string` (default: `""`)
 
 ---
 
@@ -1794,19 +1864,19 @@ See also `t.isRestElement(node, opts)` and `t.assertRestElement(node, opts)`.
 Aliases: `LVal`, `PatternLike`
 
  - `argument`: `LVal` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### returnStatement
 ```javascript
-t.returnStatement(argument)
+t.returnStatement()
 ```
 
 See also `t.isReturnStatement(node, opts)` and `t.assertReturnStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (default: `null`)
 
@@ -1845,7 +1915,7 @@ t.stringLiteral(value)
 
 See also `t.isStringLiteral(node, opts)` and `t.assertStringLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -1871,20 +1941,7 @@ t.stringTypeAnnotation()
 
 See also `t.isStringTypeAnnotation(node, opts)` and `t.assertStringTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
-
----
-
-### super
-```javascript
-t.super()
-```
-
-See also `t.isSuper(node, opts)` and `t.assertSuper(node, opts)`.
-
-Aliases: `Expression`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1895,7 +1952,9 @@ t.switchCase(test, consequent)
 
 See also `t.isSwitchCase(node, opts)` and `t.assertSwitchCase(node, opts)`.
 
- - `test`: `Expression` (default: `null`)
+Aliases: none
+
+ - `test`: `Expression` (required)
  - `consequent`: `Array<Statement>` (required)
 
 ---
@@ -1907,796 +1966,10 @@ t.switchStatement(discriminant, cases)
 
 See also `t.isSwitchStatement(node, opts)` and `t.assertSwitchStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Scopable`
+Aliases: `BlockParent`, `Scopable`, `Statement`
 
  - `discriminant`: `Expression` (required)
  - `cases`: `Array<SwitchCase>` (required)
-
----
-
-### tSAnyKeyword
-```javascript
-t.tsAnyKeyword()
-```
-
-See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSArrayType
-```javascript
-t.tsArrayType(elementType)
-```
-
-See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementType`: `TSType` (required)
-
----
-
-### tSAsExpression
-```javascript
-t.tsAsExpression(expression, typeAnnotation)
-```
-
-See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSBooleanKeyword
-```javascript
-t.tsBooleanKeyword()
-```
-
-See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSCallSignatureDeclaration
-```javascript
-t.tsCallSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConditionalType
-```javascript
-t.tsConditionalType(checkType, extendsType, trueType, falseType)
-```
-
-See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
-
-Aliases: `TSType`
-
- - `checkType`: `TSType` (required)
- - `extendsType`: `TSType` (required)
- - `trueType`: `TSType` (required)
- - `falseType`: `TSType` (required)
-
----
-
-### tSConstructSignatureDeclaration
-```javascript
-t.tsConstructSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConstructorType
-```javascript
-t.tsConstructorType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSDeclareFunction
-```javascript
-t.tsDeclareFunction(id, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (default: `null`)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
- - `generator`: `boolean` (default: `false`)
-
----
-
-### tSDeclareMethod
-```javascript
-t.tsDeclareMethod(decorators, key, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
-
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `access`: `"public" | "private" | "protected"` (default: `null`)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `computed`: `boolean` (default: `false`)
- - `generator`: `boolean` (default: `false`)
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
- - `optional`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
-
----
-
-### tSEnumDeclaration
-```javascript
-t.tsEnumDeclaration(id, members)
-```
-
-See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `members`: `Array<TSEnumMember>` (required)
- - `const`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSEnumMember
-```javascript
-t.tsEnumMember(id, initializer)
-```
-
-See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
-
- - `id`: `Identifier | StringLiteral` (required)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSExportAssignment
-```javascript
-t.tsExportAssignment(expression)
-```
-
-See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
-
-Aliases: `Statement`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSExpressionWithTypeArguments
-```javascript
-t.tsExpressionWithTypeArguments(expression, typeParameters)
-```
-
-See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
-
-Aliases: `TSType`
-
- - `expression`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSExternalModuleReference
-```javascript
-t.tsExternalModuleReference(expression)
-```
-
-See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
-
- - `expression`: `StringLiteral` (required)
-
----
-
-### tSFunctionType
-```javascript
-t.tsFunctionType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSImportEqualsDeclaration
-```javascript
-t.tsImportEqualsDeclaration(id, moduleReference)
-```
-
-See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
- - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
- - `isExport`: `boolean` (default: `null`)
-
----
-
-### tSIndexSignature
-```javascript
-t.tsIndexSignature(parameters, typeAnnotation)
-```
-
-See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `parameters`: `Array<Identifier>` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSIndexedAccessType
-```javascript
-t.tsIndexedAccessType(objectType, indexType)
-```
-
-See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
-
-Aliases: `TSType`
-
- - `objectType`: `TSType` (required)
- - `indexType`: `TSType` (required)
-
----
-
-### tSInferType
-```javascript
-t.tsInferType(typeParameter)
-```
-
-See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
-
----
-
-### tSInterfaceBody
-```javascript
-t.tsInterfaceBody(body)
-```
-
-See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
-
- - `body`: `Array<TSTypeElement>` (required)
-
----
-
-### tSInterfaceDeclaration
-```javascript
-t.tsInterfaceDeclaration(id, typeParameters, extends, body)
-```
-
-See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<TSExpressionWithTypeArguments>` (default: `null`)
- - `body`: `TSInterfaceBody` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSIntersectionType
-```javascript
-t.tsIntersectionType(types)
-```
-
-See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSLiteralType
-```javascript
-t.tsLiteralType(literal)
-```
-
-See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
-
-Aliases: `TSType`
-
- - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
-
----
-
-### tSMappedType
-```javascript
-t.tsMappedType(typeParameter, typeAnnotation)
-```
-
-See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
- - `typeAnnotation`: `TSType` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSMethodSignature
-```javascript
-t.tsMethodSignature(key, typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
-
----
-
-### tSModuleBlock
-```javascript
-t.tsModuleBlock(body)
-```
-
-See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
-
- - `body`: `Array<Statement>` (required)
-
----
-
-### tSModuleDeclaration
-```javascript
-t.tsModuleDeclaration(id, body)
-```
-
-See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
- - `declare`: `boolean` (default: `null`)
- - `global`: `boolean` (default: `null`)
-
----
-
-### tSNamespaceExportDeclaration
-```javascript
-t.tsNamespaceExportDeclaration(id)
-```
-
-See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
-
----
-
-### tSNeverKeyword
-```javascript
-t.tsNeverKeyword()
-```
-
-See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNonNullExpression
-```javascript
-t.tsNonNullExpression(expression)
-```
-
-See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSNullKeyword
-```javascript
-t.tsNullKeyword()
-```
-
-See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNumberKeyword
-```javascript
-t.tsNumberKeyword()
-```
-
-See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSObjectKeyword
-```javascript
-t.tsObjectKeyword()
-```
-
-See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSParameterProperty
-```javascript
-t.tsParameterProperty(parameter)
-```
-
-See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
-
-Aliases: `LVal`
-
- - `parameter`: `Identifier | AssignmentPattern` (required)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSParenthesizedType
-```javascript
-t.tsParenthesizedType(typeAnnotation)
-```
-
-See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSPropertySignature
-```javascript
-t.tsPropertySignature(key, typeAnnotation, initializer)
-```
-
-See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSQualifiedName
-```javascript
-t.tsQualifiedName(left, right)
-```
-
-See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
-
-Aliases: `TSEntityName`
-
- - `left`: `TSEntityName` (required)
- - `right`: `Identifier` (required)
-
----
-
-### tSStringKeyword
-```javascript
-t.tsStringKeyword()
-```
-
-See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSSymbolKeyword
-```javascript
-t.tsSymbolKeyword()
-```
-
-See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSThisType
-```javascript
-t.tsThisType()
-```
-
-See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSTupleType
-```javascript
-t.tsTupleType(elementTypes)
-```
-
-See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementTypes`: `Array<TSType>` (required)
-
----
-
-### tSTypeAliasDeclaration
-```javascript
-t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
-```
-
-See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSType` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSTypeAnnotation
-```javascript
-t.tsTypeAnnotation(typeAnnotation)
-```
-
-See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSTypeAssertion
-```javascript
-t.tsTypeAssertion(typeAnnotation, expression)
-```
-
-See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
-
-Aliases: `Expression`
-
- - `typeAnnotation`: `TSType` (required)
- - `expression`: `Expression` (required)
-
----
-
-### tSTypeLiteral
-```javascript
-t.tsTypeLiteral(members)
-```
-
-See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
-
-Aliases: `TSType`
-
- - `members`: `Array<TSTypeElement>` (required)
-
----
-
-### tSTypeOperator
-```javascript
-t.tsTypeOperator(typeAnnotation)
-```
-
-See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
- - `operator`: `string` (default: `null`)
-
----
-
-### tSTypeParameter
-```javascript
-t.tsTypeParameter(constraint, default)
-```
-
-See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
-
- - `constraint`: `TSType` (default: `null`)
- - `default`: `TSType` (default: `null`)
- - `name`: `string` (default: `null`)
-
----
-
-### tSTypeParameterDeclaration
-```javascript
-t.tsTypeParameterDeclaration(params)
-```
-
-See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
-
- - `params`: `Array<TSTypeParameter>` (required)
-
----
-
-### tSTypeParameterInstantiation
-```javascript
-t.tsTypeParameterInstantiation(params)
-```
-
-See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
-
- - `params`: `Array<TSType>` (required)
-
----
-
-### tSTypePredicate
-```javascript
-t.tsTypePredicate(parameterName, typeAnnotation)
-```
-
-See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
-
-Aliases: `TSType`
-
- - `parameterName`: `Identifier | TSThisType` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (required)
-
----
-
-### tSTypeQuery
-```javascript
-t.tsTypeQuery(exprName)
-```
-
-See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
-
-Aliases: `TSType`
-
- - `exprName`: `TSEntityName` (required)
-
----
-
-### tSTypeReference
-```javascript
-t.tsTypeReference(typeName, typeParameters)
-```
-
-See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeName`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSUndefinedKeyword
-```javascript
-t.tsUndefinedKeyword()
-```
-
-See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSUnionType
-```javascript
-t.tsUnionType(types)
-```
-
-See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSUnknownType
-```javascript
-t.tsUnknownType(types)
-```
-
-See also `t.isTSUnknownType(node, opts)` and `t.assertTSUnknownType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSVoidKeyword
-```javascript
-t.tsVoidKeyword()
-```
-
-See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
-
-Aliases: `TSType`
-
 
 ---
 
@@ -2711,17 +1984,21 @@ Aliases: `Expression`
 
  - `tag`: `Expression` (required)
  - `quasi`: `TemplateLiteral` (required)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### templateElement
 ```javascript
-t.templateElement(value, tail)
+t.templateElement(value)
 ```
 
 See also `t.isTemplateElement(node, opts)` and `t.assertTemplateElement(node, opts)`.
 
- - `value` (required)
+Aliases: none
+
+ - `value`: `{ raw: string` (required)
+ - `cooked`: `string }` (default: `null`)
  - `tail`: `boolean` (default: `false`)
 
 ---
@@ -2749,7 +2026,6 @@ See also `t.isThisExpression(node, opts)` and `t.assertThisExpression(node, opts
 
 Aliases: `Expression`
 
-
 ---
 
 ### thisTypeAnnotation
@@ -2759,8 +2035,7 @@ t.thisTypeAnnotation()
 
 See also `t.isThisTypeAnnotation(node, opts)` and `t.assertThisTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -2771,7 +2046,7 @@ t.throwStatement(argument)
 
 See also `t.isThrowStatement(node, opts)` and `t.assertThrowStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (required)
 
@@ -2779,7 +2054,7 @@ Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
 ### tryStatement
 ```javascript
-t.tryStatement(block, handler, finalizer)
+t.tryStatement(block)
 ```
 
 See also `t.isTryStatement(node, opts)` and `t.assertTryStatement(node, opts)`.
@@ -2789,6 +2064,838 @@ Aliases: `Statement`
  - `block`: `BlockStatement` (required)
  - `handler`: `CatchClause` (default: `null`)
  - `finalizer`: `BlockStatement` (default: `null`)
+
+---
+
+### tsAnyKeyword
+```javascript
+t.tsAnyKeyword()
+```
+
+See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsArrayType
+```javascript
+t.tsArrayType(elementType)
+```
+
+See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementType`: `TSType` (required)
+
+---
+
+### tsAsExpression
+```javascript
+t.tsAsExpression(expression, typeAnnotation)
+```
+
+See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsBooleanKeyword
+```javascript
+t.tsBooleanKeyword()
+```
+
+See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsCallSignatureDeclaration
+```javascript
+t.tsCallSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConditionalType
+```javascript
+t.tsConditionalType(checkType, extendsType, trueType, falseType)
+```
+
+See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `checkType`: `TSType` (required)
+ - `extendsType`: `TSType` (required)
+ - `trueType`: `TSType` (required)
+ - `falseType`: `TSType` (required)
+
+---
+
+### tsConstructorType
+```javascript
+t.tsConstructorType(typeParameters, parameters)
+```
+
+See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConstructSignatureDeclaration
+```javascript
+t.tsConstructSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsDeclareFunction
+```javascript
+t.tsDeclareFunction(id, typeParameters, params)
+```
+
+See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+
+---
+
+### tsDeclareMethod
+```javascript
+t.tsDeclareMethod(decorators, key, typeParameters, params)
+```
+
+See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
+
+Aliases: none
+
+ - `decorators`: `Array<Decorator>` (required)
+ - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `optional`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
+
+---
+
+### tsEnumDeclaration
+```javascript
+t.tsEnumDeclaration(id, members)
+```
+
+See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `members`: `Array<TSEnumMember>` (required)
+ - `const`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsEnumMember
+```javascript
+t.tsEnumMember(id)
+```
+
+See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
+
+Aliases: none
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsExportAssignment
+```javascript
+t.tsExportAssignment(expression)
+```
+
+See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
+
+Aliases: `Statement`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsExpressionWithTypeArguments
+```javascript
+t.tsExpressionWithTypeArguments(expression)
+```
+
+See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
+
+Aliases: `TSType`
+
+ - `expression`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsExternalModuleReference
+```javascript
+t.tsExternalModuleReference(expression)
+```
+
+See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `StringLiteral` (required)
+
+---
+
+### tsFunctionType
+```javascript
+t.tsFunctionType(typeParameters, parameters)
+```
+
+See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsImportEqualsDeclaration
+```javascript
+t.tsImportEqualsDeclaration(id, moduleReference)
+```
+
+See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+ - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
+ - `isExport`: `boolean` (default: `false`)
+
+---
+
+### tsImportType
+```javascript
+t.tsImportType(argument)
+```
+
+See also `t.isTSImportType(node, opts)` and `t.assertTSImportType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `argument`: `StringLiteral` (required)
+ - `qualifier`: `TSEntityName` (default: `null`)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsIndexedAccessType
+```javascript
+t.tsIndexedAccessType(objectType, indexType)
+```
+
+See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `objectType`: `TSType` (required)
+ - `indexType`: `TSType` (required)
+
+---
+
+### tsIndexSignature
+```javascript
+t.tsIndexSignature(parameters)
+```
+
+See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `parameters`: `Array<Identifier>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsInferType
+```javascript
+t.tsInferType(typeParameter)
+```
+
+See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+
+---
+
+### tsInterfaceBody
+```javascript
+t.tsInterfaceBody(body)
+```
+
+See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
+
+Aliases: none
+
+ - `body`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsInterfaceDeclaration
+```javascript
+t.tsInterfaceDeclaration(id, typeParameters, extends, body)
+```
+
+See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `extends`: `Array<TSExpressionWithTypeArguments>` (required)
+ - `body`: `TSInterfaceBody` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsIntersectionType
+```javascript
+t.tsIntersectionType(types)
+```
+
+See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsLiteralType
+```javascript
+t.tsLiteralType(literal)
+```
+
+See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
+
+---
+
+### tsMappedType
+```javascript
+t.tsMappedType(typeParameter)
+```
+
+See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+ - `typeAnnotation`: `TSType` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsMethodSignature
+```javascript
+t.tsMethodSignature(key, typeParameters, parameters)
+```
+
+See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+
+---
+
+### tsModuleBlock
+```javascript
+t.tsModuleBlock(body)
+```
+
+See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
+
+Aliases: `Block`, `BlockParent`, `Scopable`
+
+ - `body`: `Array<Statement>` (required)
+
+---
+
+### tsModuleDeclaration
+```javascript
+t.tsModuleDeclaration(id, body)
+```
+
+See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
+ - `declare`: `boolean` (default: `false`)
+ - `global`: `boolean` (default: `false`)
+
+---
+
+### tsNamespaceExportDeclaration
+```javascript
+t.tsNamespaceExportDeclaration(id)
+```
+
+See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
+### tsNeverKeyword
+```javascript
+t.tsNeverKeyword()
+```
+
+See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNonNullExpression
+```javascript
+t.tsNonNullExpression(expression)
+```
+
+See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsNullKeyword
+```javascript
+t.tsNullKeyword()
+```
+
+See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNumberKeyword
+```javascript
+t.tsNumberKeyword()
+```
+
+See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsObjectKeyword
+```javascript
+t.tsObjectKeyword()
+```
+
+See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsOptionalType
+```javascript
+t.tsOptionalType(typeAnnotation)
+```
+
+See also `t.isTSOptionalType(node, opts)` and `t.assertTSOptionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsParameterProperty
+```javascript
+t.tsParameterProperty(parameter)
+```
+
+See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
+
+Aliases: `LVal`
+
+ - `parameter`: `Identifier | AssignmentPattern` (required)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsParenthesizedType
+```javascript
+t.tsParenthesizedType(typeAnnotation)
+```
+
+See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsPropertySignature
+```javascript
+t.tsPropertySignature(key)
+```
+
+See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `initializer`: `Expression` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsQualifiedName
+```javascript
+t.tsQualifiedName(left, right)
+```
+
+See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
+
+Aliases: `TSEntityName`
+
+ - `left`: `TSEntityName` (required)
+ - `right`: `Identifier` (required)
+
+---
+
+### tsRestType
+```javascript
+t.tsRestType(typeAnnotation)
+```
+
+See also `t.isTSRestType(node, opts)` and `t.assertTSRestType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsStringKeyword
+```javascript
+t.tsStringKeyword()
+```
+
+See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsSymbolKeyword
+```javascript
+t.tsSymbolKeyword()
+```
+
+See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsThisType
+```javascript
+t.tsThisType()
+```
+
+See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsTupleType
+```javascript
+t.tsTupleType(elementTypes)
+```
+
+See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementTypes`: `Array<TSType>` (required)
+
+---
+
+### tsTypeAliasDeclaration
+```javascript
+t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
+```
+
+See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `typeAnnotation`: `TSType` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsTypeAnnotation
+```javascript
+t.tsTypeAnnotation(typeAnnotation)
+```
+
+See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
+
+Aliases: none
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsTypeAssertion
+```javascript
+t.tsTypeAssertion(typeAnnotation, expression)
+```
+
+See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
+
+Aliases: `Expression`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `expression`: `Expression` (required)
+
+---
+
+### tsTypeLiteral
+```javascript
+t.tsTypeLiteral(members)
+```
+
+See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
+
+Aliases: `TSType`
+
+ - `members`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsTypeOperator
+```javascript
+t.tsTypeOperator(typeAnnotation)
+```
+
+See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `operator`: `string` (default: `""`)
+
+---
+
+### tsTypeParameter
+```javascript
+t.tsTypeParameter()
+```
+
+See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
+
+Aliases: none
+
+ - `constraint`: `TSType` (default: `null`)
+ - `default`: `TSType` (default: `null`)
+ - `name`: `string` (default: `""`)
+
+---
+
+### tsTypeParameterDeclaration
+```javascript
+t.tsTypeParameterDeclaration(params)
+```
+
+See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSTypeParameter>` (required)
+
+---
+
+### tsTypeParameterInstantiation
+```javascript
+t.tsTypeParameterInstantiation(params)
+```
+
+See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSType>` (required)
+
+---
+
+### tsTypePredicate
+```javascript
+t.tsTypePredicate(parameterName, typeAnnotation)
+```
+
+See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
+
+Aliases: `TSType`
+
+ - `parameterName`: `Identifier | TSThisType` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (required)
+
+---
+
+### tsTypeQuery
+```javascript
+t.tsTypeQuery(exprName)
+```
+
+See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
+
+Aliases: `TSType`
+
+ - `exprName`: `TSEntityName | TSImportType` (required)
+
+---
+
+### tsTypeReference
+```javascript
+t.tsTypeReference(typeName)
+```
+
+See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeName`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsUndefinedKeyword
+```javascript
+t.tsUndefinedKeyword()
+```
+
+See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsUnionType
+```javascript
+t.tsUnionType(types)
+```
+
+See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsUnknownKeyword
+```javascript
+t.tsUnknownKeyword()
+```
+
+See also `t.isTSUnknownKeyword(node, opts)` and `t.assertTSUnknownKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsVoidKeyword
+```javascript
+t.tsVoidKeyword()
+```
+
+See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
+
+Aliases: `TSType`
 
 ---
 
@@ -2812,10 +2919,10 @@ t.typeAlias(id, typeParameters, right)
 
 See also `t.isTypeAlias(node, opts)` and `t.assertTypeAlias(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `right`: `FlowType` (required)
 
 ---
@@ -2840,16 +2947,29 @@ t.typeCastExpression(expression, typeAnnotation)
 
 See also `t.isTypeCastExpression(node, opts)` and `t.assertTypeCastExpression(node, opts)`.
 
-Aliases: `Flow`, `ExpressionWrapper`, `Expression`
+Aliases: `Expression`, `ExpressionWrapper`, `Flow`
 
  - `expression`: `Expression` (required)
  - `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
+### typeofTypeAnnotation
+```javascript
+t.typeofTypeAnnotation(argument)
+```
+
+See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowType`
+
+ - `argument`: `FlowType` (required)
+
+---
+
 ### typeParameter
 ```javascript
-t.typeParameter(bound, default, variance)
+t.typeParameter()
 ```
 
 See also `t.isTypeParameter(node, opts)` and `t.assertTypeParameter(node, opts)`.
@@ -2859,7 +2979,7 @@ Aliases: `Flow`
  - `bound`: `TypeAnnotation` (default: `null`)
  - `default`: `FlowType` (default: `null`)
  - `variance`: `Variance` (default: `null`)
- - `name`: `string` (default: `null`)
+ - `name`: `string` (default: `""`)
 
 ---
 
@@ -2889,31 +3009,18 @@ Aliases: `Flow`
 
 ---
 
-### typeofTypeAnnotation
-```javascript
-t.typeofTypeAnnotation(argument)
-```
-
-See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`
-
- - `argument`: `FlowType` (required)
-
----
-
 ### unaryExpression
 ```javascript
-t.unaryExpression(operator, argument, prefix)
+t.unaryExpression(operator, argument)
 ```
 
 See also `t.isUnaryExpression(node, opts)` and `t.assertUnaryExpression(node, opts)`.
 
-Aliases: `UnaryLike`, `Expression`
+Aliases: `Expression`, `UnaryLike`
 
  - `operator`: `"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"` (required)
  - `argument`: `Expression` (required)
- - `prefix`: `boolean` (default: `true`)
+ - `prefix`: `boolean` (default: `false`)
 
 ---
 
@@ -2932,7 +3039,7 @@ Aliases: `Flow`, `FlowType`
 
 ### updateExpression
 ```javascript
-t.updateExpression(operator, argument, prefix)
+t.updateExpression(operator, argument)
 ```
 
 See also `t.isUpdateExpression(node, opts)` and `t.assertUpdateExpression(node, opts)`.
@@ -2952,24 +3059,26 @@ t.variableDeclaration(kind, declarations)
 
 See also `t.isVariableDeclaration(node, opts)` and `t.assertVariableDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`
+Aliases: `Declaration`, `Statement`
 
  - `kind`: `"var" | "let" | "const"` (required)
  - `declarations`: `Array<VariableDeclarator>` (required)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
 
 ---
 
 ### variableDeclarator
 ```javascript
-t.variableDeclarator(id, init)
+t.variableDeclarator(id)
 ```
 
 See also `t.isVariableDeclarator(node, opts)` and `t.assertVariableDeclarator(node, opts)`.
 
+Aliases: none
+
  - `id`: `LVal` (required)
  - `init`: `Expression` (default: `null`)
- - `definite`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
 
 ---
 
@@ -2993,8 +3102,7 @@ t.voidTypeAnnotation()
 
 See also `t.isVoidTypeAnnotation(node, opts)` and `t.assertVoidTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -3005,7 +3113,7 @@ t.whileStatement(test, body)
 
 See also `t.isWhileStatement(node, opts)` and `t.assertWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `BlockStatement | Statement` (required)
@@ -3028,7 +3136,7 @@ Aliases: `Statement`
 
 ### yieldExpression
 ```javascript
-t.yieldExpression(argument, delegate)
+t.yieldExpression()
 ```
 
 See also `t.isYieldExpression(node, opts)` and `t.assertYieldExpression(node, opts)`.
@@ -3039,4 +3147,3 @@ Aliases: `Expression`, `Terminatorless`
  - `delegate`: `boolean` (default: `false`)
 
 ---
-

--- a/scripts/generate-docs-types-versions.js
+++ b/scripts/generate-docs-types-versions.js
@@ -1,0 +1,72 @@
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+const { promisify } = require("util");
+
+const mkdir = promisify(fs.mkdir);
+const cp = promisify(fs.copyFile);
+
+const work = (cwd, cmd, argv) =>
+  new Promise((resolve, reject) => {
+    const worker = spawn(cmd, argv, { cwd, shell: true });
+
+    worker.stdout.on("data", data => {
+      console.log(`stdout: ${data.toString()}`);
+    });
+
+    worker.stderr.on("data", data => {
+      console.log(`stderr: ${data.toString()}`);
+    });
+
+    worker.on("close", code => {
+      if (code) {
+        reject();
+      } else {
+        resolve();
+      }
+    });
+  });
+
+(async () => {
+  try {
+    await mkdir(path.resolve(__dirname, "tmp"));
+  } catch (error) {
+    console.log("failed creating directory tmp");
+    console.log(error);
+  }
+  const latest = "7.5.5";
+  const typesVersions = ["7.0.0", "7.2.0", "7.4.0", latest];
+  for (const babelVersion of typesVersions) {
+    const location = path.resolve(__dirname, "tmp", babelVersion);
+    try {
+      await mkdir(location);
+    } catch (error) {
+      console.log("failed creating directory:", location);
+      console.log(error);
+    }
+    await work(location, "yarn", ["init", "-y"]);
+    await work(location, "yarn", ["add", `@babel/core@${babelVersion}`]);
+    await cp(
+      path.resolve(__dirname, "generate-docs-types.js"),
+      path.join(location, "generate-docs-types.js")
+    );
+    await work(location, "node", [
+      "generate-docs-types.js",
+      babelVersion === latest
+        ? ""
+        : `--babel-types-id=version-${babelVersion}-babel-types`,
+    ]);
+    const dest =
+      babelVersion === latest
+        ? path.resolve(__dirname, "..", "docs", "types.md")
+        : path.resolve(
+            __dirname,
+            "..",
+            "website",
+            "versioned_docs",
+            `version-${babelVersion}`,
+            "types.md"
+          );
+    await cp(path.join(location, "types.md"), dest);
+  }
+})();

--- a/scripts/generate-docs-types.js
+++ b/scripts/generate-docs-types.js
@@ -1,0 +1,279 @@
+const fs = require("fs");
+const path = require("path");
+const t = require("@babel/types");
+const { promisify } = require("util");
+
+const readfile = promisify(fs.readFile);
+const writefile = promisify(fs.writeFile);
+
+const callRegex = /(\w+)(\??:)\s(.+)/;
+const signatureRegex = /\((.*)\):\s(\w+)/i;
+const typeRegex = /:\s(\w+);$/i;
+
+// const signature = (type, args, returnType) => {
+const signature = (type, args) => {
+  const required = args
+    .map(line => {
+      const match = line.match(callRegex);
+      if (!match || match[2] === "?:") {
+        return;
+      }
+      return match[1].slice(0, 1) === "_" ? match[1].slice(1) : match[1];
+    })
+    .filter(s => Boolean(s))
+    .join(", ");
+  return [
+    "```javascript",
+    `t.${type}(${required})`,
+    // `t.${type}(${required}): ${returnType || "unknown"}`,
+    "```",
+    "",
+  ];
+};
+
+const removeNullUndefined = type => {
+  if (type.includes("null") || type.includes("undefined")) {
+    const types = type.split(" | ");
+    return types.filter(a => a !== "null" && a !== "undefined").join(" | ");
+  }
+  return type;
+};
+
+const typeOverwrites = {
+  classMethod: {
+    key: "if computed then `Expression` else `Identifier | Literal`",
+  },
+  memberExpression: {
+    property: "if computed then `Expression` else `Identifier`",
+  },
+  objectMethod: {
+    key: "if computed then `Expression` else `Identifier | Literal`",
+  },
+  objectProperty: {
+    key: "if computed then `Expression` else `Identifier | Literal`",
+  },
+};
+
+const requirementOverwrites = {
+  classMethod: {
+    kind: "default: `method`",
+  },
+  program: {
+    sourceType: "default: `'script'`",
+  },
+  regExpLiteral: {
+    flags: 'default: `""`',
+  },
+  tsDeclareMethod: {
+    kind: "default: `'method'`",
+  },
+};
+
+const getRequirement = (required, id, type, types) => {
+  if (
+    requirementOverwrites.hasOwnProperty(type) &&
+    requirementOverwrites[type].hasOwnProperty(id)
+  ) {
+    return requirementOverwrites[type][id];
+  }
+
+  if (required) {
+    return "required";
+  }
+
+  if (types.slice(0, "`Array<".length) === "`Array<") {
+    return "default: `[]`";
+  }
+
+  switch (types) {
+    case "`boolean`":
+      return "default: `false`";
+
+    case "`string`":
+      return 'default: `""`';
+
+    default:
+      return "default: `null`";
+  }
+};
+
+const typeToDoc = type => line => {
+  const match = line.match(callRegex);
+  const id = match[1].slice(0, 1) === "_" ? match[1].slice(1) : match[1];
+  const required = match[2] === ":";
+  const types =
+    typeOverwrites.hasOwnProperty(type) &&
+    typeOverwrites[type].hasOwnProperty(id)
+      ? typeOverwrites[type][id]
+      : "`" + removeNullUndefined(match[3]) + "`";
+  return ` - \`${id}\`: ${types} (${getRequirement(
+    required,
+    id,
+    type,
+    types
+  )})`;
+};
+
+const seeAlso = type => {
+  const see = { assert: "", is: "" };
+  const is = String(`is${type}`).toLowerCase();
+  const assert = String(`assert${type}`).toLocaleLowerCase();
+  for (const type in t) {
+    if (type.toLowerCase() === assert) {
+      see.assert = type;
+    }
+    if (type.toLowerCase() === is) {
+      see.is = type;
+    }
+  }
+  return `See also \`t.${see.is}(node, opts)\` and \`t.${
+    see.assert
+  }(node, opts)\`.`;
+};
+
+const findAliases = typeDefLines => {
+  const aliasBlock = [];
+  let collect = false;
+  for (const line of typeDefLines) {
+    if (line === "export interface Aliases {") {
+      collect = true;
+    } else if (collect && line === "}") {
+      collect = false;
+    } else if (collect) {
+      const parts = line.split(":");
+      aliasBlock.push(parts[0].trim());
+    }
+  }
+  const aliases = {};
+  aliasBlock.forEach(alias => {
+    const types = typeDefLines.filter(l =>
+      new RegExp(`^export type ${alias} = `).test(l)
+    );
+    const names = types[0]
+      .slice(`export type ${alias} = `.length)
+      .split(" | ")
+      .map(s => (s.slice(-1) === ";" ? s.slice(0, -1) : s));
+    for (const name of names) {
+      if (aliases.hasOwnProperty(name)) {
+        aliases[name].push(alias);
+      } else {
+        aliases[name] = [alias];
+      }
+    }
+  });
+  for (const key in aliases) {
+    aliases[key].sort((a, b) => a.localeCompare(b));
+  }
+  return aliases;
+};
+
+const getArgumentsAndReturnType = def => {
+  const match = def.match(signatureRegex);
+  if (match && match[1] && match[2]) {
+    return [match[1].split(",").map(s => String(s).trim()), match[2]];
+  } else if (def.includes("()")) {
+    const r = def.match(typeRegex);
+    if (r && r[1]) {
+      return [[], r[1]];
+    }
+  }
+  return [[], "unknown"];
+};
+
+(async () => {
+  const typeDefs = await readfile(
+    path.resolve(
+      __dirname,
+      "node_modules",
+      "@babel",
+      "types",
+      "lib",
+      "index.d.ts"
+    ),
+    "utf-8"
+  );
+  const typeDefLines = typeDefs.split("\n");
+  const aliases = findAliases(typeDefLines);
+  const sections = [];
+
+  for (const type in t) {
+    const isBuilder = /_builder\.default/.test(t[type].toString());
+    if (!isBuilder) {
+      continue;
+    }
+
+    const findFunction = typeDefLines.filter(l =>
+      new RegExp(`^export function ${type}\\(`).test(l)
+    );
+
+    if (findFunction.length === 0) {
+      continue;
+    }
+
+    const section = {
+      aliases: ["Aliases: none", ""],
+      args: [],
+      header: [`### ${type}`], // [`### ${type}`, ""],
+      returnType: "unknown",
+      seeAlso: [seeAlso(type), ""],
+      signature: [],
+      type,
+    };
+
+    const [args, returnType] = getArgumentsAndReturnType(findFunction[0]);
+    section.args = args.length ? args.map(typeToDoc(type)).concat([""]) : [];
+    section.signature = signature(type, args, returnType);
+    section.returnType = returnType;
+    if (aliases.hasOwnProperty(section.returnType)) {
+      section.aliases = [
+        `Aliases: \`${aliases[section.returnType].join("`, `")}\``,
+        "",
+      ];
+    }
+    sections.push(section);
+    seeAlso(type);
+  }
+
+  const argv = Array.from(process.argv).slice(2);
+  const overWriteId = argv
+    .filter(arg => /^--babel-types-id=/.test(arg))
+    .map(arg => arg.split("=")[1])[0];
+
+  const content = [
+    "---",
+    `id: ${overWriteId ? overWriteId : "babel-types"}`,
+    "title: @babel/types",
+    "sidebar_label: types",
+  ]
+    .concat(overWriteId ? ["original_id: babel-types"] : [])
+    .concat([
+      "---",
+      "",
+      "## Install",
+      "",
+      "```sh",
+      "npm install --save-dev @babel/types",
+      "```",
+      "",
+      "## API",
+      "",
+    ])
+    .concat(
+      sections
+        .sort((a, b) => a.type.localeCompare(b.type))
+        .reduce(
+          (acc, cur) =>
+            acc.concat(
+              cur.header
+                .concat(cur.signature)
+                .concat(cur.seeAlso)
+                .concat(cur.aliases)
+                .concat(cur.args)
+                .concat(["---", ""])
+            ),
+          []
+        )
+    );
+
+  await writefile(path.resolve(__dirname, "types.md"), content.join("\n"));
+})();

--- a/website/versioned_docs/version-7.0.0/types.md
+++ b/website/versioned_docs/version-7.0.0/types.md
@@ -12,6 +12,7 @@ npm install --save-dev @babel/types
 ```
 
 ## API
+
 ### anyTypeAnnotation
 ```javascript
 t.anyTypeAnnotation()
@@ -19,14 +20,24 @@ t.anyTypeAnnotation()
 
 See also `t.isAnyTypeAnnotation(node, opts)` and `t.assertAnyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
+---
+
+### argumentPlaceholder
+```javascript
+t.argumentPlaceholder()
+```
+
+See also `t.isArgumentPlaceholder(node, opts)` and `t.assertArgumentPlaceholder(node, opts)`.
+
+Aliases: none
 
 ---
 
 ### arrayExpression
 ```javascript
-t.arrayExpression(elements)
+t.arrayExpression()
 ```
 
 See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, opts)`.
@@ -44,10 +55,10 @@ t.arrayPattern(elements)
 
 See also `t.isArrayPattern(node, opts)` and `t.assertArrayPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `elements`: `Array<PatternLike>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -67,17 +78,17 @@ Aliases: `Flow`, `FlowType`
 
 ### arrowFunctionExpression
 ```javascript
-t.arrowFunctionExpression(params, body, async)
+t.arrowFunctionExpression(params, body)
 ```
 
 See also `t.isArrowFunctionExpression(node, opts)` and `t.assertArrowFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement | Expression` (required)
  - `async`: `boolean` (default: `false`)
- - `expression`: `boolean` (default: `null`)
+ - `expression`: `boolean` (default: `false`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -106,11 +117,11 @@ t.assignmentPattern(left, right)
 
 See also `t.isAssignmentPattern(node, opts)` and `t.assertAssignmentPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
- - `left`: `Identifier | ObjectPattern | ArrayPattern` (required)
+ - `left`: `Identifier | ObjectPattern | ArrayPattern | MemberExpression` (required)
  - `right`: `Expression` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -135,7 +146,7 @@ t.bigIntLiteral(value)
 
 See also `t.isBigIntLiteral(node, opts)` and `t.assertBigIntLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -165,19 +176,19 @@ See also `t.isBindExpression(node, opts)` and `t.assertBindExpression(node, opts
 
 Aliases: `Expression`
 
- - `object` (required)
- - `callee` (required)
+ - `object`: `any` (required)
+ - `callee`: `any` (required)
 
 ---
 
 ### blockStatement
 ```javascript
-t.blockStatement(body, directives)
+t.blockStatement(body)
 ```
 
 See also `t.isBlockStatement(node, opts)` and `t.assertBlockStatement(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`, `Statement`
+Aliases: `Block`, `BlockParent`, `Scopable`, `Statement`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
@@ -191,7 +202,7 @@ t.booleanLiteral(value)
 
 See also `t.isBooleanLiteral(node, opts)` and `t.assertBooleanLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `boolean` (required)
 
@@ -217,19 +228,18 @@ t.booleanTypeAnnotation()
 
 See also `t.isBooleanTypeAnnotation(node, opts)` and `t.assertBooleanTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
 ### breakStatement
 ```javascript
-t.breakStatement(label)
+t.breakStatement()
 ```
 
 See also `t.isBreakStatement(node, opts)` and `t.assertBreakStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -245,7 +255,7 @@ See also `t.isCallExpression(node, opts)` and `t.assertCallExpression(node, opts
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -259,9 +269,9 @@ t.catchClause(param, body)
 
 See also `t.isCatchClause(node, opts)` and `t.assertCatchClause(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`
+Aliases: `BlockParent`, `Scopable`
 
- - `param`: `Identifier` (default: `null`)
+ - `param`: `Identifier` (required)
  - `body`: `BlockStatement` (required)
 
 ---
@@ -273,27 +283,29 @@ t.classBody(body)
 
 See also `t.isClassBody(node, opts)` and `t.assertClassBody(node, opts)`.
 
- - `body`: `Array<ClassMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
+Aliases: none
+
+ - `body`: `Array<ClassMethod | ClassPrivateMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
 
 ---
 
 ### classDeclaration
 ```javascript
-t.classDeclaration(id, superClass, body, decorators)
+t.classDeclaration(id, superClass, body)
 ```
 
 See also `t.isClassDeclaration(node, opts)` and `t.assertClassDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
+Aliases: `Class`, `Declaration`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `abstract`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -301,19 +313,19 @@ Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
 
 ### classExpression
 ```javascript
-t.classExpression(id, superClass, body, decorators)
+t.classExpression(id, superClass, body)
 ```
 
 See also `t.isClassExpression(node, opts)` and `t.assertClassExpression(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
+Aliases: `Class`, `Expression`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -321,7 +333,7 @@ Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
 
 ### classImplements
 ```javascript
-t.classImplements(id, typeParameters)
+t.classImplements(id)
 ```
 
 See also `t.isClassImplements(node, opts)` and `t.assertClassImplements(node, opts)`.
@@ -335,39 +347,66 @@ Aliases: `Flow`
 
 ### classMethod
 ```javascript
-t.classMethod(kind, key, params, body, computed, static)
+t.classMethod(kind, key, params, body)
 ```
 
 See also `t.isClassMethod(node, opts)` and `t.assertClassMethod(node, opts)`.
 
-Aliases: `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Scopable`
 
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `method`)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
- - `static`: `boolean` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
  - `access`: `"public" | "private" | "protected"` (default: `null`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
+### classPrivateMethod
+```javascript
+t.classPrivateMethod(kind, key, params, body)
+```
+
+See also `t.isClassPrivateMethod(node, opts)` and `t.assertClassPrivateMethod(node, opts)`.
+
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Private`, `Scopable`
+
+ - `kind`: `"get" | "set" | "method" | "constructor"` (required)
+ - `key`: `PrivateName` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `body`: `BlockStatement` (required)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `generator`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `returnType`: `any` (default: `null`)
+ - `typeParameters`: `any` (default: `null`)
+
+---
+
 ### classPrivateProperty
 ```javascript
-t.classPrivateProperty(key, value)
+t.classPrivateProperty(key)
 ```
 
 See also `t.isClassPrivateProperty(node, opts)` and `t.assertClassPrivateProperty(node, opts)`.
 
-Aliases: `Property`, `Private`
+Aliases: `Private`, `Property`
 
  - `key`: `PrivateName` (required)
  - `value`: `Expression` (default: `null`)
@@ -376,7 +415,7 @@ Aliases: `Property`, `Private`
 
 ### classProperty
 ```javascript
-t.classProperty(key, value, typeAnnotation, decorators, computed)
+t.classProperty(key)
 ```
 
 See also `t.isClassProperty(node, opts)` and `t.assertClassProperty(node, opts)`.
@@ -386,14 +425,14 @@ Aliases: `Property`
  - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
  - `value`: `Expression` (default: `null`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `computed`: `boolean` (default: `false`)
- - `abstract`: `boolean` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `definite`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -404,7 +443,7 @@ t.conditionalExpression(test, consequent, alternate)
 
 See also `t.isConditionalExpression(node, opts)` and `t.assertConditionalExpression(node, opts)`.
 
-Aliases: `Expression`, `Conditional`
+Aliases: `Conditional`, `Expression`
 
  - `test`: `Expression` (required)
  - `consequent`: `Expression` (required)
@@ -414,12 +453,12 @@ Aliases: `Expression`, `Conditional`
 
 ### continueStatement
 ```javascript
-t.continueStatement(label)
+t.continueStatement()
 ```
 
 See also `t.isContinueStatement(node, opts)` and `t.assertContinueStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -434,7 +473,6 @@ See also `t.isDebuggerStatement(node, opts)` and `t.assertDebuggerStatement(node
 
 Aliases: `Statement`
 
-
 ---
 
 ### declareClass
@@ -444,147 +482,14 @@ t.declareClass(id, typeParameters, extends, body)
 
 See also `t.isDeclareClass(node, opts)` and `t.assertDeclareClass(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareExportAllDeclaration
-```javascript
-t.declareExportAllDeclaration(source)
-```
-
-See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `source`: `StringLiteral` (required)
- - `exportKind`: `["type","value"]` (default: `null`)
-
----
-
-### declareExportDeclaration
-```javascript
-t.declareExportDeclaration(declaration, specifiers, source)
-```
-
-See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `declaration`: `Flow` (default: `null`)
- - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `null`)
- - `source`: `StringLiteral` (default: `null`)
- - `default`: `boolean` (default: `null`)
-
----
-
-### declareFunction
-```javascript
-t.declareFunction(id)
-```
-
-See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `predicate`: `DeclaredPredicate` (default: `null`)
-
----
-
-### declareInterface
-```javascript
-t.declareInterface(id, typeParameters, extends, body)
-```
-
-See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareModule
-```javascript
-t.declareModule(id, body, kind)
-```
-
-See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `BlockStatement` (required)
- - `kind`: `"CommonJS" | "ES"` (default: `null`)
-
----
-
-### declareModuleExports
-```javascript
-t.declareModuleExports(typeAnnotation)
-```
-
-See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `typeAnnotation`: `TypeAnnotation` (required)
-
----
-
-### declareOpaqueType
-```javascript
-t.declareOpaqueType(id, typeParameters, supertype)
-```
-
-See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
-
----
-
-### declareTypeAlias
-```javascript
-t.declareTypeAlias(id, typeParameters, right)
-```
-
-See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `FlowType` (required)
-
----
-
-### declareVariable
-```javascript
-t.declareVariable(id)
-```
-
-See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
@@ -601,12 +506,147 @@ Aliases: `Flow`, `FlowPredicate`
 
 ---
 
+### declareExportAllDeclaration
+```javascript
+t.declareExportAllDeclaration(source)
+```
+
+See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `source`: `StringLiteral` (required)
+ - `exportKind`: `"type" | "value"` (default: `null`)
+
+---
+
+### declareExportDeclaration
+```javascript
+t.declareExportDeclaration()
+```
+
+See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `declaration`: `Flow` (default: `null`)
+ - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `[]`)
+ - `source`: `StringLiteral` (default: `null`)
+ - `default`: `boolean` (default: `false`)
+
+---
+
+### declareFunction
+```javascript
+t.declareFunction(id)
+```
+
+See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `predicate`: `DeclaredPredicate` (default: `null`)
+
+---
+
+### declareInterface
+```javascript
+t.declareInterface(id, typeParameters, extends, body)
+```
+
+See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
+ - `body`: `ObjectTypeAnnotation` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
+
+---
+
+### declareModule
+```javascript
+t.declareModule(id, body)
+```
+
+See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `BlockStatement` (required)
+ - `kind`: `"CommonJS" | "ES"` (default: `null`)
+
+---
+
+### declareModuleExports
+```javascript
+t.declareModuleExports(typeAnnotation)
+```
+
+See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `typeAnnotation`: `TypeAnnotation` (required)
+
+---
+
+### declareOpaqueType
+```javascript
+t.declareOpaqueType(id)
+```
+
+See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `supertype`: `FlowType` (default: `null`)
+
+---
+
+### declareTypeAlias
+```javascript
+t.declareTypeAlias(id, typeParameters, right)
+```
+
+See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `right`: `FlowType` (required)
+
+---
+
+### declareVariable
+```javascript
+t.declareVariable(id)
+```
+
+See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
 ### decorator
 ```javascript
 t.decorator(expression)
 ```
 
 See also `t.isDecorator(node, opts)` and `t.assertDecorator(node, opts)`.
+
+Aliases: none
 
  - `expression`: `Expression` (required)
 
@@ -619,6 +659,8 @@ t.directive(value)
 
 See also `t.isDirective(node, opts)` and `t.assertDirective(node, opts)`.
 
+Aliases: none
+
  - `value`: `DirectiveLiteral` (required)
 
 ---
@@ -629,6 +671,8 @@ t.directiveLiteral(value)
 ```
 
 See also `t.isDirectiveLiteral(node, opts)` and `t.assertDirectiveLiteral(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -654,7 +698,7 @@ t.doWhileStatement(test, body)
 
 See also `t.isDoWhileStatement(node, opts)` and `t.assertDoWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `Statement` (required)
@@ -670,7 +714,6 @@ See also `t.isEmptyStatement(node, opts)` and `t.assertEmptyStatement(node, opts
 
 Aliases: `Statement`
 
-
 ---
 
 ### emptyTypeAnnotation
@@ -680,8 +723,7 @@ t.emptyTypeAnnotation()
 
 See also `t.isEmptyTypeAnnotation(node, opts)` and `t.assertEmptyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -694,7 +736,6 @@ See also `t.isExistsTypeAnnotation(node, opts)` and `t.assertExistsTypeAnnotatio
 
 Aliases: `Flow`, `FlowType`
 
-
 ---
 
 ### exportAllDeclaration
@@ -704,7 +745,7 @@ t.exportAllDeclaration(source)
 
 See also `t.isExportAllDeclaration(node, opts)` and `t.assertExportAllDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `source`: `StringLiteral` (required)
 
@@ -717,7 +758,7 @@ t.exportDefaultDeclaration(declaration)
 
 See also `t.isExportDefaultDeclaration(node, opts)` and `t.assertExportDefaultDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `declaration`: `FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression` (required)
 
@@ -738,16 +779,17 @@ Aliases: `ModuleSpecifier`
 
 ### exportNamedDeclaration
 ```javascript
-t.exportNamedDeclaration(declaration, specifiers, source)
+t.exportNamedDeclaration(declaration, specifiers)
 ```
 
 See also `t.isExportNamedDeclaration(node, opts)` and `t.assertExportNamedDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
- - `declaration`: `Declaration` (default: `null`)
+ - `declaration`: `Declaration` (required)
  - `specifiers`: `Array<ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (default: `null`)
+ - `exportKind`: `"type" | "value"` (default: `null`)
 
 ---
 
@@ -785,7 +827,7 @@ t.expressionStatement(expression)
 
 See also `t.isExpressionStatement(node, opts)` and `t.assertExpressionStatement(node, opts)`.
 
-Aliases: `Statement`, `ExpressionWrapper`
+Aliases: `ExpressionWrapper`, `Statement`
 
  - `expression`: `Expression` (required)
 
@@ -798,9 +840,11 @@ t.file(program, comments, tokens)
 
 See also `t.isFile(node, opts)` and `t.assertFile(node, opts)`.
 
+Aliases: none
+
  - `program`: `Program` (required)
- - `comments` (required)
- - `tokens` (required)
+ - `comments`: `any` (required)
+ - `tokens`: `any` (required)
 
 ---
 
@@ -811,7 +855,7 @@ t.forInStatement(left, right, body)
 
 See also `t.isForInStatement(node, opts)` and `t.assertForInStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -826,7 +870,7 @@ t.forOfStatement(left, right, body)
 
 See also `t.isForOfStatement(node, opts)` and `t.assertForOfStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -842,30 +886,30 @@ t.forStatement(init, test, update, body)
 
 See also `t.isForStatement(node, opts)` and `t.assertForStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`
+Aliases: `BlockParent`, `For`, `Loop`, `Scopable`, `Statement`
 
- - `init`: `VariableDeclaration | Expression` (default: `null`)
- - `test`: `Expression` (default: `null`)
- - `update`: `Expression` (default: `null`)
+ - `init`: `VariableDeclaration | Expression` (required)
+ - `test`: `Expression` (required)
+ - `update`: `Expression` (required)
  - `body`: `Statement` (required)
 
 ---
 
 ### functionDeclaration
 ```javascript
-t.functionDeclaration(id, params, body, generator, async)
+t.functionDeclaration(id, params, body)
 ```
 
 See also `t.isFunctionDeclaration(node, opts)` and `t.assertFunctionDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `Pureish`, `Declaration`
+Aliases: `BlockParent`, `Declaration`, `Function`, `FunctionParent`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -873,15 +917,15 @@ Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `
 
 ### functionExpression
 ```javascript
-t.functionExpression(id, params, body, generator, async)
+t.functionExpression(id, params, body)
 ```
 
 See also `t.isFunctionExpression(node, opts)` and `t.assertFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
@@ -899,9 +943,9 @@ See also `t.isFunctionTypeAnnotation(node, opts)` and `t.assertFunctionTypeAnnot
 
 Aliases: `Flow`, `FlowType`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `params`: `Array<FunctionTypeParam>` (required)
- - `rest`: `FunctionTypeParam` (default: `null`)
+ - `rest`: `FunctionTypeParam` (required)
  - `returnType`: `FlowType` (required)
 
 ---
@@ -915,22 +959,22 @@ See also `t.isFunctionTypeParam(node, opts)` and `t.assertFunctionTypeParam(node
 
 Aliases: `Flow`
 
- - `name`: `Identifier` (default: `null`)
+ - `name`: `Identifier` (required)
  - `typeAnnotation`: `FlowType` (required)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
 
 ---
 
 ### genericTypeAnnotation
 ```javascript
-t.genericTypeAnnotation(id, typeParameters)
+t.genericTypeAnnotation(id)
 ```
 
 See also `t.isGenericTypeAnnotation(node, opts)` and `t.assertGenericTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -942,39 +986,27 @@ t.identifier(name)
 
 See also `t.isIdentifier(node, opts)` and `t.assertIdentifier(node, opts)`.
 
-Aliases: `Expression`, `PatternLike`, `LVal`, `TSEntityName`
+Aliases: `Expression`, `LVal`, `PatternLike`, `TSEntityName`
 
  - `name`: `string` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `optional`: `boolean` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `optional`: `boolean` (default: `false`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### ifStatement
 ```javascript
-t.ifStatement(test, consequent, alternate)
+t.ifStatement(test, consequent)
 ```
 
 See also `t.isIfStatement(node, opts)` and `t.assertIfStatement(node, opts)`.
 
-Aliases: `Statement`, `Conditional`
+Aliases: `Conditional`, `Statement`
 
  - `test`: `Expression` (required)
  - `consequent`: `Statement` (required)
  - `alternate`: `Statement` (default: `null`)
-
----
-
-### import
-```javascript
-t.import()
-```
-
-See also `t.isImport(node, opts)` and `t.assertImport(node, opts)`.
-
-Aliases: `Expression`
-
 
 ---
 
@@ -985,10 +1017,11 @@ t.importDeclaration(specifiers, source)
 
 See also `t.isImportDeclaration(node, opts)` and `t.assertImportDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`
+Aliases: `Declaration`, `ModuleDeclaration`, `Statement`
 
  - `specifiers`: `Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (required)
+ - `importKind`: `"type" | "typeof" | "value"` (default: `null`)
 
 ---
 
@@ -1029,7 +1062,7 @@ Aliases: `ModuleSpecifier`
 
  - `local`: `Identifier` (required)
  - `imported`: `Identifier` (required)
- - `importKind`: `null | "type" | "typeof"` (default: `null`)
+ - `importKind`: `"type" | "typeof"` (default: `null`)
 
 ---
 
@@ -1042,7 +1075,6 @@ See also `t.isInferredPredicate(node, opts)` and `t.assertInferredPredicate(node
 
 Aliases: `Flow`, `FlowPredicate`
 
-
 ---
 
 ### interfaceDeclaration
@@ -1052,27 +1084,27 @@ t.interfaceDeclaration(id, typeParameters, extends, body)
 
 See also `t.isInterfaceDeclaration(node, opts)` and `t.assertInterfaceDeclaration(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
 ### interfaceExtends
 ```javascript
-t.interfaceExtends(id, typeParameters)
+t.interfaceExtends(id)
 ```
 
 See also `t.isInterfaceExtends(node, opts)` and `t.assertInterfaceExtends(node, opts)`.
 
 Aliases: `Flow`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -1086,7 +1118,7 @@ See also `t.isInterfaceTypeAnnotation(node, opts)` and `t.assertInterfaceTypeAnn
 
 Aliases: `Flow`, `FlowType`
 
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
 
 ---
@@ -1097,6 +1129,8 @@ t.interpreterDirective(value)
 ```
 
 See also `t.isInterpreterDirective(node, opts)` and `t.assertInterpreterDirective(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -1115,62 +1149,61 @@ Aliases: `Flow`, `FlowType`
 
 ---
 
-### jSXAttribute
+### jsxAttribute
 ```javascript
-t.jsxAttribute(name, value)
+t.jsxAttribute(name)
 ```
 
 See also `t.isJSXAttribute(node, opts)` and `t.assertJSXAttribute(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXNamespacedName` (required)
  - `value`: `JSXElement | JSXFragment | StringLiteral | JSXExpressionContainer` (default: `null`)
 
 ---
 
-### jSXClosingElement
+### jsxClosingElement
 ```javascript
 t.jsxClosingElement(name)
 ```
 
 See also `t.isJSXClosingElement(node, opts)` and `t.assertJSXClosingElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
 
 ---
 
-### jSXClosingFragment
+### jsxClosingFragment
 ```javascript
 t.jsxClosingFragment()
 ```
 
 See also `t.isJSXClosingFragment(node, opts)` and `t.assertJSXClosingFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXElement
+### jsxElement
 ```javascript
 t.jsxElement(openingElement, closingElement, children, selfClosing)
 ```
 
 See also `t.isJSXElement(node, opts)` and `t.assertJSXElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingElement`: `JSXOpeningElement` (required)
- - `closingElement`: `JSXClosingElement` (default: `null`)
+ - `closingElement`: `JSXClosingElement` (required)
  - `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
- - `selfClosing` (required)
+ - `selfClosing`: `any` (required)
 
 ---
 
-### jSXEmptyExpression
+### jsxEmptyExpression
 ```javascript
 t.jsxEmptyExpression()
 ```
@@ -1179,30 +1212,29 @@ See also `t.isJSXEmptyExpression(node, opts)` and `t.assertJSXEmptyExpression(no
 
 Aliases: `JSX`
 
-
 ---
 
-### jSXExpressionContainer
+### jsxExpressionContainer
 ```javascript
 t.jsxExpressionContainer(expression)
 ```
 
 See also `t.isJSXExpressionContainer(node, opts)` and `t.assertJSXExpressionContainer(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
- - `expression`: `Expression` (required)
+ - `expression`: `Expression | JSXEmptyExpression` (required)
 
 ---
 
-### jSXFragment
+### jsxFragment
 ```javascript
 t.jsxFragment(openingFragment, closingFragment, children)
 ```
 
 See also `t.isJSXFragment(node, opts)` and `t.assertJSXFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingFragment`: `JSXOpeningFragment` (required)
  - `closingFragment`: `JSXClosingFragment` (required)
@@ -1210,7 +1242,7 @@ Aliases: `JSX`, `Immutable`, `Expression`
 
 ---
 
-### jSXIdentifier
+### jsxIdentifier
 ```javascript
 t.jsxIdentifier(name)
 ```
@@ -1223,7 +1255,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXMemberExpression
+### jsxMemberExpression
 ```javascript
 t.jsxMemberExpression(object, property)
 ```
@@ -1237,7 +1269,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXNamespacedName
+### jsxNamespacedName
 ```javascript
 t.jsxNamespacedName(namespace, name)
 ```
@@ -1251,34 +1283,34 @@ Aliases: `JSX`
 
 ---
 
-### jSXOpeningElement
+### jsxOpeningElement
 ```javascript
-t.jsxOpeningElement(name, attributes, selfClosing)
+t.jsxOpeningElement(name, attributes)
 ```
 
 See also `t.isJSXOpeningElement(node, opts)` and `t.assertJSXOpeningElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
  - `attributes`: `Array<JSXAttribute | JSXSpreadAttribute>` (required)
  - `selfClosing`: `boolean` (default: `false`)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
-### jSXOpeningFragment
+### jsxOpeningFragment
 ```javascript
 t.jsxOpeningFragment()
 ```
 
 See also `t.isJSXOpeningFragment(node, opts)` and `t.assertJSXOpeningFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXSpreadAttribute
+### jsxSpreadAttribute
 ```javascript
 t.jsxSpreadAttribute(argument)
 ```
@@ -1291,27 +1323,27 @@ Aliases: `JSX`
 
 ---
 
-### jSXSpreadChild
+### jsxSpreadChild
 ```javascript
 t.jsxSpreadChild(expression)
 ```
 
 See also `t.isJSXSpreadChild(node, opts)` and `t.assertJSXSpreadChild(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `expression`: `Expression` (required)
 
 ---
 
-### jSXText
+### jsxText
 ```javascript
 t.jsxText(value)
 ```
 
 See also `t.isJSXText(node, opts)` and `t.assertJSXText(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `value`: `string` (required)
 
@@ -1348,7 +1380,7 @@ Aliases: `Binary`, `Expression`
 
 ### memberExpression
 ```javascript
-t.memberExpression(object, property, computed, optional)
+t.memberExpression(object, property)
 ```
 
 See also `t.isMemberExpression(node, opts)` and `t.assertMemberExpression(node, opts)`.
@@ -1383,8 +1415,7 @@ t.mixedTypeAnnotation()
 
 See also `t.isMixedTypeAnnotation(node, opts)` and `t.assertMixedTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1398,7 +1429,7 @@ See also `t.isNewExpression(node, opts)` and `t.assertNewExpression(node, opts)`
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -1412,30 +1443,7 @@ t.noop()
 
 See also `t.isNoop(node, opts)` and `t.assertNoop(node, opts)`.
 
-
----
-
-### nullLiteral
-```javascript
-t.nullLiteral()
-```
-
-See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
-
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
-
-
----
-
-### nullLiteralTypeAnnotation
-```javascript
-t.nullLiteralTypeAnnotation()
-```
-
-See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: none
 
 ---
 
@@ -1449,6 +1457,28 @@ See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnot
 Aliases: `Flow`, `FlowType`
 
  - `typeAnnotation`: `FlowType` (required)
+
+---
+
+### nullLiteral
+```javascript
+t.nullLiteral()
+```
+
+See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
+
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
+
+---
+
+### nullLiteralTypeAnnotation
+```javascript
+t.nullLiteralTypeAnnotation()
+```
+
+See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1472,8 +1502,7 @@ t.numberTypeAnnotation()
 
 See also `t.isNumberTypeAnnotation(node, opts)` and `t.assertNumberTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1484,7 +1513,7 @@ t.numericLiteral(value)
 
 See also `t.isNumericLiteral(node, opts)` and `t.assertNumericLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `number` (required)
 
@@ -1505,20 +1534,20 @@ Aliases: `Expression`
 
 ### objectMethod
 ```javascript
-t.objectMethod(kind, key, params, body, computed)
+t.objectMethod(kind, key, params, body)
 ```
 
 See also `t.isObjectMethod(node, opts)` and `t.assertObjectMethod(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`, `ObjectMember`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `ObjectMember`, `Scopable`, `UserWhitespacable`
 
- - `kind`: `"method" | "get" | "set"` (default: `'method'`)
+ - `kind`: `"method" | "get" | "set"` (required)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -1532,34 +1561,34 @@ t.objectPattern(properties)
 
 See also `t.isObjectPattern(node, opts)` and `t.assertObjectPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `properties`: `Array<RestElement | ObjectProperty>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### objectProperty
 ```javascript
-t.objectProperty(key, value, computed, shorthand, decorators)
+t.objectProperty(key, value)
 ```
 
 See also `t.isObjectProperty(node, opts)` and `t.assertObjectProperty(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Property`, `ObjectMember`
+Aliases: `ObjectMember`, `Property`, `UserWhitespacable`
 
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
  - `value`: `Expression | PatternLike` (required)
  - `computed`: `boolean` (default: `false`)
  - `shorthand`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
 
 ---
 
 ### objectTypeAnnotation
 ```javascript
-t.objectTypeAnnotation(properties, indexers, callProperties, internalSlots, exact)
+t.objectTypeAnnotation(properties)
 ```
 
 See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotation(node, opts)`.
@@ -1567,10 +1596,11 @@ See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotatio
 Aliases: `Flow`, `FlowType`
 
  - `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
- - `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
- - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `null`)
- - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `null`)
+ - `indexers`: `Array<ObjectTypeIndexer>` (default: `[]`)
+ - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `[]`)
+ - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `[]`)
  - `exact`: `boolean` (default: `false`)
+ - `inexact`: `boolean` (default: `false`)
 
 ---
 
@@ -1584,24 +1614,24 @@ See also `t.isObjectTypeCallProperty(node, opts)` and `t.assertObjectTypeCallPro
 Aliases: `Flow`, `UserWhitespacable`
 
  - `value`: `FlowType` (required)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
 ### objectTypeIndexer
 ```javascript
-t.objectTypeIndexer(id, key, value, variance)
+t.objectTypeIndexer(id, key, value)
 ```
 
 See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `id`: `Identifier` (default: `null`)
+ - `id`: `Identifier` (required)
  - `key`: `FlowType` (required)
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1624,7 +1654,7 @@ Aliases: `Flow`, `UserWhitespacable`
 
 ### objectTypeProperty
 ```javascript
-t.objectTypeProperty(key, value, variance)
+t.objectTypeProperty(key, value)
 ```
 
 See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(node, opts)`.
@@ -1635,9 +1665,9 @@ Aliases: `Flow`, `UserWhitespacable`
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
  - `kind`: `"init" | "get" | "set"` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `proto`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `proto`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1661,11 +1691,11 @@ t.opaqueType(id, typeParameters, supertype, impltype)
 
 See also `t.isOpaqueType(node, opts)` and `t.assertOpaqueType(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `supertype`: `FlowType` (required)
  - `impltype`: `FlowType` (required)
 
 ---
@@ -1698,7 +1728,7 @@ Aliases: `Expression`
 
  - `object`: `Expression` (required)
  - `property`: `any` (required)
- - `computed`: `boolean` (default: `false`)
+ - `computed`: `boolean` (required)
  - `optional`: `boolean` (required)
 
 ---
@@ -1713,6 +1743,57 @@ See also `t.isParenthesizedExpression(node, opts)` and `t.assertParenthesizedExp
 Aliases: `Expression`, `ExpressionWrapper`
 
  - `expression`: `Expression` (required)
+
+---
+
+### pipelineBareFunction
+```javascript
+t.pipelineBareFunction(callee)
+```
+
+See also `t.isPipelineBareFunction(node, opts)` and `t.assertPipelineBareFunction(node, opts)`.
+
+Aliases: none
+
+ - `callee`: `Expression` (required)
+
+---
+
+### pipelinePrimaryTopicReference
+```javascript
+t.pipelinePrimaryTopicReference()
+```
+
+See also `t.isPipelinePrimaryTopicReference(node, opts)` and `t.assertPipelinePrimaryTopicReference(node, opts)`.
+
+Aliases: `Expression`
+
+---
+
+### pipelineTopicExpression
+```javascript
+t.pipelineTopicExpression(expression)
+```
+
+See also `t.isPipelineTopicExpression(node, opts)` and `t.assertPipelineTopicExpression(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `Expression` (required)
+
+---
+
+### placeholder
+```javascript
+t.placeholder(expectedNode, name)
+```
+
+See also `t.isPlaceholder(node, opts)` and `t.assertPlaceholder(node, opts)`.
+
+Aliases: none
+
+ - `expectedNode`: `"Identifier" | "StringLiteral" | "Expression" | "Statement" | "Declaration" | "BlockStatement" | "ClassBody" | "Pattern"` (required)
+ - `name`: `Identifier` (required)
 
 ---
 
@@ -1731,18 +1812,18 @@ Aliases: `Private`
 
 ### program
 ```javascript
-t.program(body, directives, sourceType, interpreter)
+t.program(body)
 ```
 
 See also `t.isProgram(node, opts)` and `t.assertProgram(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`
+Aliases: `Block`, `BlockParent`, `Scopable`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
  - `sourceType`: `"script" | "module"` (default: `'script'`)
  - `interpreter`: `InterpreterDirective` (default: `null`)
- - `sourceFile`: `string` (default: `null`)
+ - `sourceFile`: `string` (default: `""`)
 
 ---
 
@@ -1762,7 +1843,7 @@ Aliases: `Flow`
 
 ### regExpLiteral
 ```javascript
-t.regExpLiteral(pattern, flags)
+t.regExpLiteral(pattern)
 ```
 
 See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`.
@@ -1770,7 +1851,7 @@ See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`
 Aliases: `Expression`, `Literal`
 
  - `pattern`: `string` (required)
- - `flags`: `string` (default: `''`)
+ - `flags`: `string` (default: `""`)
 
 ---
 
@@ -1784,19 +1865,19 @@ See also `t.isRestElement(node, opts)` and `t.assertRestElement(node, opts)`.
 Aliases: `LVal`, `PatternLike`
 
  - `argument`: `LVal` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### returnStatement
 ```javascript
-t.returnStatement(argument)
+t.returnStatement()
 ```
 
 See also `t.isReturnStatement(node, opts)` and `t.assertReturnStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (default: `null`)
 
@@ -1835,7 +1916,7 @@ t.stringLiteral(value)
 
 See also `t.isStringLiteral(node, opts)` and `t.assertStringLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -1861,20 +1942,7 @@ t.stringTypeAnnotation()
 
 See also `t.isStringTypeAnnotation(node, opts)` and `t.assertStringTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
-
----
-
-### super
-```javascript
-t.super()
-```
-
-See also `t.isSuper(node, opts)` and `t.assertSuper(node, opts)`.
-
-Aliases: `Expression`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1885,7 +1953,9 @@ t.switchCase(test, consequent)
 
 See also `t.isSwitchCase(node, opts)` and `t.assertSwitchCase(node, opts)`.
 
- - `test`: `Expression` (default: `null`)
+Aliases: none
+
+ - `test`: `Expression` (required)
  - `consequent`: `Array<Statement>` (required)
 
 ---
@@ -1897,783 +1967,10 @@ t.switchStatement(discriminant, cases)
 
 See also `t.isSwitchStatement(node, opts)` and `t.assertSwitchStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Scopable`
+Aliases: `BlockParent`, `Scopable`, `Statement`
 
  - `discriminant`: `Expression` (required)
  - `cases`: `Array<SwitchCase>` (required)
-
----
-
-### tSAnyKeyword
-```javascript
-t.tsAnyKeyword()
-```
-
-See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSArrayType
-```javascript
-t.tsArrayType(elementType)
-```
-
-See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementType`: `TSType` (required)
-
----
-
-### tSAsExpression
-```javascript
-t.tsAsExpression(expression, typeAnnotation)
-```
-
-See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSBooleanKeyword
-```javascript
-t.tsBooleanKeyword()
-```
-
-See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSCallSignatureDeclaration
-```javascript
-t.tsCallSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConditionalType
-```javascript
-t.tsConditionalType(checkType, extendsType, trueType, falseType)
-```
-
-See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
-
-Aliases: `TSType`
-
- - `checkType`: `TSType` (required)
- - `extendsType`: `TSType` (required)
- - `trueType`: `TSType` (required)
- - `falseType`: `TSType` (required)
-
----
-
-### tSConstructSignatureDeclaration
-```javascript
-t.tsConstructSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConstructorType
-```javascript
-t.tsConstructorType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSDeclareFunction
-```javascript
-t.tsDeclareFunction(id, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (default: `null`)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
- - `generator`: `boolean` (default: `false`)
-
----
-
-### tSDeclareMethod
-```javascript
-t.tsDeclareMethod(decorators, key, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
-
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `access`: `"public" | "private" | "protected"` (default: `null`)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `computed`: `boolean` (default: `false`)
- - `generator`: `boolean` (default: `false`)
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
- - `optional`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
-
----
-
-### tSEnumDeclaration
-```javascript
-t.tsEnumDeclaration(id, members)
-```
-
-See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `members`: `Array<TSEnumMember>` (required)
- - `const`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSEnumMember
-```javascript
-t.tsEnumMember(id, initializer)
-```
-
-See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
-
- - `id`: `Identifier | StringLiteral` (required)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSExportAssignment
-```javascript
-t.tsExportAssignment(expression)
-```
-
-See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
-
-Aliases: `Statement`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSExpressionWithTypeArguments
-```javascript
-t.tsExpressionWithTypeArguments(expression, typeParameters)
-```
-
-See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
-
-Aliases: `TSType`
-
- - `expression`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSExternalModuleReference
-```javascript
-t.tsExternalModuleReference(expression)
-```
-
-See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
-
- - `expression`: `StringLiteral` (required)
-
----
-
-### tSFunctionType
-```javascript
-t.tsFunctionType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSImportEqualsDeclaration
-```javascript
-t.tsImportEqualsDeclaration(id, moduleReference)
-```
-
-See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
- - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
- - `isExport`: `boolean` (default: `null`)
-
----
-
-### tSIndexSignature
-```javascript
-t.tsIndexSignature(parameters, typeAnnotation)
-```
-
-See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `parameters`: `Array<Identifier>` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSIndexedAccessType
-```javascript
-t.tsIndexedAccessType(objectType, indexType)
-```
-
-See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
-
-Aliases: `TSType`
-
- - `objectType`: `TSType` (required)
- - `indexType`: `TSType` (required)
-
----
-
-### tSInferType
-```javascript
-t.tsInferType(typeParameter)
-```
-
-See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
-
----
-
-### tSInterfaceBody
-```javascript
-t.tsInterfaceBody(body)
-```
-
-See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
-
- - `body`: `Array<TSTypeElement>` (required)
-
----
-
-### tSInterfaceDeclaration
-```javascript
-t.tsInterfaceDeclaration(id, typeParameters, extends, body)
-```
-
-See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<TSExpressionWithTypeArguments>` (default: `null`)
- - `body`: `TSInterfaceBody` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSIntersectionType
-```javascript
-t.tsIntersectionType(types)
-```
-
-See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSLiteralType
-```javascript
-t.tsLiteralType(literal)
-```
-
-See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
-
-Aliases: `TSType`
-
- - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
-
----
-
-### tSMappedType
-```javascript
-t.tsMappedType(typeParameter, typeAnnotation)
-```
-
-See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
- - `typeAnnotation`: `TSType` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSMethodSignature
-```javascript
-t.tsMethodSignature(key, typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
-
----
-
-### tSModuleBlock
-```javascript
-t.tsModuleBlock(body)
-```
-
-See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
-
- - `body`: `Array<Statement>` (required)
-
----
-
-### tSModuleDeclaration
-```javascript
-t.tsModuleDeclaration(id, body)
-```
-
-See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
- - `declare`: `boolean` (default: `null`)
- - `global`: `boolean` (default: `null`)
-
----
-
-### tSNamespaceExportDeclaration
-```javascript
-t.tsNamespaceExportDeclaration(id)
-```
-
-See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
-
----
-
-### tSNeverKeyword
-```javascript
-t.tsNeverKeyword()
-```
-
-See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNonNullExpression
-```javascript
-t.tsNonNullExpression(expression)
-```
-
-See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSNullKeyword
-```javascript
-t.tsNullKeyword()
-```
-
-See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNumberKeyword
-```javascript
-t.tsNumberKeyword()
-```
-
-See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSObjectKeyword
-```javascript
-t.tsObjectKeyword()
-```
-
-See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSParameterProperty
-```javascript
-t.tsParameterProperty(parameter)
-```
-
-See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
-
-Aliases: `LVal`
-
- - `parameter`: `Identifier | AssignmentPattern` (required)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSParenthesizedType
-```javascript
-t.tsParenthesizedType(typeAnnotation)
-```
-
-See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSPropertySignature
-```javascript
-t.tsPropertySignature(key, typeAnnotation, initializer)
-```
-
-See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSQualifiedName
-```javascript
-t.tsQualifiedName(left, right)
-```
-
-See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
-
-Aliases: `TSEntityName`
-
- - `left`: `TSEntityName` (required)
- - `right`: `Identifier` (required)
-
----
-
-### tSStringKeyword
-```javascript
-t.tsStringKeyword()
-```
-
-See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSSymbolKeyword
-```javascript
-t.tsSymbolKeyword()
-```
-
-See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSThisType
-```javascript
-t.tsThisType()
-```
-
-See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSTupleType
-```javascript
-t.tsTupleType(elementTypes)
-```
-
-See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementTypes`: `Array<TSType>` (required)
-
----
-
-### tSTypeAliasDeclaration
-```javascript
-t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
-```
-
-See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSType` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSTypeAnnotation
-```javascript
-t.tsTypeAnnotation(typeAnnotation)
-```
-
-See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSTypeAssertion
-```javascript
-t.tsTypeAssertion(typeAnnotation, expression)
-```
-
-See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
-
-Aliases: `Expression`
-
- - `typeAnnotation`: `TSType` (required)
- - `expression`: `Expression` (required)
-
----
-
-### tSTypeLiteral
-```javascript
-t.tsTypeLiteral(members)
-```
-
-See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
-
-Aliases: `TSType`
-
- - `members`: `Array<TSTypeElement>` (required)
-
----
-
-### tSTypeOperator
-```javascript
-t.tsTypeOperator(typeAnnotation)
-```
-
-See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
- - `operator`: `string` (default: `null`)
-
----
-
-### tSTypeParameter
-```javascript
-t.tsTypeParameter(constraint, default)
-```
-
-See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
-
- - `constraint`: `TSType` (default: `null`)
- - `default`: `TSType` (default: `null`)
- - `name`: `string` (default: `null`)
-
----
-
-### tSTypeParameterDeclaration
-```javascript
-t.tsTypeParameterDeclaration(params)
-```
-
-See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
-
- - `params`: `Array<TSTypeParameter>` (required)
-
----
-
-### tSTypeParameterInstantiation
-```javascript
-t.tsTypeParameterInstantiation(params)
-```
-
-See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
-
- - `params`: `Array<TSType>` (required)
-
----
-
-### tSTypePredicate
-```javascript
-t.tsTypePredicate(parameterName, typeAnnotation)
-```
-
-See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
-
-Aliases: `TSType`
-
- - `parameterName`: `Identifier | TSThisType` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (required)
-
----
-
-### tSTypeQuery
-```javascript
-t.tsTypeQuery(exprName)
-```
-
-See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
-
-Aliases: `TSType`
-
- - `exprName`: `TSEntityName` (required)
-
----
-
-### tSTypeReference
-```javascript
-t.tsTypeReference(typeName, typeParameters)
-```
-
-See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeName`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSUndefinedKeyword
-```javascript
-t.tsUndefinedKeyword()
-```
-
-See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSUnionType
-```javascript
-t.tsUnionType(types)
-```
-
-See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSVoidKeyword
-```javascript
-t.tsVoidKeyword()
-```
-
-See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
-
-Aliases: `TSType`
-
 
 ---
 
@@ -2688,17 +1985,21 @@ Aliases: `Expression`
 
  - `tag`: `Expression` (required)
  - `quasi`: `TemplateLiteral` (required)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### templateElement
 ```javascript
-t.templateElement(value, tail)
+t.templateElement(value)
 ```
 
 See also `t.isTemplateElement(node, opts)` and `t.assertTemplateElement(node, opts)`.
 
- - `value` (required)
+Aliases: none
+
+ - `value`: `{ raw: string` (required)
+ - `cooked`: `string }` (default: `null`)
  - `tail`: `boolean` (default: `false`)
 
 ---
@@ -2726,7 +2027,6 @@ See also `t.isThisExpression(node, opts)` and `t.assertThisExpression(node, opts
 
 Aliases: `Expression`
 
-
 ---
 
 ### thisTypeAnnotation
@@ -2736,8 +2036,7 @@ t.thisTypeAnnotation()
 
 See also `t.isThisTypeAnnotation(node, opts)` and `t.assertThisTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -2748,7 +2047,7 @@ t.throwStatement(argument)
 
 See also `t.isThrowStatement(node, opts)` and `t.assertThrowStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (required)
 
@@ -2756,7 +2055,7 @@ Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
 ### tryStatement
 ```javascript
-t.tryStatement(block, handler, finalizer)
+t.tryStatement(block)
 ```
 
 See also `t.isTryStatement(node, opts)` and `t.assertTryStatement(node, opts)`.
@@ -2766,6 +2065,838 @@ Aliases: `Statement`
  - `block`: `BlockStatement` (required)
  - `handler`: `CatchClause` (default: `null`)
  - `finalizer`: `BlockStatement` (default: `null`)
+
+---
+
+### tsAnyKeyword
+```javascript
+t.tsAnyKeyword()
+```
+
+See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsArrayType
+```javascript
+t.tsArrayType(elementType)
+```
+
+See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementType`: `TSType` (required)
+
+---
+
+### tsAsExpression
+```javascript
+t.tsAsExpression(expression, typeAnnotation)
+```
+
+See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsBooleanKeyword
+```javascript
+t.tsBooleanKeyword()
+```
+
+See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsCallSignatureDeclaration
+```javascript
+t.tsCallSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConditionalType
+```javascript
+t.tsConditionalType(checkType, extendsType, trueType, falseType)
+```
+
+See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `checkType`: `TSType` (required)
+ - `extendsType`: `TSType` (required)
+ - `trueType`: `TSType` (required)
+ - `falseType`: `TSType` (required)
+
+---
+
+### tsConstructorType
+```javascript
+t.tsConstructorType(typeParameters, parameters)
+```
+
+See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConstructSignatureDeclaration
+```javascript
+t.tsConstructSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsDeclareFunction
+```javascript
+t.tsDeclareFunction(id, typeParameters, params)
+```
+
+See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+
+---
+
+### tsDeclareMethod
+```javascript
+t.tsDeclareMethod(decorators, key, typeParameters, params)
+```
+
+See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
+
+Aliases: none
+
+ - `decorators`: `Array<Decorator>` (required)
+ - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `optional`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
+
+---
+
+### tsEnumDeclaration
+```javascript
+t.tsEnumDeclaration(id, members)
+```
+
+See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `members`: `Array<TSEnumMember>` (required)
+ - `const`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsEnumMember
+```javascript
+t.tsEnumMember(id)
+```
+
+See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
+
+Aliases: none
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsExportAssignment
+```javascript
+t.tsExportAssignment(expression)
+```
+
+See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
+
+Aliases: `Statement`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsExpressionWithTypeArguments
+```javascript
+t.tsExpressionWithTypeArguments(expression)
+```
+
+See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
+
+Aliases: `TSType`
+
+ - `expression`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsExternalModuleReference
+```javascript
+t.tsExternalModuleReference(expression)
+```
+
+See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `StringLiteral` (required)
+
+---
+
+### tsFunctionType
+```javascript
+t.tsFunctionType(typeParameters, parameters)
+```
+
+See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsImportEqualsDeclaration
+```javascript
+t.tsImportEqualsDeclaration(id, moduleReference)
+```
+
+See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+ - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
+ - `isExport`: `boolean` (default: `false`)
+
+---
+
+### tsImportType
+```javascript
+t.tsImportType(argument)
+```
+
+See also `t.isTSImportType(node, opts)` and `t.assertTSImportType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `argument`: `StringLiteral` (required)
+ - `qualifier`: `TSEntityName` (default: `null`)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsIndexedAccessType
+```javascript
+t.tsIndexedAccessType(objectType, indexType)
+```
+
+See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `objectType`: `TSType` (required)
+ - `indexType`: `TSType` (required)
+
+---
+
+### tsIndexSignature
+```javascript
+t.tsIndexSignature(parameters)
+```
+
+See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `parameters`: `Array<Identifier>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsInferType
+```javascript
+t.tsInferType(typeParameter)
+```
+
+See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+
+---
+
+### tsInterfaceBody
+```javascript
+t.tsInterfaceBody(body)
+```
+
+See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
+
+Aliases: none
+
+ - `body`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsInterfaceDeclaration
+```javascript
+t.tsInterfaceDeclaration(id, typeParameters, extends, body)
+```
+
+See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `extends`: `Array<TSExpressionWithTypeArguments>` (required)
+ - `body`: `TSInterfaceBody` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsIntersectionType
+```javascript
+t.tsIntersectionType(types)
+```
+
+See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsLiteralType
+```javascript
+t.tsLiteralType(literal)
+```
+
+See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
+
+---
+
+### tsMappedType
+```javascript
+t.tsMappedType(typeParameter)
+```
+
+See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+ - `typeAnnotation`: `TSType` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsMethodSignature
+```javascript
+t.tsMethodSignature(key, typeParameters, parameters)
+```
+
+See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+
+---
+
+### tsModuleBlock
+```javascript
+t.tsModuleBlock(body)
+```
+
+See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
+
+Aliases: `Block`, `BlockParent`, `Scopable`
+
+ - `body`: `Array<Statement>` (required)
+
+---
+
+### tsModuleDeclaration
+```javascript
+t.tsModuleDeclaration(id, body)
+```
+
+See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
+ - `declare`: `boolean` (default: `false`)
+ - `global`: `boolean` (default: `false`)
+
+---
+
+### tsNamespaceExportDeclaration
+```javascript
+t.tsNamespaceExportDeclaration(id)
+```
+
+See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
+### tsNeverKeyword
+```javascript
+t.tsNeverKeyword()
+```
+
+See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNonNullExpression
+```javascript
+t.tsNonNullExpression(expression)
+```
+
+See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsNullKeyword
+```javascript
+t.tsNullKeyword()
+```
+
+See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNumberKeyword
+```javascript
+t.tsNumberKeyword()
+```
+
+See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsObjectKeyword
+```javascript
+t.tsObjectKeyword()
+```
+
+See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsOptionalType
+```javascript
+t.tsOptionalType(typeAnnotation)
+```
+
+See also `t.isTSOptionalType(node, opts)` and `t.assertTSOptionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsParameterProperty
+```javascript
+t.tsParameterProperty(parameter)
+```
+
+See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
+
+Aliases: `LVal`
+
+ - `parameter`: `Identifier | AssignmentPattern` (required)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsParenthesizedType
+```javascript
+t.tsParenthesizedType(typeAnnotation)
+```
+
+See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsPropertySignature
+```javascript
+t.tsPropertySignature(key)
+```
+
+See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `initializer`: `Expression` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsQualifiedName
+```javascript
+t.tsQualifiedName(left, right)
+```
+
+See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
+
+Aliases: `TSEntityName`
+
+ - `left`: `TSEntityName` (required)
+ - `right`: `Identifier` (required)
+
+---
+
+### tsRestType
+```javascript
+t.tsRestType(typeAnnotation)
+```
+
+See also `t.isTSRestType(node, opts)` and `t.assertTSRestType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsStringKeyword
+```javascript
+t.tsStringKeyword()
+```
+
+See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsSymbolKeyword
+```javascript
+t.tsSymbolKeyword()
+```
+
+See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsThisType
+```javascript
+t.tsThisType()
+```
+
+See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsTupleType
+```javascript
+t.tsTupleType(elementTypes)
+```
+
+See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementTypes`: `Array<TSType>` (required)
+
+---
+
+### tsTypeAliasDeclaration
+```javascript
+t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
+```
+
+See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `typeAnnotation`: `TSType` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsTypeAnnotation
+```javascript
+t.tsTypeAnnotation(typeAnnotation)
+```
+
+See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
+
+Aliases: none
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsTypeAssertion
+```javascript
+t.tsTypeAssertion(typeAnnotation, expression)
+```
+
+See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
+
+Aliases: `Expression`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `expression`: `Expression` (required)
+
+---
+
+### tsTypeLiteral
+```javascript
+t.tsTypeLiteral(members)
+```
+
+See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
+
+Aliases: `TSType`
+
+ - `members`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsTypeOperator
+```javascript
+t.tsTypeOperator(typeAnnotation)
+```
+
+See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `operator`: `string` (default: `""`)
+
+---
+
+### tsTypeParameter
+```javascript
+t.tsTypeParameter()
+```
+
+See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
+
+Aliases: none
+
+ - `constraint`: `TSType` (default: `null`)
+ - `default`: `TSType` (default: `null`)
+ - `name`: `string` (default: `""`)
+
+---
+
+### tsTypeParameterDeclaration
+```javascript
+t.tsTypeParameterDeclaration(params)
+```
+
+See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSTypeParameter>` (required)
+
+---
+
+### tsTypeParameterInstantiation
+```javascript
+t.tsTypeParameterInstantiation(params)
+```
+
+See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSType>` (required)
+
+---
+
+### tsTypePredicate
+```javascript
+t.tsTypePredicate(parameterName, typeAnnotation)
+```
+
+See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
+
+Aliases: `TSType`
+
+ - `parameterName`: `Identifier | TSThisType` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (required)
+
+---
+
+### tsTypeQuery
+```javascript
+t.tsTypeQuery(exprName)
+```
+
+See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
+
+Aliases: `TSType`
+
+ - `exprName`: `TSEntityName | TSImportType` (required)
+
+---
+
+### tsTypeReference
+```javascript
+t.tsTypeReference(typeName)
+```
+
+See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeName`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsUndefinedKeyword
+```javascript
+t.tsUndefinedKeyword()
+```
+
+See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsUnionType
+```javascript
+t.tsUnionType(types)
+```
+
+See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsUnknownKeyword
+```javascript
+t.tsUnknownKeyword()
+```
+
+See also `t.isTSUnknownKeyword(node, opts)` and `t.assertTSUnknownKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsVoidKeyword
+```javascript
+t.tsVoidKeyword()
+```
+
+See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
+
+Aliases: `TSType`
 
 ---
 
@@ -2789,10 +2920,10 @@ t.typeAlias(id, typeParameters, right)
 
 See also `t.isTypeAlias(node, opts)` and `t.assertTypeAlias(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `right`: `FlowType` (required)
 
 ---
@@ -2817,16 +2948,29 @@ t.typeCastExpression(expression, typeAnnotation)
 
 See also `t.isTypeCastExpression(node, opts)` and `t.assertTypeCastExpression(node, opts)`.
 
-Aliases: `Flow`, `ExpressionWrapper`, `Expression`
+Aliases: `Expression`, `ExpressionWrapper`, `Flow`
 
  - `expression`: `Expression` (required)
  - `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
+### typeofTypeAnnotation
+```javascript
+t.typeofTypeAnnotation(argument)
+```
+
+See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowType`
+
+ - `argument`: `FlowType` (required)
+
+---
+
 ### typeParameter
 ```javascript
-t.typeParameter(bound, default, variance)
+t.typeParameter()
 ```
 
 See also `t.isTypeParameter(node, opts)` and `t.assertTypeParameter(node, opts)`.
@@ -2836,7 +2980,7 @@ Aliases: `Flow`
  - `bound`: `TypeAnnotation` (default: `null`)
  - `default`: `FlowType` (default: `null`)
  - `variance`: `Variance` (default: `null`)
- - `name`: `string` (default: `null`)
+ - `name`: `string` (default: `""`)
 
 ---
 
@@ -2866,31 +3010,18 @@ Aliases: `Flow`
 
 ---
 
-### typeofTypeAnnotation
-```javascript
-t.typeofTypeAnnotation(argument)
-```
-
-See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`
-
- - `argument`: `FlowType` (required)
-
----
-
 ### unaryExpression
 ```javascript
-t.unaryExpression(operator, argument, prefix)
+t.unaryExpression(operator, argument)
 ```
 
 See also `t.isUnaryExpression(node, opts)` and `t.assertUnaryExpression(node, opts)`.
 
-Aliases: `UnaryLike`, `Expression`
+Aliases: `Expression`, `UnaryLike`
 
  - `operator`: `"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"` (required)
  - `argument`: `Expression` (required)
- - `prefix`: `boolean` (default: `true`)
+ - `prefix`: `boolean` (default: `false`)
 
 ---
 
@@ -2909,7 +3040,7 @@ Aliases: `Flow`, `FlowType`
 
 ### updateExpression
 ```javascript
-t.updateExpression(operator, argument, prefix)
+t.updateExpression(operator, argument)
 ```
 
 See also `t.isUpdateExpression(node, opts)` and `t.assertUpdateExpression(node, opts)`.
@@ -2929,24 +3060,26 @@ t.variableDeclaration(kind, declarations)
 
 See also `t.isVariableDeclaration(node, opts)` and `t.assertVariableDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`
+Aliases: `Declaration`, `Statement`
 
  - `kind`: `"var" | "let" | "const"` (required)
  - `declarations`: `Array<VariableDeclarator>` (required)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
 
 ---
 
 ### variableDeclarator
 ```javascript
-t.variableDeclarator(id, init)
+t.variableDeclarator(id)
 ```
 
 See also `t.isVariableDeclarator(node, opts)` and `t.assertVariableDeclarator(node, opts)`.
 
+Aliases: none
+
  - `id`: `LVal` (required)
  - `init`: `Expression` (default: `null`)
- - `definite`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
 
 ---
 
@@ -2970,8 +3103,7 @@ t.voidTypeAnnotation()
 
 See also `t.isVoidTypeAnnotation(node, opts)` and `t.assertVoidTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -2982,7 +3114,7 @@ t.whileStatement(test, body)
 
 See also `t.isWhileStatement(node, opts)` and `t.assertWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `BlockStatement | Statement` (required)
@@ -3005,7 +3137,7 @@ Aliases: `Statement`
 
 ### yieldExpression
 ```javascript
-t.yieldExpression(argument, delegate)
+t.yieldExpression()
 ```
 
 See also `t.isYieldExpression(node, opts)` and `t.assertYieldExpression(node, opts)`.
@@ -3016,4 +3148,3 @@ Aliases: `Expression`, `Terminatorless`
  - `delegate`: `boolean` (default: `false`)
 
 ---
-

--- a/website/versioned_docs/version-7.2.0/types.md
+++ b/website/versioned_docs/version-7.2.0/types.md
@@ -12,6 +12,7 @@ npm install --save-dev @babel/types
 ```
 
 ## API
+
 ### anyTypeAnnotation
 ```javascript
 t.anyTypeAnnotation()
@@ -19,14 +20,24 @@ t.anyTypeAnnotation()
 
 See also `t.isAnyTypeAnnotation(node, opts)` and `t.assertAnyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
+---
+
+### argumentPlaceholder
+```javascript
+t.argumentPlaceholder()
+```
+
+See also `t.isArgumentPlaceholder(node, opts)` and `t.assertArgumentPlaceholder(node, opts)`.
+
+Aliases: none
 
 ---
 
 ### arrayExpression
 ```javascript
-t.arrayExpression(elements)
+t.arrayExpression()
 ```
 
 See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, opts)`.
@@ -44,10 +55,10 @@ t.arrayPattern(elements)
 
 See also `t.isArrayPattern(node, opts)` and `t.assertArrayPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `elements`: `Array<PatternLike>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -67,17 +78,17 @@ Aliases: `Flow`, `FlowType`
 
 ### arrowFunctionExpression
 ```javascript
-t.arrowFunctionExpression(params, body, async)
+t.arrowFunctionExpression(params, body)
 ```
 
 See also `t.isArrowFunctionExpression(node, opts)` and `t.assertArrowFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement | Expression` (required)
  - `async`: `boolean` (default: `false`)
- - `expression`: `boolean` (default: `null`)
+ - `expression`: `boolean` (default: `false`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -106,11 +117,11 @@ t.assignmentPattern(left, right)
 
 See also `t.isAssignmentPattern(node, opts)` and `t.assertAssignmentPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
- - `left`: `Identifier | ObjectPattern | ArrayPattern` (required)
+ - `left`: `Identifier | ObjectPattern | ArrayPattern | MemberExpression` (required)
  - `right`: `Expression` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -135,7 +146,7 @@ t.bigIntLiteral(value)
 
 See also `t.isBigIntLiteral(node, opts)` and `t.assertBigIntLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -165,19 +176,19 @@ See also `t.isBindExpression(node, opts)` and `t.assertBindExpression(node, opts
 
 Aliases: `Expression`
 
- - `object` (required)
- - `callee` (required)
+ - `object`: `any` (required)
+ - `callee`: `any` (required)
 
 ---
 
 ### blockStatement
 ```javascript
-t.blockStatement(body, directives)
+t.blockStatement(body)
 ```
 
 See also `t.isBlockStatement(node, opts)` and `t.assertBlockStatement(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`, `Statement`
+Aliases: `Block`, `BlockParent`, `Scopable`, `Statement`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
@@ -191,7 +202,7 @@ t.booleanLiteral(value)
 
 See also `t.isBooleanLiteral(node, opts)` and `t.assertBooleanLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `boolean` (required)
 
@@ -217,19 +228,18 @@ t.booleanTypeAnnotation()
 
 See also `t.isBooleanTypeAnnotation(node, opts)` and `t.assertBooleanTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
 ### breakStatement
 ```javascript
-t.breakStatement(label)
+t.breakStatement()
 ```
 
 See also `t.isBreakStatement(node, opts)` and `t.assertBreakStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -245,7 +255,7 @@ See also `t.isCallExpression(node, opts)` and `t.assertCallExpression(node, opts
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -259,9 +269,9 @@ t.catchClause(param, body)
 
 See also `t.isCatchClause(node, opts)` and `t.assertCatchClause(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`
+Aliases: `BlockParent`, `Scopable`
 
- - `param`: `Identifier` (default: `null`)
+ - `param`: `Identifier` (required)
  - `body`: `BlockStatement` (required)
 
 ---
@@ -273,27 +283,29 @@ t.classBody(body)
 
 See also `t.isClassBody(node, opts)` and `t.assertClassBody(node, opts)`.
 
- - `body`: `Array<ClassMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
+Aliases: none
+
+ - `body`: `Array<ClassMethod | ClassPrivateMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
 
 ---
 
 ### classDeclaration
 ```javascript
-t.classDeclaration(id, superClass, body, decorators)
+t.classDeclaration(id, superClass, body)
 ```
 
 See also `t.isClassDeclaration(node, opts)` and `t.assertClassDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
+Aliases: `Class`, `Declaration`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `abstract`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -301,19 +313,19 @@ Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
 
 ### classExpression
 ```javascript
-t.classExpression(id, superClass, body, decorators)
+t.classExpression(id, superClass, body)
 ```
 
 See also `t.isClassExpression(node, opts)` and `t.assertClassExpression(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
+Aliases: `Class`, `Expression`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -321,7 +333,7 @@ Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
 
 ### classImplements
 ```javascript
-t.classImplements(id, typeParameters)
+t.classImplements(id)
 ```
 
 See also `t.isClassImplements(node, opts)` and `t.assertClassImplements(node, opts)`.
@@ -335,39 +347,66 @@ Aliases: `Flow`
 
 ### classMethod
 ```javascript
-t.classMethod(kind, key, params, body, computed, static)
+t.classMethod(kind, key, params, body)
 ```
 
 See also `t.isClassMethod(node, opts)` and `t.assertClassMethod(node, opts)`.
 
-Aliases: `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Scopable`
 
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `method`)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
- - `static`: `boolean` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
  - `access`: `"public" | "private" | "protected"` (default: `null`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
+### classPrivateMethod
+```javascript
+t.classPrivateMethod(kind, key, params, body)
+```
+
+See also `t.isClassPrivateMethod(node, opts)` and `t.assertClassPrivateMethod(node, opts)`.
+
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Private`, `Scopable`
+
+ - `kind`: `"get" | "set" | "method" | "constructor"` (required)
+ - `key`: `PrivateName` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `body`: `BlockStatement` (required)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `generator`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `returnType`: `any` (default: `null`)
+ - `typeParameters`: `any` (default: `null`)
+
+---
+
 ### classPrivateProperty
 ```javascript
-t.classPrivateProperty(key, value)
+t.classPrivateProperty(key)
 ```
 
 See also `t.isClassPrivateProperty(node, opts)` and `t.assertClassPrivateProperty(node, opts)`.
 
-Aliases: `Property`, `Private`
+Aliases: `Private`, `Property`
 
  - `key`: `PrivateName` (required)
  - `value`: `Expression` (default: `null`)
@@ -376,7 +415,7 @@ Aliases: `Property`, `Private`
 
 ### classProperty
 ```javascript
-t.classProperty(key, value, typeAnnotation, decorators, computed)
+t.classProperty(key)
 ```
 
 See also `t.isClassProperty(node, opts)` and `t.assertClassProperty(node, opts)`.
@@ -386,14 +425,14 @@ Aliases: `Property`
  - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
  - `value`: `Expression` (default: `null`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `computed`: `boolean` (default: `false`)
- - `abstract`: `boolean` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `definite`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -404,7 +443,7 @@ t.conditionalExpression(test, consequent, alternate)
 
 See also `t.isConditionalExpression(node, opts)` and `t.assertConditionalExpression(node, opts)`.
 
-Aliases: `Expression`, `Conditional`
+Aliases: `Conditional`, `Expression`
 
  - `test`: `Expression` (required)
  - `consequent`: `Expression` (required)
@@ -414,12 +453,12 @@ Aliases: `Expression`, `Conditional`
 
 ### continueStatement
 ```javascript
-t.continueStatement(label)
+t.continueStatement()
 ```
 
 See also `t.isContinueStatement(node, opts)` and `t.assertContinueStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -434,7 +473,6 @@ See also `t.isDebuggerStatement(node, opts)` and `t.assertDebuggerStatement(node
 
 Aliases: `Statement`
 
-
 ---
 
 ### declareClass
@@ -444,147 +482,14 @@ t.declareClass(id, typeParameters, extends, body)
 
 See also `t.isDeclareClass(node, opts)` and `t.assertDeclareClass(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareExportAllDeclaration
-```javascript
-t.declareExportAllDeclaration(source)
-```
-
-See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `source`: `StringLiteral` (required)
- - `exportKind`: `["type","value"]` (default: `null`)
-
----
-
-### declareExportDeclaration
-```javascript
-t.declareExportDeclaration(declaration, specifiers, source)
-```
-
-See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `declaration`: `Flow` (default: `null`)
- - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `null`)
- - `source`: `StringLiteral` (default: `null`)
- - `default`: `boolean` (default: `null`)
-
----
-
-### declareFunction
-```javascript
-t.declareFunction(id)
-```
-
-See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `predicate`: `DeclaredPredicate` (default: `null`)
-
----
-
-### declareInterface
-```javascript
-t.declareInterface(id, typeParameters, extends, body)
-```
-
-See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareModule
-```javascript
-t.declareModule(id, body, kind)
-```
-
-See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `BlockStatement` (required)
- - `kind`: `"CommonJS" | "ES"` (default: `null`)
-
----
-
-### declareModuleExports
-```javascript
-t.declareModuleExports(typeAnnotation)
-```
-
-See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `typeAnnotation`: `TypeAnnotation` (required)
-
----
-
-### declareOpaqueType
-```javascript
-t.declareOpaqueType(id, typeParameters, supertype)
-```
-
-See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
-
----
-
-### declareTypeAlias
-```javascript
-t.declareTypeAlias(id, typeParameters, right)
-```
-
-See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `FlowType` (required)
-
----
-
-### declareVariable
-```javascript
-t.declareVariable(id)
-```
-
-See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
@@ -601,12 +506,147 @@ Aliases: `Flow`, `FlowPredicate`
 
 ---
 
+### declareExportAllDeclaration
+```javascript
+t.declareExportAllDeclaration(source)
+```
+
+See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `source`: `StringLiteral` (required)
+ - `exportKind`: `"type" | "value"` (default: `null`)
+
+---
+
+### declareExportDeclaration
+```javascript
+t.declareExportDeclaration()
+```
+
+See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `declaration`: `Flow` (default: `null`)
+ - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `[]`)
+ - `source`: `StringLiteral` (default: `null`)
+ - `default`: `boolean` (default: `false`)
+
+---
+
+### declareFunction
+```javascript
+t.declareFunction(id)
+```
+
+See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `predicate`: `DeclaredPredicate` (default: `null`)
+
+---
+
+### declareInterface
+```javascript
+t.declareInterface(id, typeParameters, extends, body)
+```
+
+See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
+ - `body`: `ObjectTypeAnnotation` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
+
+---
+
+### declareModule
+```javascript
+t.declareModule(id, body)
+```
+
+See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `BlockStatement` (required)
+ - `kind`: `"CommonJS" | "ES"` (default: `null`)
+
+---
+
+### declareModuleExports
+```javascript
+t.declareModuleExports(typeAnnotation)
+```
+
+See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `typeAnnotation`: `TypeAnnotation` (required)
+
+---
+
+### declareOpaqueType
+```javascript
+t.declareOpaqueType(id)
+```
+
+See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `supertype`: `FlowType` (default: `null`)
+
+---
+
+### declareTypeAlias
+```javascript
+t.declareTypeAlias(id, typeParameters, right)
+```
+
+See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `right`: `FlowType` (required)
+
+---
+
+### declareVariable
+```javascript
+t.declareVariable(id)
+```
+
+See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
 ### decorator
 ```javascript
 t.decorator(expression)
 ```
 
 See also `t.isDecorator(node, opts)` and `t.assertDecorator(node, opts)`.
+
+Aliases: none
 
  - `expression`: `Expression` (required)
 
@@ -619,6 +659,8 @@ t.directive(value)
 
 See also `t.isDirective(node, opts)` and `t.assertDirective(node, opts)`.
 
+Aliases: none
+
  - `value`: `DirectiveLiteral` (required)
 
 ---
@@ -629,6 +671,8 @@ t.directiveLiteral(value)
 ```
 
 See also `t.isDirectiveLiteral(node, opts)` and `t.assertDirectiveLiteral(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -654,7 +698,7 @@ t.doWhileStatement(test, body)
 
 See also `t.isDoWhileStatement(node, opts)` and `t.assertDoWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `Statement` (required)
@@ -670,7 +714,6 @@ See also `t.isEmptyStatement(node, opts)` and `t.assertEmptyStatement(node, opts
 
 Aliases: `Statement`
 
-
 ---
 
 ### emptyTypeAnnotation
@@ -680,8 +723,7 @@ t.emptyTypeAnnotation()
 
 See also `t.isEmptyTypeAnnotation(node, opts)` and `t.assertEmptyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -694,7 +736,6 @@ See also `t.isExistsTypeAnnotation(node, opts)` and `t.assertExistsTypeAnnotatio
 
 Aliases: `Flow`, `FlowType`
 
-
 ---
 
 ### exportAllDeclaration
@@ -704,7 +745,7 @@ t.exportAllDeclaration(source)
 
 See also `t.isExportAllDeclaration(node, opts)` and `t.assertExportAllDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `source`: `StringLiteral` (required)
 
@@ -717,7 +758,7 @@ t.exportDefaultDeclaration(declaration)
 
 See also `t.isExportDefaultDeclaration(node, opts)` and `t.assertExportDefaultDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `declaration`: `FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression` (required)
 
@@ -738,16 +779,17 @@ Aliases: `ModuleSpecifier`
 
 ### exportNamedDeclaration
 ```javascript
-t.exportNamedDeclaration(declaration, specifiers, source)
+t.exportNamedDeclaration(declaration, specifiers)
 ```
 
 See also `t.isExportNamedDeclaration(node, opts)` and `t.assertExportNamedDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
- - `declaration`: `Declaration` (default: `null`)
+ - `declaration`: `Declaration` (required)
  - `specifiers`: `Array<ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (default: `null`)
+ - `exportKind`: `"type" | "value"` (default: `null`)
 
 ---
 
@@ -785,7 +827,7 @@ t.expressionStatement(expression)
 
 See also `t.isExpressionStatement(node, opts)` and `t.assertExpressionStatement(node, opts)`.
 
-Aliases: `Statement`, `ExpressionWrapper`
+Aliases: `ExpressionWrapper`, `Statement`
 
  - `expression`: `Expression` (required)
 
@@ -798,9 +840,11 @@ t.file(program, comments, tokens)
 
 See also `t.isFile(node, opts)` and `t.assertFile(node, opts)`.
 
+Aliases: none
+
  - `program`: `Program` (required)
- - `comments` (required)
- - `tokens` (required)
+ - `comments`: `any` (required)
+ - `tokens`: `any` (required)
 
 ---
 
@@ -811,7 +855,7 @@ t.forInStatement(left, right, body)
 
 See also `t.isForInStatement(node, opts)` and `t.assertForInStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -826,7 +870,7 @@ t.forOfStatement(left, right, body)
 
 See also `t.isForOfStatement(node, opts)` and `t.assertForOfStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -842,30 +886,30 @@ t.forStatement(init, test, update, body)
 
 See also `t.isForStatement(node, opts)` and `t.assertForStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`
+Aliases: `BlockParent`, `For`, `Loop`, `Scopable`, `Statement`
 
- - `init`: `VariableDeclaration | Expression` (default: `null`)
- - `test`: `Expression` (default: `null`)
- - `update`: `Expression` (default: `null`)
+ - `init`: `VariableDeclaration | Expression` (required)
+ - `test`: `Expression` (required)
+ - `update`: `Expression` (required)
  - `body`: `Statement` (required)
 
 ---
 
 ### functionDeclaration
 ```javascript
-t.functionDeclaration(id, params, body, generator, async)
+t.functionDeclaration(id, params, body)
 ```
 
 See also `t.isFunctionDeclaration(node, opts)` and `t.assertFunctionDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `Pureish`, `Declaration`
+Aliases: `BlockParent`, `Declaration`, `Function`, `FunctionParent`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -873,15 +917,15 @@ Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `
 
 ### functionExpression
 ```javascript
-t.functionExpression(id, params, body, generator, async)
+t.functionExpression(id, params, body)
 ```
 
 See also `t.isFunctionExpression(node, opts)` and `t.assertFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
@@ -899,9 +943,9 @@ See also `t.isFunctionTypeAnnotation(node, opts)` and `t.assertFunctionTypeAnnot
 
 Aliases: `Flow`, `FlowType`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `params`: `Array<FunctionTypeParam>` (required)
- - `rest`: `FunctionTypeParam` (default: `null`)
+ - `rest`: `FunctionTypeParam` (required)
  - `returnType`: `FlowType` (required)
 
 ---
@@ -915,22 +959,22 @@ See also `t.isFunctionTypeParam(node, opts)` and `t.assertFunctionTypeParam(node
 
 Aliases: `Flow`
 
- - `name`: `Identifier` (default: `null`)
+ - `name`: `Identifier` (required)
  - `typeAnnotation`: `FlowType` (required)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
 
 ---
 
 ### genericTypeAnnotation
 ```javascript
-t.genericTypeAnnotation(id, typeParameters)
+t.genericTypeAnnotation(id)
 ```
 
 See also `t.isGenericTypeAnnotation(node, opts)` and `t.assertGenericTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -942,39 +986,27 @@ t.identifier(name)
 
 See also `t.isIdentifier(node, opts)` and `t.assertIdentifier(node, opts)`.
 
-Aliases: `Expression`, `PatternLike`, `LVal`, `TSEntityName`
+Aliases: `Expression`, `LVal`, `PatternLike`, `TSEntityName`
 
  - `name`: `string` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `optional`: `boolean` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `optional`: `boolean` (default: `false`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### ifStatement
 ```javascript
-t.ifStatement(test, consequent, alternate)
+t.ifStatement(test, consequent)
 ```
 
 See also `t.isIfStatement(node, opts)` and `t.assertIfStatement(node, opts)`.
 
-Aliases: `Statement`, `Conditional`
+Aliases: `Conditional`, `Statement`
 
  - `test`: `Expression` (required)
  - `consequent`: `Statement` (required)
  - `alternate`: `Statement` (default: `null`)
-
----
-
-### import
-```javascript
-t.import()
-```
-
-See also `t.isImport(node, opts)` and `t.assertImport(node, opts)`.
-
-Aliases: `Expression`
-
 
 ---
 
@@ -985,10 +1017,11 @@ t.importDeclaration(specifiers, source)
 
 See also `t.isImportDeclaration(node, opts)` and `t.assertImportDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`
+Aliases: `Declaration`, `ModuleDeclaration`, `Statement`
 
  - `specifiers`: `Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (required)
+ - `importKind`: `"type" | "typeof" | "value"` (default: `null`)
 
 ---
 
@@ -1029,7 +1062,7 @@ Aliases: `ModuleSpecifier`
 
  - `local`: `Identifier` (required)
  - `imported`: `Identifier` (required)
- - `importKind`: `null | "type" | "typeof"` (default: `null`)
+ - `importKind`: `"type" | "typeof"` (default: `null`)
 
 ---
 
@@ -1042,7 +1075,6 @@ See also `t.isInferredPredicate(node, opts)` and `t.assertInferredPredicate(node
 
 Aliases: `Flow`, `FlowPredicate`
 
-
 ---
 
 ### interfaceDeclaration
@@ -1052,27 +1084,27 @@ t.interfaceDeclaration(id, typeParameters, extends, body)
 
 See also `t.isInterfaceDeclaration(node, opts)` and `t.assertInterfaceDeclaration(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
 ### interfaceExtends
 ```javascript
-t.interfaceExtends(id, typeParameters)
+t.interfaceExtends(id)
 ```
 
 See also `t.isInterfaceExtends(node, opts)` and `t.assertInterfaceExtends(node, opts)`.
 
 Aliases: `Flow`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -1086,7 +1118,7 @@ See also `t.isInterfaceTypeAnnotation(node, opts)` and `t.assertInterfaceTypeAnn
 
 Aliases: `Flow`, `FlowType`
 
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
 
 ---
@@ -1097,6 +1129,8 @@ t.interpreterDirective(value)
 ```
 
 See also `t.isInterpreterDirective(node, opts)` and `t.assertInterpreterDirective(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -1115,62 +1149,61 @@ Aliases: `Flow`, `FlowType`
 
 ---
 
-### jSXAttribute
+### jsxAttribute
 ```javascript
-t.jsxAttribute(name, value)
+t.jsxAttribute(name)
 ```
 
 See also `t.isJSXAttribute(node, opts)` and `t.assertJSXAttribute(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXNamespacedName` (required)
  - `value`: `JSXElement | JSXFragment | StringLiteral | JSXExpressionContainer` (default: `null`)
 
 ---
 
-### jSXClosingElement
+### jsxClosingElement
 ```javascript
 t.jsxClosingElement(name)
 ```
 
 See also `t.isJSXClosingElement(node, opts)` and `t.assertJSXClosingElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
 
 ---
 
-### jSXClosingFragment
+### jsxClosingFragment
 ```javascript
 t.jsxClosingFragment()
 ```
 
 See also `t.isJSXClosingFragment(node, opts)` and `t.assertJSXClosingFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXElement
+### jsxElement
 ```javascript
 t.jsxElement(openingElement, closingElement, children, selfClosing)
 ```
 
 See also `t.isJSXElement(node, opts)` and `t.assertJSXElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingElement`: `JSXOpeningElement` (required)
- - `closingElement`: `JSXClosingElement` (default: `null`)
+ - `closingElement`: `JSXClosingElement` (required)
  - `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
- - `selfClosing` (required)
+ - `selfClosing`: `any` (required)
 
 ---
 
-### jSXEmptyExpression
+### jsxEmptyExpression
 ```javascript
 t.jsxEmptyExpression()
 ```
@@ -1179,30 +1212,29 @@ See also `t.isJSXEmptyExpression(node, opts)` and `t.assertJSXEmptyExpression(no
 
 Aliases: `JSX`
 
-
 ---
 
-### jSXExpressionContainer
+### jsxExpressionContainer
 ```javascript
 t.jsxExpressionContainer(expression)
 ```
 
 See also `t.isJSXExpressionContainer(node, opts)` and `t.assertJSXExpressionContainer(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
- - `expression`: `Expression` (required)
+ - `expression`: `Expression | JSXEmptyExpression` (required)
 
 ---
 
-### jSXFragment
+### jsxFragment
 ```javascript
 t.jsxFragment(openingFragment, closingFragment, children)
 ```
 
 See also `t.isJSXFragment(node, opts)` and `t.assertJSXFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingFragment`: `JSXOpeningFragment` (required)
  - `closingFragment`: `JSXClosingFragment` (required)
@@ -1210,7 +1242,7 @@ Aliases: `JSX`, `Immutable`, `Expression`
 
 ---
 
-### jSXIdentifier
+### jsxIdentifier
 ```javascript
 t.jsxIdentifier(name)
 ```
@@ -1223,7 +1255,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXMemberExpression
+### jsxMemberExpression
 ```javascript
 t.jsxMemberExpression(object, property)
 ```
@@ -1237,7 +1269,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXNamespacedName
+### jsxNamespacedName
 ```javascript
 t.jsxNamespacedName(namespace, name)
 ```
@@ -1251,34 +1283,34 @@ Aliases: `JSX`
 
 ---
 
-### jSXOpeningElement
+### jsxOpeningElement
 ```javascript
-t.jsxOpeningElement(name, attributes, selfClosing)
+t.jsxOpeningElement(name, attributes)
 ```
 
 See also `t.isJSXOpeningElement(node, opts)` and `t.assertJSXOpeningElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
  - `attributes`: `Array<JSXAttribute | JSXSpreadAttribute>` (required)
  - `selfClosing`: `boolean` (default: `false`)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
-### jSXOpeningFragment
+### jsxOpeningFragment
 ```javascript
 t.jsxOpeningFragment()
 ```
 
 See also `t.isJSXOpeningFragment(node, opts)` and `t.assertJSXOpeningFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXSpreadAttribute
+### jsxSpreadAttribute
 ```javascript
 t.jsxSpreadAttribute(argument)
 ```
@@ -1291,27 +1323,27 @@ Aliases: `JSX`
 
 ---
 
-### jSXSpreadChild
+### jsxSpreadChild
 ```javascript
 t.jsxSpreadChild(expression)
 ```
 
 See also `t.isJSXSpreadChild(node, opts)` and `t.assertJSXSpreadChild(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `expression`: `Expression` (required)
 
 ---
 
-### jSXText
+### jsxText
 ```javascript
 t.jsxText(value)
 ```
 
 See also `t.isJSXText(node, opts)` and `t.assertJSXText(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `value`: `string` (required)
 
@@ -1348,7 +1380,7 @@ Aliases: `Binary`, `Expression`
 
 ### memberExpression
 ```javascript
-t.memberExpression(object, property, computed, optional)
+t.memberExpression(object, property)
 ```
 
 See also `t.isMemberExpression(node, opts)` and `t.assertMemberExpression(node, opts)`.
@@ -1383,8 +1415,7 @@ t.mixedTypeAnnotation()
 
 See also `t.isMixedTypeAnnotation(node, opts)` and `t.assertMixedTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1398,7 +1429,7 @@ See also `t.isNewExpression(node, opts)` and `t.assertNewExpression(node, opts)`
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -1412,30 +1443,7 @@ t.noop()
 
 See also `t.isNoop(node, opts)` and `t.assertNoop(node, opts)`.
 
-
----
-
-### nullLiteral
-```javascript
-t.nullLiteral()
-```
-
-See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
-
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
-
-
----
-
-### nullLiteralTypeAnnotation
-```javascript
-t.nullLiteralTypeAnnotation()
-```
-
-See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: none
 
 ---
 
@@ -1449,6 +1457,28 @@ See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnot
 Aliases: `Flow`, `FlowType`
 
  - `typeAnnotation`: `FlowType` (required)
+
+---
+
+### nullLiteral
+```javascript
+t.nullLiteral()
+```
+
+See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
+
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
+
+---
+
+### nullLiteralTypeAnnotation
+```javascript
+t.nullLiteralTypeAnnotation()
+```
+
+See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1472,8 +1502,7 @@ t.numberTypeAnnotation()
 
 See also `t.isNumberTypeAnnotation(node, opts)` and `t.assertNumberTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1484,7 +1513,7 @@ t.numericLiteral(value)
 
 See also `t.isNumericLiteral(node, opts)` and `t.assertNumericLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `number` (required)
 
@@ -1505,20 +1534,20 @@ Aliases: `Expression`
 
 ### objectMethod
 ```javascript
-t.objectMethod(kind, key, params, body, computed)
+t.objectMethod(kind, key, params, body)
 ```
 
 See also `t.isObjectMethod(node, opts)` and `t.assertObjectMethod(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`, `ObjectMember`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `ObjectMember`, `Scopable`, `UserWhitespacable`
 
- - `kind`: `"method" | "get" | "set"` (default: `'method'`)
+ - `kind`: `"method" | "get" | "set"` (required)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -1532,34 +1561,34 @@ t.objectPattern(properties)
 
 See also `t.isObjectPattern(node, opts)` and `t.assertObjectPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `properties`: `Array<RestElement | ObjectProperty>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### objectProperty
 ```javascript
-t.objectProperty(key, value, computed, shorthand, decorators)
+t.objectProperty(key, value)
 ```
 
 See also `t.isObjectProperty(node, opts)` and `t.assertObjectProperty(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Property`, `ObjectMember`
+Aliases: `ObjectMember`, `Property`, `UserWhitespacable`
 
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
  - `value`: `Expression | PatternLike` (required)
  - `computed`: `boolean` (default: `false`)
  - `shorthand`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
 
 ---
 
 ### objectTypeAnnotation
 ```javascript
-t.objectTypeAnnotation(properties, indexers, callProperties, internalSlots, exact)
+t.objectTypeAnnotation(properties)
 ```
 
 See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotation(node, opts)`.
@@ -1567,10 +1596,11 @@ See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotatio
 Aliases: `Flow`, `FlowType`
 
  - `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
- - `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
- - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `null`)
- - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `null`)
+ - `indexers`: `Array<ObjectTypeIndexer>` (default: `[]`)
+ - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `[]`)
+ - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `[]`)
  - `exact`: `boolean` (default: `false`)
+ - `inexact`: `boolean` (default: `false`)
 
 ---
 
@@ -1584,24 +1614,24 @@ See also `t.isObjectTypeCallProperty(node, opts)` and `t.assertObjectTypeCallPro
 Aliases: `Flow`, `UserWhitespacable`
 
  - `value`: `FlowType` (required)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
 ### objectTypeIndexer
 ```javascript
-t.objectTypeIndexer(id, key, value, variance)
+t.objectTypeIndexer(id, key, value)
 ```
 
 See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `id`: `Identifier` (default: `null`)
+ - `id`: `Identifier` (required)
  - `key`: `FlowType` (required)
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1624,7 +1654,7 @@ Aliases: `Flow`, `UserWhitespacable`
 
 ### objectTypeProperty
 ```javascript
-t.objectTypeProperty(key, value, variance)
+t.objectTypeProperty(key, value)
 ```
 
 See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(node, opts)`.
@@ -1635,9 +1665,9 @@ Aliases: `Flow`, `UserWhitespacable`
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
  - `kind`: `"init" | "get" | "set"` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `proto`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `proto`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1661,11 +1691,11 @@ t.opaqueType(id, typeParameters, supertype, impltype)
 
 See also `t.isOpaqueType(node, opts)` and `t.assertOpaqueType(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `supertype`: `FlowType` (required)
  - `impltype`: `FlowType` (required)
 
 ---
@@ -1698,7 +1728,7 @@ Aliases: `Expression`
 
  - `object`: `Expression` (required)
  - `property`: `any` (required)
- - `computed`: `boolean` (default: `false`)
+ - `computed`: `boolean` (required)
  - `optional`: `boolean` (required)
 
 ---
@@ -1713,6 +1743,57 @@ See also `t.isParenthesizedExpression(node, opts)` and `t.assertParenthesizedExp
 Aliases: `Expression`, `ExpressionWrapper`
 
  - `expression`: `Expression` (required)
+
+---
+
+### pipelineBareFunction
+```javascript
+t.pipelineBareFunction(callee)
+```
+
+See also `t.isPipelineBareFunction(node, opts)` and `t.assertPipelineBareFunction(node, opts)`.
+
+Aliases: none
+
+ - `callee`: `Expression` (required)
+
+---
+
+### pipelinePrimaryTopicReference
+```javascript
+t.pipelinePrimaryTopicReference()
+```
+
+See also `t.isPipelinePrimaryTopicReference(node, opts)` and `t.assertPipelinePrimaryTopicReference(node, opts)`.
+
+Aliases: `Expression`
+
+---
+
+### pipelineTopicExpression
+```javascript
+t.pipelineTopicExpression(expression)
+```
+
+See also `t.isPipelineTopicExpression(node, opts)` and `t.assertPipelineTopicExpression(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `Expression` (required)
+
+---
+
+### placeholder
+```javascript
+t.placeholder(expectedNode, name)
+```
+
+See also `t.isPlaceholder(node, opts)` and `t.assertPlaceholder(node, opts)`.
+
+Aliases: none
+
+ - `expectedNode`: `"Identifier" | "StringLiteral" | "Expression" | "Statement" | "Declaration" | "BlockStatement" | "ClassBody" | "Pattern"` (required)
+ - `name`: `Identifier` (required)
 
 ---
 
@@ -1731,18 +1812,18 @@ Aliases: `Private`
 
 ### program
 ```javascript
-t.program(body, directives, sourceType, interpreter)
+t.program(body)
 ```
 
 See also `t.isProgram(node, opts)` and `t.assertProgram(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`
+Aliases: `Block`, `BlockParent`, `Scopable`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
  - `sourceType`: `"script" | "module"` (default: `'script'`)
  - `interpreter`: `InterpreterDirective` (default: `null`)
- - `sourceFile`: `string` (default: `null`)
+ - `sourceFile`: `string` (default: `""`)
 
 ---
 
@@ -1762,7 +1843,7 @@ Aliases: `Flow`
 
 ### regExpLiteral
 ```javascript
-t.regExpLiteral(pattern, flags)
+t.regExpLiteral(pattern)
 ```
 
 See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`.
@@ -1770,7 +1851,7 @@ See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`
 Aliases: `Expression`, `Literal`
 
  - `pattern`: `string` (required)
- - `flags`: `string` (default: `''`)
+ - `flags`: `string` (default: `""`)
 
 ---
 
@@ -1784,19 +1865,19 @@ See also `t.isRestElement(node, opts)` and `t.assertRestElement(node, opts)`.
 Aliases: `LVal`, `PatternLike`
 
  - `argument`: `LVal` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### returnStatement
 ```javascript
-t.returnStatement(argument)
+t.returnStatement()
 ```
 
 See also `t.isReturnStatement(node, opts)` and `t.assertReturnStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (default: `null`)
 
@@ -1835,7 +1916,7 @@ t.stringLiteral(value)
 
 See also `t.isStringLiteral(node, opts)` and `t.assertStringLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -1861,20 +1942,7 @@ t.stringTypeAnnotation()
 
 See also `t.isStringTypeAnnotation(node, opts)` and `t.assertStringTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
-
----
-
-### super
-```javascript
-t.super()
-```
-
-See also `t.isSuper(node, opts)` and `t.assertSuper(node, opts)`.
-
-Aliases: `Expression`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1885,7 +1953,9 @@ t.switchCase(test, consequent)
 
 See also `t.isSwitchCase(node, opts)` and `t.assertSwitchCase(node, opts)`.
 
- - `test`: `Expression` (default: `null`)
+Aliases: none
+
+ - `test`: `Expression` (required)
  - `consequent`: `Array<Statement>` (required)
 
 ---
@@ -1897,796 +1967,10 @@ t.switchStatement(discriminant, cases)
 
 See also `t.isSwitchStatement(node, opts)` and `t.assertSwitchStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Scopable`
+Aliases: `BlockParent`, `Scopable`, `Statement`
 
  - `discriminant`: `Expression` (required)
  - `cases`: `Array<SwitchCase>` (required)
-
----
-
-### tSAnyKeyword
-```javascript
-t.tsAnyKeyword()
-```
-
-See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSArrayType
-```javascript
-t.tsArrayType(elementType)
-```
-
-See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementType`: `TSType` (required)
-
----
-
-### tSAsExpression
-```javascript
-t.tsAsExpression(expression, typeAnnotation)
-```
-
-See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSBooleanKeyword
-```javascript
-t.tsBooleanKeyword()
-```
-
-See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSCallSignatureDeclaration
-```javascript
-t.tsCallSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConditionalType
-```javascript
-t.tsConditionalType(checkType, extendsType, trueType, falseType)
-```
-
-See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
-
-Aliases: `TSType`
-
- - `checkType`: `TSType` (required)
- - `extendsType`: `TSType` (required)
- - `trueType`: `TSType` (required)
- - `falseType`: `TSType` (required)
-
----
-
-### tSConstructSignatureDeclaration
-```javascript
-t.tsConstructSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConstructorType
-```javascript
-t.tsConstructorType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSDeclareFunction
-```javascript
-t.tsDeclareFunction(id, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (default: `null`)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
- - `generator`: `boolean` (default: `false`)
-
----
-
-### tSDeclareMethod
-```javascript
-t.tsDeclareMethod(decorators, key, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
-
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `access`: `"public" | "private" | "protected"` (default: `null`)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `computed`: `boolean` (default: `false`)
- - `generator`: `boolean` (default: `false`)
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
- - `optional`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
-
----
-
-### tSEnumDeclaration
-```javascript
-t.tsEnumDeclaration(id, members)
-```
-
-See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `members`: `Array<TSEnumMember>` (required)
- - `const`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSEnumMember
-```javascript
-t.tsEnumMember(id, initializer)
-```
-
-See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
-
- - `id`: `Identifier | StringLiteral` (required)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSExportAssignment
-```javascript
-t.tsExportAssignment(expression)
-```
-
-See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
-
-Aliases: `Statement`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSExpressionWithTypeArguments
-```javascript
-t.tsExpressionWithTypeArguments(expression, typeParameters)
-```
-
-See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
-
-Aliases: `TSType`
-
- - `expression`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSExternalModuleReference
-```javascript
-t.tsExternalModuleReference(expression)
-```
-
-See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
-
- - `expression`: `StringLiteral` (required)
-
----
-
-### tSFunctionType
-```javascript
-t.tsFunctionType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSImportEqualsDeclaration
-```javascript
-t.tsImportEqualsDeclaration(id, moduleReference)
-```
-
-See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
- - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
- - `isExport`: `boolean` (default: `null`)
-
----
-
-### tSIndexSignature
-```javascript
-t.tsIndexSignature(parameters, typeAnnotation)
-```
-
-See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `parameters`: `Array<Identifier>` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSIndexedAccessType
-```javascript
-t.tsIndexedAccessType(objectType, indexType)
-```
-
-See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
-
-Aliases: `TSType`
-
- - `objectType`: `TSType` (required)
- - `indexType`: `TSType` (required)
-
----
-
-### tSInferType
-```javascript
-t.tsInferType(typeParameter)
-```
-
-See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
-
----
-
-### tSInterfaceBody
-```javascript
-t.tsInterfaceBody(body)
-```
-
-See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
-
- - `body`: `Array<TSTypeElement>` (required)
-
----
-
-### tSInterfaceDeclaration
-```javascript
-t.tsInterfaceDeclaration(id, typeParameters, extends, body)
-```
-
-See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<TSExpressionWithTypeArguments>` (default: `null`)
- - `body`: `TSInterfaceBody` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSIntersectionType
-```javascript
-t.tsIntersectionType(types)
-```
-
-See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSLiteralType
-```javascript
-t.tsLiteralType(literal)
-```
-
-See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
-
-Aliases: `TSType`
-
- - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
-
----
-
-### tSMappedType
-```javascript
-t.tsMappedType(typeParameter, typeAnnotation)
-```
-
-See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
- - `typeAnnotation`: `TSType` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSMethodSignature
-```javascript
-t.tsMethodSignature(key, typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
-
----
-
-### tSModuleBlock
-```javascript
-t.tsModuleBlock(body)
-```
-
-See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
-
- - `body`: `Array<Statement>` (required)
-
----
-
-### tSModuleDeclaration
-```javascript
-t.tsModuleDeclaration(id, body)
-```
-
-See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
- - `declare`: `boolean` (default: `null`)
- - `global`: `boolean` (default: `null`)
-
----
-
-### tSNamespaceExportDeclaration
-```javascript
-t.tsNamespaceExportDeclaration(id)
-```
-
-See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
-
----
-
-### tSNeverKeyword
-```javascript
-t.tsNeverKeyword()
-```
-
-See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNonNullExpression
-```javascript
-t.tsNonNullExpression(expression)
-```
-
-See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSNullKeyword
-```javascript
-t.tsNullKeyword()
-```
-
-See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNumberKeyword
-```javascript
-t.tsNumberKeyword()
-```
-
-See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSObjectKeyword
-```javascript
-t.tsObjectKeyword()
-```
-
-See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSParameterProperty
-```javascript
-t.tsParameterProperty(parameter)
-```
-
-See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
-
-Aliases: `LVal`
-
- - `parameter`: `Identifier | AssignmentPattern` (required)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSParenthesizedType
-```javascript
-t.tsParenthesizedType(typeAnnotation)
-```
-
-See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSPropertySignature
-```javascript
-t.tsPropertySignature(key, typeAnnotation, initializer)
-```
-
-See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSQualifiedName
-```javascript
-t.tsQualifiedName(left, right)
-```
-
-See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
-
-Aliases: `TSEntityName`
-
- - `left`: `TSEntityName` (required)
- - `right`: `Identifier` (required)
-
----
-
-### tSStringKeyword
-```javascript
-t.tsStringKeyword()
-```
-
-See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSSymbolKeyword
-```javascript
-t.tsSymbolKeyword()
-```
-
-See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSThisType
-```javascript
-t.tsThisType()
-```
-
-See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSTupleType
-```javascript
-t.tsTupleType(elementTypes)
-```
-
-See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementTypes`: `Array<TSType>` (required)
-
----
-
-### tSTypeAliasDeclaration
-```javascript
-t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
-```
-
-See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSType` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSTypeAnnotation
-```javascript
-t.tsTypeAnnotation(typeAnnotation)
-```
-
-See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSTypeAssertion
-```javascript
-t.tsTypeAssertion(typeAnnotation, expression)
-```
-
-See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
-
-Aliases: `Expression`
-
- - `typeAnnotation`: `TSType` (required)
- - `expression`: `Expression` (required)
-
----
-
-### tSTypeLiteral
-```javascript
-t.tsTypeLiteral(members)
-```
-
-See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
-
-Aliases: `TSType`
-
- - `members`: `Array<TSTypeElement>` (required)
-
----
-
-### tSTypeOperator
-```javascript
-t.tsTypeOperator(typeAnnotation)
-```
-
-See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
- - `operator`: `string` (default: `null`)
-
----
-
-### tSTypeParameter
-```javascript
-t.tsTypeParameter(constraint, default)
-```
-
-See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
-
- - `constraint`: `TSType` (default: `null`)
- - `default`: `TSType` (default: `null`)
- - `name`: `string` (default: `null`)
-
----
-
-### tSTypeParameterDeclaration
-```javascript
-t.tsTypeParameterDeclaration(params)
-```
-
-See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
-
- - `params`: `Array<TSTypeParameter>` (required)
-
----
-
-### tSTypeParameterInstantiation
-```javascript
-t.tsTypeParameterInstantiation(params)
-```
-
-See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
-
- - `params`: `Array<TSType>` (required)
-
----
-
-### tSTypePredicate
-```javascript
-t.tsTypePredicate(parameterName, typeAnnotation)
-```
-
-See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
-
-Aliases: `TSType`
-
- - `parameterName`: `Identifier | TSThisType` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (required)
-
----
-
-### tSTypeQuery
-```javascript
-t.tsTypeQuery(exprName)
-```
-
-See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
-
-Aliases: `TSType`
-
- - `exprName`: `TSEntityName` (required)
-
----
-
-### tSTypeReference
-```javascript
-t.tsTypeReference(typeName, typeParameters)
-```
-
-See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeName`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSUndefinedKeyword
-```javascript
-t.tsUndefinedKeyword()
-```
-
-See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSUnionType
-```javascript
-t.tsUnionType(types)
-```
-
-See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSUnknownType
-```javascript
-t.tsUnknownType(types)
-```
-
-See also `t.isTSUnknownType(node, opts)` and `t.assertTSUnknownType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSVoidKeyword
-```javascript
-t.tsVoidKeyword()
-```
-
-See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
-
-Aliases: `TSType`
-
 
 ---
 
@@ -2701,17 +1985,21 @@ Aliases: `Expression`
 
  - `tag`: `Expression` (required)
  - `quasi`: `TemplateLiteral` (required)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### templateElement
 ```javascript
-t.templateElement(value, tail)
+t.templateElement(value)
 ```
 
 See also `t.isTemplateElement(node, opts)` and `t.assertTemplateElement(node, opts)`.
 
- - `value` (required)
+Aliases: none
+
+ - `value`: `{ raw: string` (required)
+ - `cooked`: `string }` (default: `null`)
  - `tail`: `boolean` (default: `false`)
 
 ---
@@ -2739,7 +2027,6 @@ See also `t.isThisExpression(node, opts)` and `t.assertThisExpression(node, opts
 
 Aliases: `Expression`
 
-
 ---
 
 ### thisTypeAnnotation
@@ -2749,8 +2036,7 @@ t.thisTypeAnnotation()
 
 See also `t.isThisTypeAnnotation(node, opts)` and `t.assertThisTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -2761,7 +2047,7 @@ t.throwStatement(argument)
 
 See also `t.isThrowStatement(node, opts)` and `t.assertThrowStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (required)
 
@@ -2769,7 +2055,7 @@ Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
 ### tryStatement
 ```javascript
-t.tryStatement(block, handler, finalizer)
+t.tryStatement(block)
 ```
 
 See also `t.isTryStatement(node, opts)` and `t.assertTryStatement(node, opts)`.
@@ -2779,6 +2065,838 @@ Aliases: `Statement`
  - `block`: `BlockStatement` (required)
  - `handler`: `CatchClause` (default: `null`)
  - `finalizer`: `BlockStatement` (default: `null`)
+
+---
+
+### tsAnyKeyword
+```javascript
+t.tsAnyKeyword()
+```
+
+See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsArrayType
+```javascript
+t.tsArrayType(elementType)
+```
+
+See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementType`: `TSType` (required)
+
+---
+
+### tsAsExpression
+```javascript
+t.tsAsExpression(expression, typeAnnotation)
+```
+
+See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsBooleanKeyword
+```javascript
+t.tsBooleanKeyword()
+```
+
+See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsCallSignatureDeclaration
+```javascript
+t.tsCallSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConditionalType
+```javascript
+t.tsConditionalType(checkType, extendsType, trueType, falseType)
+```
+
+See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `checkType`: `TSType` (required)
+ - `extendsType`: `TSType` (required)
+ - `trueType`: `TSType` (required)
+ - `falseType`: `TSType` (required)
+
+---
+
+### tsConstructorType
+```javascript
+t.tsConstructorType(typeParameters, parameters)
+```
+
+See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConstructSignatureDeclaration
+```javascript
+t.tsConstructSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsDeclareFunction
+```javascript
+t.tsDeclareFunction(id, typeParameters, params)
+```
+
+See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+
+---
+
+### tsDeclareMethod
+```javascript
+t.tsDeclareMethod(decorators, key, typeParameters, params)
+```
+
+See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
+
+Aliases: none
+
+ - `decorators`: `Array<Decorator>` (required)
+ - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `optional`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
+
+---
+
+### tsEnumDeclaration
+```javascript
+t.tsEnumDeclaration(id, members)
+```
+
+See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `members`: `Array<TSEnumMember>` (required)
+ - `const`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsEnumMember
+```javascript
+t.tsEnumMember(id)
+```
+
+See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
+
+Aliases: none
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsExportAssignment
+```javascript
+t.tsExportAssignment(expression)
+```
+
+See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
+
+Aliases: `Statement`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsExpressionWithTypeArguments
+```javascript
+t.tsExpressionWithTypeArguments(expression)
+```
+
+See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
+
+Aliases: `TSType`
+
+ - `expression`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsExternalModuleReference
+```javascript
+t.tsExternalModuleReference(expression)
+```
+
+See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `StringLiteral` (required)
+
+---
+
+### tsFunctionType
+```javascript
+t.tsFunctionType(typeParameters, parameters)
+```
+
+See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsImportEqualsDeclaration
+```javascript
+t.tsImportEqualsDeclaration(id, moduleReference)
+```
+
+See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+ - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
+ - `isExport`: `boolean` (default: `false`)
+
+---
+
+### tsImportType
+```javascript
+t.tsImportType(argument)
+```
+
+See also `t.isTSImportType(node, opts)` and `t.assertTSImportType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `argument`: `StringLiteral` (required)
+ - `qualifier`: `TSEntityName` (default: `null`)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsIndexedAccessType
+```javascript
+t.tsIndexedAccessType(objectType, indexType)
+```
+
+See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `objectType`: `TSType` (required)
+ - `indexType`: `TSType` (required)
+
+---
+
+### tsIndexSignature
+```javascript
+t.tsIndexSignature(parameters)
+```
+
+See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `parameters`: `Array<Identifier>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsInferType
+```javascript
+t.tsInferType(typeParameter)
+```
+
+See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+
+---
+
+### tsInterfaceBody
+```javascript
+t.tsInterfaceBody(body)
+```
+
+See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
+
+Aliases: none
+
+ - `body`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsInterfaceDeclaration
+```javascript
+t.tsInterfaceDeclaration(id, typeParameters, extends, body)
+```
+
+See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `extends`: `Array<TSExpressionWithTypeArguments>` (required)
+ - `body`: `TSInterfaceBody` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsIntersectionType
+```javascript
+t.tsIntersectionType(types)
+```
+
+See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsLiteralType
+```javascript
+t.tsLiteralType(literal)
+```
+
+See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
+
+---
+
+### tsMappedType
+```javascript
+t.tsMappedType(typeParameter)
+```
+
+See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+ - `typeAnnotation`: `TSType` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsMethodSignature
+```javascript
+t.tsMethodSignature(key, typeParameters, parameters)
+```
+
+See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+
+---
+
+### tsModuleBlock
+```javascript
+t.tsModuleBlock(body)
+```
+
+See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
+
+Aliases: `Block`, `BlockParent`, `Scopable`
+
+ - `body`: `Array<Statement>` (required)
+
+---
+
+### tsModuleDeclaration
+```javascript
+t.tsModuleDeclaration(id, body)
+```
+
+See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
+ - `declare`: `boolean` (default: `false`)
+ - `global`: `boolean` (default: `false`)
+
+---
+
+### tsNamespaceExportDeclaration
+```javascript
+t.tsNamespaceExportDeclaration(id)
+```
+
+See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
+### tsNeverKeyword
+```javascript
+t.tsNeverKeyword()
+```
+
+See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNonNullExpression
+```javascript
+t.tsNonNullExpression(expression)
+```
+
+See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsNullKeyword
+```javascript
+t.tsNullKeyword()
+```
+
+See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNumberKeyword
+```javascript
+t.tsNumberKeyword()
+```
+
+See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsObjectKeyword
+```javascript
+t.tsObjectKeyword()
+```
+
+See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsOptionalType
+```javascript
+t.tsOptionalType(typeAnnotation)
+```
+
+See also `t.isTSOptionalType(node, opts)` and `t.assertTSOptionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsParameterProperty
+```javascript
+t.tsParameterProperty(parameter)
+```
+
+See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
+
+Aliases: `LVal`
+
+ - `parameter`: `Identifier | AssignmentPattern` (required)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsParenthesizedType
+```javascript
+t.tsParenthesizedType(typeAnnotation)
+```
+
+See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsPropertySignature
+```javascript
+t.tsPropertySignature(key)
+```
+
+See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `initializer`: `Expression` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsQualifiedName
+```javascript
+t.tsQualifiedName(left, right)
+```
+
+See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
+
+Aliases: `TSEntityName`
+
+ - `left`: `TSEntityName` (required)
+ - `right`: `Identifier` (required)
+
+---
+
+### tsRestType
+```javascript
+t.tsRestType(typeAnnotation)
+```
+
+See also `t.isTSRestType(node, opts)` and `t.assertTSRestType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsStringKeyword
+```javascript
+t.tsStringKeyword()
+```
+
+See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsSymbolKeyword
+```javascript
+t.tsSymbolKeyword()
+```
+
+See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsThisType
+```javascript
+t.tsThisType()
+```
+
+See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsTupleType
+```javascript
+t.tsTupleType(elementTypes)
+```
+
+See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementTypes`: `Array<TSType>` (required)
+
+---
+
+### tsTypeAliasDeclaration
+```javascript
+t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
+```
+
+See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `typeAnnotation`: `TSType` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsTypeAnnotation
+```javascript
+t.tsTypeAnnotation(typeAnnotation)
+```
+
+See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
+
+Aliases: none
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsTypeAssertion
+```javascript
+t.tsTypeAssertion(typeAnnotation, expression)
+```
+
+See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
+
+Aliases: `Expression`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `expression`: `Expression` (required)
+
+---
+
+### tsTypeLiteral
+```javascript
+t.tsTypeLiteral(members)
+```
+
+See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
+
+Aliases: `TSType`
+
+ - `members`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsTypeOperator
+```javascript
+t.tsTypeOperator(typeAnnotation)
+```
+
+See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `operator`: `string` (default: `""`)
+
+---
+
+### tsTypeParameter
+```javascript
+t.tsTypeParameter()
+```
+
+See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
+
+Aliases: none
+
+ - `constraint`: `TSType` (default: `null`)
+ - `default`: `TSType` (default: `null`)
+ - `name`: `string` (default: `""`)
+
+---
+
+### tsTypeParameterDeclaration
+```javascript
+t.tsTypeParameterDeclaration(params)
+```
+
+See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSTypeParameter>` (required)
+
+---
+
+### tsTypeParameterInstantiation
+```javascript
+t.tsTypeParameterInstantiation(params)
+```
+
+See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSType>` (required)
+
+---
+
+### tsTypePredicate
+```javascript
+t.tsTypePredicate(parameterName, typeAnnotation)
+```
+
+See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
+
+Aliases: `TSType`
+
+ - `parameterName`: `Identifier | TSThisType` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (required)
+
+---
+
+### tsTypeQuery
+```javascript
+t.tsTypeQuery(exprName)
+```
+
+See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
+
+Aliases: `TSType`
+
+ - `exprName`: `TSEntityName | TSImportType` (required)
+
+---
+
+### tsTypeReference
+```javascript
+t.tsTypeReference(typeName)
+```
+
+See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeName`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsUndefinedKeyword
+```javascript
+t.tsUndefinedKeyword()
+```
+
+See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsUnionType
+```javascript
+t.tsUnionType(types)
+```
+
+See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsUnknownKeyword
+```javascript
+t.tsUnknownKeyword()
+```
+
+See also `t.isTSUnknownKeyword(node, opts)` and `t.assertTSUnknownKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsVoidKeyword
+```javascript
+t.tsVoidKeyword()
+```
+
+See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
+
+Aliases: `TSType`
 
 ---
 
@@ -2802,10 +2920,10 @@ t.typeAlias(id, typeParameters, right)
 
 See also `t.isTypeAlias(node, opts)` and `t.assertTypeAlias(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `right`: `FlowType` (required)
 
 ---
@@ -2830,16 +2948,29 @@ t.typeCastExpression(expression, typeAnnotation)
 
 See also `t.isTypeCastExpression(node, opts)` and `t.assertTypeCastExpression(node, opts)`.
 
-Aliases: `Flow`, `ExpressionWrapper`, `Expression`
+Aliases: `Expression`, `ExpressionWrapper`, `Flow`
 
  - `expression`: `Expression` (required)
  - `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
+### typeofTypeAnnotation
+```javascript
+t.typeofTypeAnnotation(argument)
+```
+
+See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowType`
+
+ - `argument`: `FlowType` (required)
+
+---
+
 ### typeParameter
 ```javascript
-t.typeParameter(bound, default, variance)
+t.typeParameter()
 ```
 
 See also `t.isTypeParameter(node, opts)` and `t.assertTypeParameter(node, opts)`.
@@ -2849,7 +2980,7 @@ Aliases: `Flow`
  - `bound`: `TypeAnnotation` (default: `null`)
  - `default`: `FlowType` (default: `null`)
  - `variance`: `Variance` (default: `null`)
- - `name`: `string` (default: `null`)
+ - `name`: `string` (default: `""`)
 
 ---
 
@@ -2879,31 +3010,18 @@ Aliases: `Flow`
 
 ---
 
-### typeofTypeAnnotation
-```javascript
-t.typeofTypeAnnotation(argument)
-```
-
-See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`
-
- - `argument`: `FlowType` (required)
-
----
-
 ### unaryExpression
 ```javascript
-t.unaryExpression(operator, argument, prefix)
+t.unaryExpression(operator, argument)
 ```
 
 See also `t.isUnaryExpression(node, opts)` and `t.assertUnaryExpression(node, opts)`.
 
-Aliases: `UnaryLike`, `Expression`
+Aliases: `Expression`, `UnaryLike`
 
  - `operator`: `"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"` (required)
  - `argument`: `Expression` (required)
- - `prefix`: `boolean` (default: `true`)
+ - `prefix`: `boolean` (default: `false`)
 
 ---
 
@@ -2922,7 +3040,7 @@ Aliases: `Flow`, `FlowType`
 
 ### updateExpression
 ```javascript
-t.updateExpression(operator, argument, prefix)
+t.updateExpression(operator, argument)
 ```
 
 See also `t.isUpdateExpression(node, opts)` and `t.assertUpdateExpression(node, opts)`.
@@ -2942,24 +3060,26 @@ t.variableDeclaration(kind, declarations)
 
 See also `t.isVariableDeclaration(node, opts)` and `t.assertVariableDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`
+Aliases: `Declaration`, `Statement`
 
  - `kind`: `"var" | "let" | "const"` (required)
  - `declarations`: `Array<VariableDeclarator>` (required)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
 
 ---
 
 ### variableDeclarator
 ```javascript
-t.variableDeclarator(id, init)
+t.variableDeclarator(id)
 ```
 
 See also `t.isVariableDeclarator(node, opts)` and `t.assertVariableDeclarator(node, opts)`.
 
+Aliases: none
+
  - `id`: `LVal` (required)
  - `init`: `Expression` (default: `null`)
- - `definite`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
 
 ---
 
@@ -2983,8 +3103,7 @@ t.voidTypeAnnotation()
 
 See also `t.isVoidTypeAnnotation(node, opts)` and `t.assertVoidTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -2995,7 +3114,7 @@ t.whileStatement(test, body)
 
 See also `t.isWhileStatement(node, opts)` and `t.assertWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `BlockStatement | Statement` (required)
@@ -3018,7 +3137,7 @@ Aliases: `Statement`
 
 ### yieldExpression
 ```javascript
-t.yieldExpression(argument, delegate)
+t.yieldExpression()
 ```
 
 See also `t.isYieldExpression(node, opts)` and `t.assertYieldExpression(node, opts)`.
@@ -3029,4 +3148,3 @@ Aliases: `Expression`, `Terminatorless`
  - `delegate`: `boolean` (default: `false`)
 
 ---
-

--- a/website/versioned_docs/version-7.4.0/types.md
+++ b/website/versioned_docs/version-7.4.0/types.md
@@ -12,6 +12,7 @@ npm install --save-dev @babel/types
 ```
 
 ## API
+
 ### anyTypeAnnotation
 ```javascript
 t.anyTypeAnnotation()
@@ -19,21 +20,7 @@ t.anyTypeAnnotation()
 
 See also `t.isAnyTypeAnnotation(node, opts)` and `t.assertAnyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
-
----
-
-### arrayExpression
-```javascript
-t.arrayExpression(elements)
-```
-
-See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `elements`: `Array<null | Expression | SpreadElement>` (default: `[]`)
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -48,6 +35,19 @@ Aliases: none
 
 ---
 
+### arrayExpression
+```javascript
+t.arrayExpression()
+```
+
+See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `elements`: `Array<null | Expression | SpreadElement>` (default: `[]`)
+
+---
+
 ### arrayPattern
 ```javascript
 t.arrayPattern(elements)
@@ -55,10 +55,10 @@ t.arrayPattern(elements)
 
 See also `t.isArrayPattern(node, opts)` and `t.assertArrayPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `elements`: `Array<PatternLike>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -78,17 +78,17 @@ Aliases: `Flow`, `FlowType`
 
 ### arrowFunctionExpression
 ```javascript
-t.arrowFunctionExpression(params, body, async)
+t.arrowFunctionExpression(params, body)
 ```
 
 See also `t.isArrowFunctionExpression(node, opts)` and `t.assertArrowFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement | Expression` (required)
  - `async`: `boolean` (default: `false`)
- - `expression`: `boolean` (default: `null`)
+ - `expression`: `boolean` (default: `false`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -117,11 +117,11 @@ t.assignmentPattern(left, right)
 
 See also `t.isAssignmentPattern(node, opts)` and `t.assertAssignmentPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
- - `left`: `Identifier | ObjectPattern | ArrayPattern` (required)
+ - `left`: `Identifier | ObjectPattern | ArrayPattern | MemberExpression` (required)
  - `right`: `Expression` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
@@ -146,7 +146,7 @@ t.bigIntLiteral(value)
 
 See also `t.isBigIntLiteral(node, opts)` and `t.assertBigIntLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -176,19 +176,19 @@ See also `t.isBindExpression(node, opts)` and `t.assertBindExpression(node, opts
 
 Aliases: `Expression`
 
- - `object` (required)
- - `callee` (required)
+ - `object`: `any` (required)
+ - `callee`: `any` (required)
 
 ---
 
 ### blockStatement
 ```javascript
-t.blockStatement(body, directives)
+t.blockStatement(body)
 ```
 
 See also `t.isBlockStatement(node, opts)` and `t.assertBlockStatement(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`, `Statement`
+Aliases: `Block`, `BlockParent`, `Scopable`, `Statement`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
@@ -202,7 +202,7 @@ t.booleanLiteral(value)
 
 See also `t.isBooleanLiteral(node, opts)` and `t.assertBooleanLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `boolean` (required)
 
@@ -228,19 +228,18 @@ t.booleanTypeAnnotation()
 
 See also `t.isBooleanTypeAnnotation(node, opts)` and `t.assertBooleanTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
 ### breakStatement
 ```javascript
-t.breakStatement(label)
+t.breakStatement()
 ```
 
 See also `t.isBreakStatement(node, opts)` and `t.assertBreakStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -256,7 +255,7 @@ See also `t.isCallExpression(node, opts)` and `t.assertCallExpression(node, opts
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -270,9 +269,9 @@ t.catchClause(param, body)
 
 See also `t.isCatchClause(node, opts)` and `t.assertCatchClause(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`
+Aliases: `BlockParent`, `Scopable`
 
- - `param`: `Identifier` (default: `null`)
+ - `param`: `Identifier` (required)
  - `body`: `BlockStatement` (required)
 
 ---
@@ -284,27 +283,29 @@ t.classBody(body)
 
 See also `t.isClassBody(node, opts)` and `t.assertClassBody(node, opts)`.
 
- - `body`: `Array<ClassMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
+Aliases: none
+
+ - `body`: `Array<ClassMethod | ClassPrivateMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
 
 ---
 
 ### classDeclaration
 ```javascript
-t.classDeclaration(id, superClass, body, decorators)
+t.classDeclaration(id, superClass, body)
 ```
 
 See also `t.isClassDeclaration(node, opts)` and `t.assertClassDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
+Aliases: `Class`, `Declaration`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `abstract`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -312,19 +313,19 @@ Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
 
 ### classExpression
 ```javascript
-t.classExpression(id, superClass, body, decorators)
+t.classExpression(id, superClass, body)
 ```
 
 See also `t.isClassExpression(node, opts)` and `t.assertClassExpression(node, opts)`.
 
-Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
+Aliases: `Class`, `Expression`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
+ - `id`: `Identifier` (required)
+ - `superClass`: `Expression` (required)
  - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `[]`)
+ - `mixins`: `any` (default: `null`)
  - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -332,7 +333,7 @@ Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
 
 ### classImplements
 ```javascript
-t.classImplements(id, typeParameters)
+t.classImplements(id)
 ```
 
 See also `t.isClassImplements(node, opts)` and `t.assertClassImplements(node, opts)`.
@@ -346,39 +347,66 @@ Aliases: `Flow`
 
 ### classMethod
 ```javascript
-t.classMethod(kind, key, params, body, computed, static)
+t.classMethod(kind, key, params, body)
 ```
 
 See also `t.isClassMethod(node, opts)` and `t.assertClassMethod(node, opts)`.
 
-Aliases: `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Scopable`
 
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `method`)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
- - `static`: `boolean` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
  - `access`: `"public" | "private" | "protected"` (default: `null`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
+### classPrivateMethod
+```javascript
+t.classPrivateMethod(kind, key, params, body)
+```
+
+See also `t.isClassPrivateMethod(node, opts)` and `t.assertClassPrivateMethod(node, opts)`.
+
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `Private`, `Scopable`
+
+ - `kind`: `"get" | "set" | "method" | "constructor"` (required)
+ - `key`: `PrivateName` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `body`: `BlockStatement` (required)
+ - `static`: `boolean` (default: `false`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `generator`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `returnType`: `any` (default: `null`)
+ - `typeParameters`: `any` (default: `null`)
+
+---
+
 ### classPrivateProperty
 ```javascript
-t.classPrivateProperty(key, value)
+t.classPrivateProperty(key)
 ```
 
 See also `t.isClassPrivateProperty(node, opts)` and `t.assertClassPrivateProperty(node, opts)`.
 
-Aliases: `Property`, `Private`
+Aliases: `Private`, `Property`
 
  - `key`: `PrivateName` (required)
  - `value`: `Expression` (default: `null`)
@@ -387,7 +415,7 @@ Aliases: `Property`, `Private`
 
 ### classProperty
 ```javascript
-t.classProperty(key, value, typeAnnotation, decorators, computed)
+t.classProperty(key)
 ```
 
 See also `t.isClassProperty(node, opts)` and `t.assertClassProperty(node, opts)`.
@@ -397,14 +425,14 @@ Aliases: `Property`
  - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
  - `value`: `Expression` (default: `null`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `computed`: `boolean` (default: `false`)
- - `abstract`: `boolean` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
  - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `definite`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -415,7 +443,7 @@ t.conditionalExpression(test, consequent, alternate)
 
 See also `t.isConditionalExpression(node, opts)` and `t.assertConditionalExpression(node, opts)`.
 
-Aliases: `Expression`, `Conditional`
+Aliases: `Conditional`, `Expression`
 
  - `test`: `Expression` (required)
  - `consequent`: `Expression` (required)
@@ -425,12 +453,12 @@ Aliases: `Expression`, `Conditional`
 
 ### continueStatement
 ```javascript
-t.continueStatement(label)
+t.continueStatement()
 ```
 
 See also `t.isContinueStatement(node, opts)` and `t.assertContinueStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `label`: `Identifier` (default: `null`)
 
@@ -445,7 +473,6 @@ See also `t.isDebuggerStatement(node, opts)` and `t.assertDebuggerStatement(node
 
 Aliases: `Statement`
 
-
 ---
 
 ### declareClass
@@ -455,147 +482,14 @@ t.declareClass(id, typeParameters, extends, body)
 
 See also `t.isDeclareClass(node, opts)` and `t.assertDeclareClass(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareExportAllDeclaration
-```javascript
-t.declareExportAllDeclaration(source)
-```
-
-See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `source`: `StringLiteral` (required)
- - `exportKind`: `["type","value"]` (default: `null`)
-
----
-
-### declareExportDeclaration
-```javascript
-t.declareExportDeclaration(declaration, specifiers, source)
-```
-
-See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `declaration`: `Flow` (default: `null`)
- - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `null`)
- - `source`: `StringLiteral` (default: `null`)
- - `default`: `boolean` (default: `null`)
-
----
-
-### declareFunction
-```javascript
-t.declareFunction(id)
-```
-
-See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `predicate`: `DeclaredPredicate` (default: `null`)
-
----
-
-### declareInterface
-```javascript
-t.declareInterface(id, typeParameters, extends, body)
-```
-
-See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
-
----
-
-### declareModule
-```javascript
-t.declareModule(id, body, kind)
-```
-
-See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `BlockStatement` (required)
- - `kind`: `"CommonJS" | "ES"` (default: `null`)
-
----
-
-### declareModuleExports
-```javascript
-t.declareModuleExports(typeAnnotation)
-```
-
-See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `typeAnnotation`: `TypeAnnotation` (required)
-
----
-
-### declareOpaqueType
-```javascript
-t.declareOpaqueType(id, typeParameters, supertype)
-```
-
-See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
-
----
-
-### declareTypeAlias
-```javascript
-t.declareTypeAlias(id, typeParameters, right)
-```
-
-See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `FlowType` (required)
-
----
-
-### declareVariable
-```javascript
-t.declareVariable(id)
-```
-
-See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
-
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
@@ -612,12 +506,147 @@ Aliases: `Flow`, `FlowPredicate`
 
 ---
 
+### declareExportAllDeclaration
+```javascript
+t.declareExportAllDeclaration(source)
+```
+
+See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `source`: `StringLiteral` (required)
+ - `exportKind`: `"type" | "value"` (default: `null`)
+
+---
+
+### declareExportDeclaration
+```javascript
+t.declareExportDeclaration()
+```
+
+See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `declaration`: `Flow` (default: `null`)
+ - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `[]`)
+ - `source`: `StringLiteral` (default: `null`)
+ - `default`: `boolean` (default: `false`)
+
+---
+
+### declareFunction
+```javascript
+t.declareFunction(id)
+```
+
+See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `predicate`: `DeclaredPredicate` (default: `null`)
+
+---
+
+### declareInterface
+```javascript
+t.declareInterface(id, typeParameters, extends, body)
+```
+
+See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
+ - `body`: `ObjectTypeAnnotation` (required)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
+
+---
+
+### declareModule
+```javascript
+t.declareModule(id, body)
+```
+
+See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `BlockStatement` (required)
+ - `kind`: `"CommonJS" | "ES"` (default: `null`)
+
+---
+
+### declareModuleExports
+```javascript
+t.declareModuleExports(typeAnnotation)
+```
+
+See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `typeAnnotation`: `TypeAnnotation` (required)
+
+---
+
+### declareOpaqueType
+```javascript
+t.declareOpaqueType(id)
+```
+
+See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `supertype`: `FlowType` (default: `null`)
+
+---
+
+### declareTypeAlias
+```javascript
+t.declareTypeAlias(id, typeParameters, right)
+```
+
+See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `right`: `FlowType` (required)
+
+---
+
+### declareVariable
+```javascript
+t.declareVariable(id)
+```
+
+See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
+
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
 ### decorator
 ```javascript
 t.decorator(expression)
 ```
 
 See also `t.isDecorator(node, opts)` and `t.assertDecorator(node, opts)`.
+
+Aliases: none
 
  - `expression`: `Expression` (required)
 
@@ -630,6 +659,8 @@ t.directive(value)
 
 See also `t.isDirective(node, opts)` and `t.assertDirective(node, opts)`.
 
+Aliases: none
+
  - `value`: `DirectiveLiteral` (required)
 
 ---
@@ -640,6 +671,8 @@ t.directiveLiteral(value)
 ```
 
 See also `t.isDirectiveLiteral(node, opts)` and `t.assertDirectiveLiteral(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -665,7 +698,7 @@ t.doWhileStatement(test, body)
 
 See also `t.isDoWhileStatement(node, opts)` and `t.assertDoWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `Statement` (required)
@@ -681,7 +714,6 @@ See also `t.isEmptyStatement(node, opts)` and `t.assertEmptyStatement(node, opts
 
 Aliases: `Statement`
 
-
 ---
 
 ### emptyTypeAnnotation
@@ -691,8 +723,7 @@ t.emptyTypeAnnotation()
 
 See also `t.isEmptyTypeAnnotation(node, opts)` and `t.assertEmptyTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -705,7 +736,6 @@ See also `t.isExistsTypeAnnotation(node, opts)` and `t.assertExistsTypeAnnotatio
 
 Aliases: `Flow`, `FlowType`
 
-
 ---
 
 ### exportAllDeclaration
@@ -715,7 +745,7 @@ t.exportAllDeclaration(source)
 
 See also `t.isExportAllDeclaration(node, opts)` and `t.assertExportAllDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `source`: `StringLiteral` (required)
 
@@ -728,7 +758,7 @@ t.exportDefaultDeclaration(declaration)
 
 See also `t.isExportDefaultDeclaration(node, opts)` and `t.assertExportDefaultDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
  - `declaration`: `FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression` (required)
 
@@ -749,16 +779,17 @@ Aliases: `ModuleSpecifier`
 
 ### exportNamedDeclaration
 ```javascript
-t.exportNamedDeclaration(declaration, specifiers, source)
+t.exportNamedDeclaration(declaration, specifiers)
 ```
 
 See also `t.isExportNamedDeclaration(node, opts)` and `t.assertExportNamedDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
+Aliases: `Declaration`, `ExportDeclaration`, `ModuleDeclaration`, `Statement`
 
- - `declaration`: `Declaration` (default: `null`)
+ - `declaration`: `Declaration` (required)
  - `specifiers`: `Array<ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (default: `null`)
+ - `exportKind`: `"type" | "value"` (default: `null`)
 
 ---
 
@@ -796,7 +827,7 @@ t.expressionStatement(expression)
 
 See also `t.isExpressionStatement(node, opts)` and `t.assertExpressionStatement(node, opts)`.
 
-Aliases: `Statement`, `ExpressionWrapper`
+Aliases: `ExpressionWrapper`, `Statement`
 
  - `expression`: `Expression` (required)
 
@@ -809,9 +840,11 @@ t.file(program, comments, tokens)
 
 See also `t.isFile(node, opts)` and `t.assertFile(node, opts)`.
 
+Aliases: none
+
  - `program`: `Program` (required)
- - `comments` (required)
- - `tokens` (required)
+ - `comments`: `any` (required)
+ - `tokens`: `any` (required)
 
 ---
 
@@ -822,7 +855,7 @@ t.forInStatement(left, right, body)
 
 See also `t.isForInStatement(node, opts)` and `t.assertForInStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -837,7 +870,7 @@ t.forOfStatement(left, right, body)
 
 See also `t.isForOfStatement(node, opts)` and `t.assertForOfStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
+Aliases: `BlockParent`, `For`, `ForXStatement`, `Loop`, `Scopable`, `Statement`
 
  - `left`: `VariableDeclaration | LVal` (required)
  - `right`: `Expression` (required)
@@ -853,30 +886,30 @@ t.forStatement(init, test, update, body)
 
 See also `t.isForStatement(node, opts)` and `t.assertForStatement(node, opts)`.
 
-Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`
+Aliases: `BlockParent`, `For`, `Loop`, `Scopable`, `Statement`
 
- - `init`: `VariableDeclaration | Expression` (default: `null`)
- - `test`: `Expression` (default: `null`)
- - `update`: `Expression` (default: `null`)
+ - `init`: `VariableDeclaration | Expression` (required)
+ - `test`: `Expression` (required)
+ - `update`: `Expression` (required)
  - `body`: `Statement` (required)
 
 ---
 
 ### functionDeclaration
 ```javascript
-t.functionDeclaration(id, params, body, generator, async)
+t.functionDeclaration(id, params, body)
 ```
 
 See also `t.isFunctionDeclaration(node, opts)` and `t.assertFunctionDeclaration(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `Pureish`, `Declaration`
+Aliases: `BlockParent`, `Declaration`, `Function`, `FunctionParent`, `Pureish`, `Scopable`, `Statement`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
@@ -884,15 +917,15 @@ Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `
 
 ### functionExpression
 ```javascript
-t.functionExpression(id, params, body, generator, async)
+t.functionExpression(id, params, body)
 ```
 
 See also `t.isFunctionExpression(node, opts)` and `t.assertFunctionExpression(node, opts)`.
 
-Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
+Aliases: `BlockParent`, `Expression`, `Function`, `FunctionParent`, `Pureish`, `Scopable`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
+ - `id`: `Identifier` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `generator`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
@@ -910,9 +943,9 @@ See also `t.isFunctionTypeAnnotation(node, opts)` and `t.assertFunctionTypeAnnot
 
 Aliases: `Flow`, `FlowType`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `params`: `Array<FunctionTypeParam>` (required)
- - `rest`: `FunctionTypeParam` (default: `null`)
+ - `rest`: `FunctionTypeParam` (required)
  - `returnType`: `FlowType` (required)
 
 ---
@@ -926,22 +959,22 @@ See also `t.isFunctionTypeParam(node, opts)` and `t.assertFunctionTypeParam(node
 
 Aliases: `Flow`
 
- - `name`: `Identifier` (default: `null`)
+ - `name`: `Identifier` (required)
  - `typeAnnotation`: `FlowType` (required)
- - `optional`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
 
 ---
 
 ### genericTypeAnnotation
 ```javascript
-t.genericTypeAnnotation(id, typeParameters)
+t.genericTypeAnnotation(id)
 ```
 
 See also `t.isGenericTypeAnnotation(node, opts)` and `t.assertGenericTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -953,39 +986,27 @@ t.identifier(name)
 
 See also `t.isIdentifier(node, opts)` and `t.assertIdentifier(node, opts)`.
 
-Aliases: `Expression`, `PatternLike`, `LVal`, `TSEntityName`
+Aliases: `Expression`, `LVal`, `PatternLike`, `TSEntityName`
 
  - `name`: `string` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `optional`: `boolean` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
+ - `optional`: `boolean` (default: `false`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### ifStatement
 ```javascript
-t.ifStatement(test, consequent, alternate)
+t.ifStatement(test, consequent)
 ```
 
 See also `t.isIfStatement(node, opts)` and `t.assertIfStatement(node, opts)`.
 
-Aliases: `Statement`, `Conditional`
+Aliases: `Conditional`, `Statement`
 
  - `test`: `Expression` (required)
  - `consequent`: `Statement` (required)
  - `alternate`: `Statement` (default: `null`)
-
----
-
-### import
-```javascript
-t.import()
-```
-
-See also `t.isImport(node, opts)` and `t.assertImport(node, opts)`.
-
-Aliases: `Expression`
-
 
 ---
 
@@ -996,10 +1017,11 @@ t.importDeclaration(specifiers, source)
 
 See also `t.isImportDeclaration(node, opts)` and `t.assertImportDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`, `ModuleDeclaration`
+Aliases: `Declaration`, `ModuleDeclaration`, `Statement`
 
  - `specifiers`: `Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>` (required)
  - `source`: `StringLiteral` (required)
+ - `importKind`: `"type" | "typeof" | "value"` (default: `null`)
 
 ---
 
@@ -1040,7 +1062,7 @@ Aliases: `ModuleSpecifier`
 
  - `local`: `Identifier` (required)
  - `imported`: `Identifier` (required)
- - `importKind`: `null | "type" | "typeof"` (default: `null`)
+ - `importKind`: `"type" | "typeof"` (default: `null`)
 
 ---
 
@@ -1053,7 +1075,6 @@ See also `t.isInferredPredicate(node, opts)` and `t.assertInferredPredicate(node
 
 Aliases: `Flow`, `FlowPredicate`
 
-
 ---
 
 ### interfaceDeclaration
@@ -1063,27 +1084,27 @@ t.interfaceDeclaration(id, typeParameters, extends, body)
 
 See also `t.isInterfaceDeclaration(node, opts)` and `t.assertInterfaceDeclaration(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
+ - `implements`: `Array<ClassImplements>` (default: `[]`)
+ - `mixins`: `Array<InterfaceExtends>` (default: `[]`)
 
 ---
 
 ### interfaceExtends
 ```javascript
-t.interfaceExtends(id, typeParameters)
+t.interfaceExtends(id)
 ```
 
 See also `t.isInterfaceExtends(node, opts)` and `t.assertInterfaceExtends(node, opts)`.
 
 Aliases: `Flow`
 
- - `id`: `Identifier` (required)
+ - `id`: `Identifier | QualifiedTypeIdentifier` (required)
  - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
@@ -1097,7 +1118,7 @@ See also `t.isInterfaceTypeAnnotation(node, opts)` and `t.assertInterfaceTypeAnn
 
 Aliases: `Flow`, `FlowType`
 
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
+ - `extends`: `Array<InterfaceExtends>` (required)
  - `body`: `ObjectTypeAnnotation` (required)
 
 ---
@@ -1108,6 +1129,8 @@ t.interpreterDirective(value)
 ```
 
 See also `t.isInterpreterDirective(node, opts)` and `t.assertInterpreterDirective(node, opts)`.
+
+Aliases: none
 
  - `value`: `string` (required)
 
@@ -1126,62 +1149,61 @@ Aliases: `Flow`, `FlowType`
 
 ---
 
-### jSXAttribute
+### jsxAttribute
 ```javascript
-t.jsxAttribute(name, value)
+t.jsxAttribute(name)
 ```
 
 See also `t.isJSXAttribute(node, opts)` and `t.assertJSXAttribute(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXNamespacedName` (required)
  - `value`: `JSXElement | JSXFragment | StringLiteral | JSXExpressionContainer` (default: `null`)
 
 ---
 
-### jSXClosingElement
+### jsxClosingElement
 ```javascript
 t.jsxClosingElement(name)
 ```
 
 See also `t.isJSXClosingElement(node, opts)` and `t.assertJSXClosingElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
 
 ---
 
-### jSXClosingFragment
+### jsxClosingFragment
 ```javascript
 t.jsxClosingFragment()
 ```
 
 See also `t.isJSXClosingFragment(node, opts)` and `t.assertJSXClosingFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXElement
+### jsxElement
 ```javascript
 t.jsxElement(openingElement, closingElement, children, selfClosing)
 ```
 
 See also `t.isJSXElement(node, opts)` and `t.assertJSXElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingElement`: `JSXOpeningElement` (required)
- - `closingElement`: `JSXClosingElement` (default: `null`)
+ - `closingElement`: `JSXClosingElement` (required)
  - `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
- - `selfClosing` (required)
+ - `selfClosing`: `any` (required)
 
 ---
 
-### jSXEmptyExpression
+### jsxEmptyExpression
 ```javascript
 t.jsxEmptyExpression()
 ```
@@ -1190,30 +1212,29 @@ See also `t.isJSXEmptyExpression(node, opts)` and `t.assertJSXEmptyExpression(no
 
 Aliases: `JSX`
 
-
 ---
 
-### jSXExpressionContainer
+### jsxExpressionContainer
 ```javascript
 t.jsxExpressionContainer(expression)
 ```
 
 See also `t.isJSXExpressionContainer(node, opts)` and `t.assertJSXExpressionContainer(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
- - `expression`: `Expression` (required)
+ - `expression`: `Expression | JSXEmptyExpression` (required)
 
 ---
 
-### jSXFragment
+### jsxFragment
 ```javascript
 t.jsxFragment(openingFragment, closingFragment, children)
 ```
 
 See also `t.isJSXFragment(node, opts)` and `t.assertJSXFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`, `Expression`
+Aliases: `Expression`, `Immutable`, `JSX`
 
  - `openingFragment`: `JSXOpeningFragment` (required)
  - `closingFragment`: `JSXClosingFragment` (required)
@@ -1221,7 +1242,7 @@ Aliases: `JSX`, `Immutable`, `Expression`
 
 ---
 
-### jSXIdentifier
+### jsxIdentifier
 ```javascript
 t.jsxIdentifier(name)
 ```
@@ -1234,7 +1255,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXMemberExpression
+### jsxMemberExpression
 ```javascript
 t.jsxMemberExpression(object, property)
 ```
@@ -1248,7 +1269,7 @@ Aliases: `JSX`
 
 ---
 
-### jSXNamespacedName
+### jsxNamespacedName
 ```javascript
 t.jsxNamespacedName(namespace, name)
 ```
@@ -1262,34 +1283,34 @@ Aliases: `JSX`
 
 ---
 
-### jSXOpeningElement
+### jsxOpeningElement
 ```javascript
-t.jsxOpeningElement(name, attributes, selfClosing)
+t.jsxOpeningElement(name, attributes)
 ```
 
 See also `t.isJSXOpeningElement(node, opts)` and `t.assertJSXOpeningElement(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `name`: `JSXIdentifier | JSXMemberExpression` (required)
  - `attributes`: `Array<JSXAttribute | JSXSpreadAttribute>` (required)
  - `selfClosing`: `boolean` (default: `false`)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
-### jSXOpeningFragment
+### jsxOpeningFragment
 ```javascript
 t.jsxOpeningFragment()
 ```
 
 See also `t.isJSXOpeningFragment(node, opts)` and `t.assertJSXOpeningFragment(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
-
+Aliases: `Immutable`, `JSX`
 
 ---
 
-### jSXSpreadAttribute
+### jsxSpreadAttribute
 ```javascript
 t.jsxSpreadAttribute(argument)
 ```
@@ -1302,27 +1323,27 @@ Aliases: `JSX`
 
 ---
 
-### jSXSpreadChild
+### jsxSpreadChild
 ```javascript
 t.jsxSpreadChild(expression)
 ```
 
 See also `t.isJSXSpreadChild(node, opts)` and `t.assertJSXSpreadChild(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `expression`: `Expression` (required)
 
 ---
 
-### jSXText
+### jsxText
 ```javascript
 t.jsxText(value)
 ```
 
 See also `t.isJSXText(node, opts)` and `t.assertJSXText(node, opts)`.
 
-Aliases: `JSX`, `Immutable`
+Aliases: `Immutable`, `JSX`
 
  - `value`: `string` (required)
 
@@ -1359,7 +1380,7 @@ Aliases: `Binary`, `Expression`
 
 ### memberExpression
 ```javascript
-t.memberExpression(object, property, computed, optional)
+t.memberExpression(object, property)
 ```
 
 See also `t.isMemberExpression(node, opts)` and `t.assertMemberExpression(node, opts)`.
@@ -1394,8 +1415,7 @@ t.mixedTypeAnnotation()
 
 See also `t.isMixedTypeAnnotation(node, opts)` and `t.assertMixedTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1409,7 +1429,7 @@ See also `t.isNewExpression(node, opts)` and `t.assertNewExpression(node, opts)`
 Aliases: `Expression`
 
  - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+ - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>` (required)
  - `optional`: `true | false` (default: `null`)
  - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
  - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
@@ -1423,30 +1443,7 @@ t.noop()
 
 See also `t.isNoop(node, opts)` and `t.assertNoop(node, opts)`.
 
-
----
-
-### nullLiteral
-```javascript
-t.nullLiteral()
-```
-
-See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
-
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
-
-
----
-
-### nullLiteralTypeAnnotation
-```javascript
-t.nullLiteralTypeAnnotation()
-```
-
-See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: none
 
 ---
 
@@ -1460,6 +1457,28 @@ See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnot
 Aliases: `Flow`, `FlowType`
 
  - `typeAnnotation`: `FlowType` (required)
+
+---
+
+### nullLiteral
+```javascript
+t.nullLiteral()
+```
+
+See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
+
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
+
+---
+
+### nullLiteralTypeAnnotation
+```javascript
+t.nullLiteralTypeAnnotation()
+```
+
+See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1483,8 +1502,7 @@ t.numberTypeAnnotation()
 
 See also `t.isNumberTypeAnnotation(node, opts)` and `t.assertNumberTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1495,7 +1513,7 @@ t.numericLiteral(value)
 
 See also `t.isNumericLiteral(node, opts)` and `t.assertNumericLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `number` (required)
 
@@ -1516,20 +1534,20 @@ Aliases: `Expression`
 
 ### objectMethod
 ```javascript
-t.objectMethod(kind, key, params, body, computed)
+t.objectMethod(kind, key, params, body)
 ```
 
 See also `t.isObjectMethod(node, opts)` and `t.assertObjectMethod(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`, `ObjectMember`
+Aliases: `BlockParent`, `Function`, `FunctionParent`, `Method`, `ObjectMember`, `Scopable`, `UserWhitespacable`
 
- - `kind`: `"method" | "get" | "set"` (default: `'method'`)
+ - `kind`: `"method" | "get" | "set"` (required)
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
  - `body`: `BlockStatement` (required)
  - `computed`: `boolean` (default: `false`)
  - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `generator`: `boolean` (default: `false`)
  - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
  - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
@@ -1543,34 +1561,34 @@ t.objectPattern(properties)
 
 See also `t.isObjectPattern(node, opts)` and `t.assertObjectPattern(node, opts)`.
 
-Aliases: `Pattern`, `PatternLike`, `LVal`
+Aliases: `LVal`, `Pattern`, `PatternLike`
 
  - `properties`: `Array<RestElement | ObjectProperty>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### objectProperty
 ```javascript
-t.objectProperty(key, value, computed, shorthand, decorators)
+t.objectProperty(key, value)
 ```
 
 See also `t.isObjectProperty(node, opts)` and `t.assertObjectProperty(node, opts)`.
 
-Aliases: `UserWhitespacable`, `Property`, `ObjectMember`
+Aliases: `ObjectMember`, `Property`, `UserWhitespacable`
 
  - `key`: if computed then `Expression` else `Identifier | Literal` (required)
  - `value`: `Expression | PatternLike` (required)
  - `computed`: `boolean` (default: `false`)
  - `shorthand`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
 
 ---
 
 ### objectTypeAnnotation
 ```javascript
-t.objectTypeAnnotation(properties, indexers, callProperties, internalSlots, exact)
+t.objectTypeAnnotation(properties)
 ```
 
 See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotation(node, opts)`.
@@ -1578,10 +1596,11 @@ See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotatio
 Aliases: `Flow`, `FlowType`
 
  - `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
- - `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
- - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `null`)
- - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `null`)
+ - `indexers`: `Array<ObjectTypeIndexer>` (default: `[]`)
+ - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `[]`)
+ - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `[]`)
  - `exact`: `boolean` (default: `false`)
+ - `inexact`: `boolean` (default: `false`)
 
 ---
 
@@ -1595,24 +1614,24 @@ See also `t.isObjectTypeCallProperty(node, opts)` and `t.assertObjectTypeCallPro
 Aliases: `Flow`, `UserWhitespacable`
 
  - `value`: `FlowType` (required)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
 ### objectTypeIndexer
 ```javascript
-t.objectTypeIndexer(id, key, value, variance)
+t.objectTypeIndexer(id, key, value)
 ```
 
 See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `id`: `Identifier` (default: `null`)
+ - `id`: `Identifier` (required)
  - `key`: `FlowType` (required)
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1635,7 +1654,7 @@ Aliases: `Flow`, `UserWhitespacable`
 
 ### objectTypeProperty
 ```javascript
-t.objectTypeProperty(key, value, variance)
+t.objectTypeProperty(key, value)
 ```
 
 See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(node, opts)`.
@@ -1646,9 +1665,9 @@ Aliases: `Flow`, `UserWhitespacable`
  - `value`: `FlowType` (required)
  - `variance`: `Variance` (default: `null`)
  - `kind`: `"init" | "get" | "set"` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `proto`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `proto`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
 
 ---
 
@@ -1672,11 +1691,11 @@ t.opaqueType(id, typeParameters, supertype, impltype)
 
 See also `t.isOpaqueType(node, opts)` and `t.assertOpaqueType(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
+ - `supertype`: `FlowType` (required)
  - `impltype`: `FlowType` (required)
 
 ---
@@ -1709,7 +1728,7 @@ Aliases: `Expression`
 
  - `object`: `Expression` (required)
  - `property`: `any` (required)
- - `computed`: `boolean` (default: `false`)
+ - `computed`: `boolean` (required)
  - `optional`: `boolean` (required)
 
 ---
@@ -1724,6 +1743,57 @@ See also `t.isParenthesizedExpression(node, opts)` and `t.assertParenthesizedExp
 Aliases: `Expression`, `ExpressionWrapper`
 
  - `expression`: `Expression` (required)
+
+---
+
+### pipelineBareFunction
+```javascript
+t.pipelineBareFunction(callee)
+```
+
+See also `t.isPipelineBareFunction(node, opts)` and `t.assertPipelineBareFunction(node, opts)`.
+
+Aliases: none
+
+ - `callee`: `Expression` (required)
+
+---
+
+### pipelinePrimaryTopicReference
+```javascript
+t.pipelinePrimaryTopicReference()
+```
+
+See also `t.isPipelinePrimaryTopicReference(node, opts)` and `t.assertPipelinePrimaryTopicReference(node, opts)`.
+
+Aliases: `Expression`
+
+---
+
+### pipelineTopicExpression
+```javascript
+t.pipelineTopicExpression(expression)
+```
+
+See also `t.isPipelineTopicExpression(node, opts)` and `t.assertPipelineTopicExpression(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `Expression` (required)
+
+---
+
+### placeholder
+```javascript
+t.placeholder(expectedNode, name)
+```
+
+See also `t.isPlaceholder(node, opts)` and `t.assertPlaceholder(node, opts)`.
+
+Aliases: none
+
+ - `expectedNode`: `"Identifier" | "StringLiteral" | "Expression" | "Statement" | "Declaration" | "BlockStatement" | "ClassBody" | "Pattern"` (required)
+ - `name`: `Identifier` (required)
 
 ---
 
@@ -1742,18 +1812,18 @@ Aliases: `Private`
 
 ### program
 ```javascript
-t.program(body, directives, sourceType, interpreter)
+t.program(body)
 ```
 
 See also `t.isProgram(node, opts)` and `t.assertProgram(node, opts)`.
 
-Aliases: `Scopable`, `BlockParent`, `Block`
+Aliases: `Block`, `BlockParent`, `Scopable`
 
  - `body`: `Array<Statement>` (required)
  - `directives`: `Array<Directive>` (default: `[]`)
  - `sourceType`: `"script" | "module"` (default: `'script'`)
  - `interpreter`: `InterpreterDirective` (default: `null`)
- - `sourceFile`: `string` (default: `null`)
+ - `sourceFile`: `string` (default: `""`)
 
 ---
 
@@ -1773,7 +1843,7 @@ Aliases: `Flow`
 
 ### regExpLiteral
 ```javascript
-t.regExpLiteral(pattern, flags)
+t.regExpLiteral(pattern)
 ```
 
 See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`.
@@ -1781,7 +1851,7 @@ See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`
 Aliases: `Expression`, `Literal`
 
  - `pattern`: `string` (required)
- - `flags`: `string` (default: `''`)
+ - `flags`: `string` (default: `""`)
 
 ---
 
@@ -1795,19 +1865,19 @@ See also `t.isRestElement(node, opts)` and `t.assertRestElement(node, opts)`.
 Aliases: `LVal`, `PatternLike`
 
  - `argument`: `LVal` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
+ - `decorators`: `Array<Decorator>` (default: `[]`)
  - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### returnStatement
 ```javascript
-t.returnStatement(argument)
+t.returnStatement()
 ```
 
 See also `t.isReturnStatement(node, opts)` and `t.assertReturnStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (default: `null`)
 
@@ -1846,7 +1916,7 @@ t.stringLiteral(value)
 
 See also `t.isStringLiteral(node, opts)` and `t.assertStringLiteral(node, opts)`.
 
-Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
+Aliases: `Expression`, `Immutable`, `Literal`, `Pureish`
 
  - `value`: `string` (required)
 
@@ -1872,20 +1942,7 @@ t.stringTypeAnnotation()
 
 See also `t.isStringTypeAnnotation(node, opts)` and `t.assertStringTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
-
----
-
-### super
-```javascript
-t.super()
-```
-
-See also `t.isSuper(node, opts)` and `t.assertSuper(node, opts)`.
-
-Aliases: `Expression`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -1896,7 +1953,9 @@ t.switchCase(test, consequent)
 
 See also `t.isSwitchCase(node, opts)` and `t.assertSwitchCase(node, opts)`.
 
- - `test`: `Expression` (default: `null`)
+Aliases: none
+
+ - `test`: `Expression` (required)
  - `consequent`: `Array<Statement>` (required)
 
 ---
@@ -1908,796 +1967,10 @@ t.switchStatement(discriminant, cases)
 
 See also `t.isSwitchStatement(node, opts)` and `t.assertSwitchStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Scopable`
+Aliases: `BlockParent`, `Scopable`, `Statement`
 
  - `discriminant`: `Expression` (required)
  - `cases`: `Array<SwitchCase>` (required)
-
----
-
-### tSAnyKeyword
-```javascript
-t.tsAnyKeyword()
-```
-
-See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSArrayType
-```javascript
-t.tsArrayType(elementType)
-```
-
-See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementType`: `TSType` (required)
-
----
-
-### tSAsExpression
-```javascript
-t.tsAsExpression(expression, typeAnnotation)
-```
-
-See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSBooleanKeyword
-```javascript
-t.tsBooleanKeyword()
-```
-
-See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSCallSignatureDeclaration
-```javascript
-t.tsCallSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConditionalType
-```javascript
-t.tsConditionalType(checkType, extendsType, trueType, falseType)
-```
-
-See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
-
-Aliases: `TSType`
-
- - `checkType`: `TSType` (required)
- - `extendsType`: `TSType` (required)
- - `trueType`: `TSType` (required)
- - `falseType`: `TSType` (required)
-
----
-
-### tSConstructSignatureDeclaration
-```javascript
-t.tsConstructSignatureDeclaration(typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
-
----
-
-### tSConstructorType
-```javascript
-t.tsConstructorType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSDeclareFunction
-```javascript
-t.tsDeclareFunction(id, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (default: `null`)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
- - `generator`: `boolean` (default: `false`)
-
----
-
-### tSDeclareMethod
-```javascript
-t.tsDeclareMethod(decorators, key, typeParameters, params, returnType)
-```
-
-See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
-
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `access`: `"public" | "private" | "protected"` (default: `null`)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `computed`: `boolean` (default: `false`)
- - `generator`: `boolean` (default: `false`)
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
- - `optional`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
-
----
-
-### tSEnumDeclaration
-```javascript
-t.tsEnumDeclaration(id, members)
-```
-
-See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `members`: `Array<TSEnumMember>` (required)
- - `const`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSEnumMember
-```javascript
-t.tsEnumMember(id, initializer)
-```
-
-See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
-
- - `id`: `Identifier | StringLiteral` (required)
- - `initializer`: `Expression` (default: `null`)
-
----
-
-### tSExportAssignment
-```javascript
-t.tsExportAssignment(expression)
-```
-
-See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
-
-Aliases: `Statement`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSExpressionWithTypeArguments
-```javascript
-t.tsExpressionWithTypeArguments(expression, typeParameters)
-```
-
-See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
-
-Aliases: `TSType`
-
- - `expression`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSExternalModuleReference
-```javascript
-t.tsExternalModuleReference(expression)
-```
-
-See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
-
- - `expression`: `StringLiteral` (required)
-
----
-
-### tSFunctionType
-```javascript
-t.tsFunctionType(typeParameters, typeAnnotation)
-```
-
-See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
-
----
-
-### tSImportEqualsDeclaration
-```javascript
-t.tsImportEqualsDeclaration(id, moduleReference)
-```
-
-See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
- - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
- - `isExport`: `boolean` (default: `null`)
-
----
-
-### tSIndexSignature
-```javascript
-t.tsIndexSignature(parameters, typeAnnotation)
-```
-
-See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `parameters`: `Array<Identifier>` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSIndexedAccessType
-```javascript
-t.tsIndexedAccessType(objectType, indexType)
-```
-
-See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
-
-Aliases: `TSType`
-
- - `objectType`: `TSType` (required)
- - `indexType`: `TSType` (required)
-
----
-
-### tSInferType
-```javascript
-t.tsInferType(typeParameter)
-```
-
-See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
-
----
-
-### tSInterfaceBody
-```javascript
-t.tsInterfaceBody(body)
-```
-
-See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
-
- - `body`: `Array<TSTypeElement>` (required)
-
----
-
-### tSInterfaceDeclaration
-```javascript
-t.tsInterfaceDeclaration(id, typeParameters, extends, body)
-```
-
-See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<TSExpressionWithTypeArguments>` (default: `null`)
- - `body`: `TSInterfaceBody` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSIntersectionType
-```javascript
-t.tsIntersectionType(types)
-```
-
-See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSLiteralType
-```javascript
-t.tsLiteralType(literal)
-```
-
-See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
-
-Aliases: `TSType`
-
- - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
-
----
-
-### tSMappedType
-```javascript
-t.tsMappedType(typeParameter, typeAnnotation)
-```
-
-See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeParameter`: `TSTypeParameter` (required)
- - `typeAnnotation`: `TSType` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSMethodSignature
-```javascript
-t.tsMethodSignature(key, typeParameters, parameters, typeAnnotation)
-```
-
-See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
-
----
-
-### tSModuleBlock
-```javascript
-t.tsModuleBlock(body)
-```
-
-See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
-
- - `body`: `Array<Statement>` (required)
-
----
-
-### tSModuleDeclaration
-```javascript
-t.tsModuleDeclaration(id, body)
-```
-
-See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
- - `declare`: `boolean` (default: `null`)
- - `global`: `boolean` (default: `null`)
-
----
-
-### tSNamespaceExportDeclaration
-```javascript
-t.tsNamespaceExportDeclaration(id)
-```
-
-See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
-
-Aliases: `Statement`
-
- - `id`: `Identifier` (required)
-
----
-
-### tSNeverKeyword
-```javascript
-t.tsNeverKeyword()
-```
-
-See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNonNullExpression
-```javascript
-t.tsNonNullExpression(expression)
-```
-
-See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
-
-Aliases: `Expression`
-
- - `expression`: `Expression` (required)
-
----
-
-### tSNullKeyword
-```javascript
-t.tsNullKeyword()
-```
-
-See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSNumberKeyword
-```javascript
-t.tsNumberKeyword()
-```
-
-See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSObjectKeyword
-```javascript
-t.tsObjectKeyword()
-```
-
-See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSParameterProperty
-```javascript
-t.tsParameterProperty(parameter)
-```
-
-See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
-
-Aliases: `LVal`
-
- - `parameter`: `Identifier | AssignmentPattern` (required)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSParenthesizedType
-```javascript
-t.tsParenthesizedType(typeAnnotation)
-```
-
-See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSPropertySignature
-```javascript
-t.tsPropertySignature(key, typeAnnotation, initializer)
-```
-
-See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
-
-Aliases: `TSTypeElement`
-
- - `key`: `Expression` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
-
----
-
-### tSQualifiedName
-```javascript
-t.tsQualifiedName(left, right)
-```
-
-See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
-
-Aliases: `TSEntityName`
-
- - `left`: `TSEntityName` (required)
- - `right`: `Identifier` (required)
-
----
-
-### tSStringKeyword
-```javascript
-t.tsStringKeyword()
-```
-
-See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSSymbolKeyword
-```javascript
-t.tsSymbolKeyword()
-```
-
-See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSThisType
-```javascript
-t.tsThisType()
-```
-
-See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSTupleType
-```javascript
-t.tsTupleType(elementTypes)
-```
-
-See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
-
-Aliases: `TSType`
-
- - `elementTypes`: `Array<TSType>` (required)
-
----
-
-### tSTypeAliasDeclaration
-```javascript
-t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
-```
-
-See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
-
-Aliases: `Statement`, `Declaration`
-
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSType` (required)
- - `declare`: `boolean` (default: `null`)
-
----
-
-### tSTypeAnnotation
-```javascript
-t.tsTypeAnnotation(typeAnnotation)
-```
-
-See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
-
- - `typeAnnotation`: `TSType` (required)
-
----
-
-### tSTypeAssertion
-```javascript
-t.tsTypeAssertion(typeAnnotation, expression)
-```
-
-See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
-
-Aliases: `Expression`
-
- - `typeAnnotation`: `TSType` (required)
- - `expression`: `Expression` (required)
-
----
-
-### tSTypeLiteral
-```javascript
-t.tsTypeLiteral(members)
-```
-
-See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
-
-Aliases: `TSType`
-
- - `members`: `Array<TSTypeElement>` (required)
-
----
-
-### tSTypeOperator
-```javascript
-t.tsTypeOperator(typeAnnotation)
-```
-
-See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeAnnotation`: `TSType` (required)
- - `operator`: `string` (default: `null`)
-
----
-
-### tSTypeParameter
-```javascript
-t.tsTypeParameter(constraint, default)
-```
-
-See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
-
- - `constraint`: `TSType` (default: `null`)
- - `default`: `TSType` (default: `null`)
- - `name`: `string` (default: `null`)
-
----
-
-### tSTypeParameterDeclaration
-```javascript
-t.tsTypeParameterDeclaration(params)
-```
-
-See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
-
- - `params`: `Array<TSTypeParameter>` (required)
-
----
-
-### tSTypeParameterInstantiation
-```javascript
-t.tsTypeParameterInstantiation(params)
-```
-
-See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
-
- - `params`: `Array<TSType>` (required)
-
----
-
-### tSTypePredicate
-```javascript
-t.tsTypePredicate(parameterName, typeAnnotation)
-```
-
-See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
-
-Aliases: `TSType`
-
- - `parameterName`: `Identifier | TSThisType` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (required)
-
----
-
-### tSTypeQuery
-```javascript
-t.tsTypeQuery(exprName)
-```
-
-See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
-
-Aliases: `TSType`
-
- - `exprName`: `TSEntityName` (required)
-
----
-
-### tSTypeReference
-```javascript
-t.tsTypeReference(typeName, typeParameters)
-```
-
-See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
-
-Aliases: `TSType`
-
- - `typeName`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
-
----
-
-### tSUndefinedKeyword
-```javascript
-t.tsUndefinedKeyword()
-```
-
-See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
-
-Aliases: `TSType`
-
-
----
-
-### tSUnionType
-```javascript
-t.tsUnionType(types)
-```
-
-See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSUnknownType
-```javascript
-t.tsUnknownType(types)
-```
-
-See also `t.isTSUnknownType(node, opts)` and `t.assertTSUnknownType(node, opts)`.
-
-Aliases: `TSType`
-
- - `types`: `Array<TSType>` (required)
-
----
-
-### tSVoidKeyword
-```javascript
-t.tsVoidKeyword()
-```
-
-See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
-
-Aliases: `TSType`
-
 
 ---
 
@@ -2712,17 +1985,21 @@ Aliases: `Expression`
 
  - `tag`: `Expression` (required)
  - `quasi`: `TemplateLiteral` (required)
+ - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### templateElement
 ```javascript
-t.templateElement(value, tail)
+t.templateElement(value)
 ```
 
 See also `t.isTemplateElement(node, opts)` and `t.assertTemplateElement(node, opts)`.
 
- - `value` (required)
+Aliases: none
+
+ - `value`: `{ raw: string` (required)
+ - `cooked`: `string }` (default: `null`)
  - `tail`: `boolean` (default: `false`)
 
 ---
@@ -2750,7 +2027,6 @@ See also `t.isThisExpression(node, opts)` and `t.assertThisExpression(node, opts
 
 Aliases: `Expression`
 
-
 ---
 
 ### thisTypeAnnotation
@@ -2760,8 +2036,7 @@ t.thisTypeAnnotation()
 
 See also `t.isThisTypeAnnotation(node, opts)` and `t.assertThisTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -2772,7 +2047,7 @@ t.throwStatement(argument)
 
 See also `t.isThrowStatement(node, opts)` and `t.assertThrowStatement(node, opts)`.
 
-Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
+Aliases: `CompletionStatement`, `Statement`, `Terminatorless`
 
  - `argument`: `Expression` (required)
 
@@ -2780,7 +2055,7 @@ Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
 ### tryStatement
 ```javascript
-t.tryStatement(block, handler, finalizer)
+t.tryStatement(block)
 ```
 
 See also `t.isTryStatement(node, opts)` and `t.assertTryStatement(node, opts)`.
@@ -2790,6 +2065,838 @@ Aliases: `Statement`
  - `block`: `BlockStatement` (required)
  - `handler`: `CatchClause` (default: `null`)
  - `finalizer`: `BlockStatement` (default: `null`)
+
+---
+
+### tsAnyKeyword
+```javascript
+t.tsAnyKeyword()
+```
+
+See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsArrayType
+```javascript
+t.tsArrayType(elementType)
+```
+
+See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementType`: `TSType` (required)
+
+---
+
+### tsAsExpression
+```javascript
+t.tsAsExpression(expression, typeAnnotation)
+```
+
+See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsBooleanKeyword
+```javascript
+t.tsBooleanKeyword()
+```
+
+See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsCallSignatureDeclaration
+```javascript
+t.tsCallSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConditionalType
+```javascript
+t.tsConditionalType(checkType, extendsType, trueType, falseType)
+```
+
+See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `checkType`: `TSType` (required)
+ - `extendsType`: `TSType` (required)
+ - `trueType`: `TSType` (required)
+ - `falseType`: `TSType` (required)
+
+---
+
+### tsConstructorType
+```javascript
+t.tsConstructorType(typeParameters, parameters)
+```
+
+See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsConstructSignatureDeclaration
+```javascript
+t.tsConstructSignatureDeclaration(typeParameters, parameters)
+```
+
+See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsDeclareFunction
+```javascript
+t.tsDeclareFunction(id, typeParameters, params)
+```
+
+See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+
+---
+
+### tsDeclareMethod
+```javascript
+t.tsDeclareMethod(decorators, key, typeParameters, params)
+```
+
+See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
+
+Aliases: none
+
+ - `decorators`: `Array<Decorator>` (required)
+ - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration | Noop` (required)
+ - `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+ - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+ - `abstract`: `boolean` (default: `false`)
+ - `access`: `"public" | "private" | "protected"` (default: `null`)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `async`: `boolean` (default: `false`)
+ - `computed`: `boolean` (default: `false`)
+ - `generator`: `boolean` (default: `false`)
+ - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+ - `optional`: `boolean` (default: `false`)
+ - `static`: `boolean` (default: `false`)
+
+---
+
+### tsEnumDeclaration
+```javascript
+t.tsEnumDeclaration(id, members)
+```
+
+See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `members`: `Array<TSEnumMember>` (required)
+ - `const`: `boolean` (default: `false`)
+ - `declare`: `boolean` (default: `false`)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsEnumMember
+```javascript
+t.tsEnumMember(id)
+```
+
+See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
+
+Aliases: none
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `initializer`: `Expression` (default: `null`)
+
+---
+
+### tsExportAssignment
+```javascript
+t.tsExportAssignment(expression)
+```
+
+See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
+
+Aliases: `Statement`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsExpressionWithTypeArguments
+```javascript
+t.tsExpressionWithTypeArguments(expression)
+```
+
+See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
+
+Aliases: `TSType`
+
+ - `expression`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsExternalModuleReference
+```javascript
+t.tsExternalModuleReference(expression)
+```
+
+See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
+
+Aliases: none
+
+ - `expression`: `StringLiteral` (required)
+
+---
+
+### tsFunctionType
+```javascript
+t.tsFunctionType(typeParameters, parameters)
+```
+
+See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+
+---
+
+### tsImportEqualsDeclaration
+```javascript
+t.tsImportEqualsDeclaration(id, moduleReference)
+```
+
+See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+ - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
+ - `isExport`: `boolean` (default: `false`)
+
+---
+
+### tsImportType
+```javascript
+t.tsImportType(argument)
+```
+
+See also `t.isTSImportType(node, opts)` and `t.assertTSImportType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `argument`: `StringLiteral` (required)
+ - `qualifier`: `TSEntityName` (default: `null`)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsIndexedAccessType
+```javascript
+t.tsIndexedAccessType(objectType, indexType)
+```
+
+See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `objectType`: `TSType` (required)
+ - `indexType`: `TSType` (required)
+
+---
+
+### tsIndexSignature
+```javascript
+t.tsIndexSignature(parameters)
+```
+
+See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `parameters`: `Array<Identifier>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsInferType
+```javascript
+t.tsInferType(typeParameter)
+```
+
+See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+
+---
+
+### tsInterfaceBody
+```javascript
+t.tsInterfaceBody(body)
+```
+
+See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
+
+Aliases: none
+
+ - `body`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsInterfaceDeclaration
+```javascript
+t.tsInterfaceDeclaration(id, typeParameters, extends, body)
+```
+
+See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `extends`: `Array<TSExpressionWithTypeArguments>` (required)
+ - `body`: `TSInterfaceBody` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsIntersectionType
+```javascript
+t.tsIntersectionType(types)
+```
+
+See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsLiteralType
+```javascript
+t.tsLiteralType(literal)
+```
+
+See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
+
+---
+
+### tsMappedType
+```javascript
+t.tsMappedType(typeParameter)
+```
+
+See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeParameter`: `TSTypeParameter` (required)
+ - `typeAnnotation`: `TSType` (default: `null`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsMethodSignature
+```javascript
+t.tsMethodSignature(key, typeParameters, parameters)
+```
+
+See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `parameters`: `Array<Identifier | RestElement>` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+
+---
+
+### tsModuleBlock
+```javascript
+t.tsModuleBlock(body)
+```
+
+See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
+
+Aliases: `Block`, `BlockParent`, `Scopable`
+
+ - `body`: `Array<Statement>` (required)
+
+---
+
+### tsModuleDeclaration
+```javascript
+t.tsModuleDeclaration(id, body)
+```
+
+See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier | StringLiteral` (required)
+ - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
+ - `declare`: `boolean` (default: `false`)
+ - `global`: `boolean` (default: `false`)
+
+---
+
+### tsNamespaceExportDeclaration
+```javascript
+t.tsNamespaceExportDeclaration(id)
+```
+
+See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
+
+Aliases: `Statement`
+
+ - `id`: `Identifier` (required)
+
+---
+
+### tsNeverKeyword
+```javascript
+t.tsNeverKeyword()
+```
+
+See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNonNullExpression
+```javascript
+t.tsNonNullExpression(expression)
+```
+
+See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
+
+Aliases: `Expression`
+
+ - `expression`: `Expression` (required)
+
+---
+
+### tsNullKeyword
+```javascript
+t.tsNullKeyword()
+```
+
+See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsNumberKeyword
+```javascript
+t.tsNumberKeyword()
+```
+
+See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsObjectKeyword
+```javascript
+t.tsObjectKeyword()
+```
+
+See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsOptionalType
+```javascript
+t.tsOptionalType(typeAnnotation)
+```
+
+See also `t.isTSOptionalType(node, opts)` and `t.assertTSOptionalType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsParameterProperty
+```javascript
+t.tsParameterProperty(parameter)
+```
+
+See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
+
+Aliases: `LVal`
+
+ - `parameter`: `Identifier | AssignmentPattern` (required)
+ - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsParenthesizedType
+```javascript
+t.tsParenthesizedType(typeAnnotation)
+```
+
+See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsPropertySignature
+```javascript
+t.tsPropertySignature(key)
+```
+
+See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
+
+Aliases: `TSTypeElement`
+
+ - `key`: `Expression` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+ - `initializer`: `Expression` (default: `null`)
+ - `computed`: `boolean` (default: `false`)
+ - `optional`: `boolean` (default: `false`)
+ - `readonly`: `boolean` (default: `false`)
+
+---
+
+### tsQualifiedName
+```javascript
+t.tsQualifiedName(left, right)
+```
+
+See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
+
+Aliases: `TSEntityName`
+
+ - `left`: `TSEntityName` (required)
+ - `right`: `Identifier` (required)
+
+---
+
+### tsRestType
+```javascript
+t.tsRestType(typeAnnotation)
+```
+
+See also `t.isTSRestType(node, opts)` and `t.assertTSRestType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsStringKeyword
+```javascript
+t.tsStringKeyword()
+```
+
+See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsSymbolKeyword
+```javascript
+t.tsSymbolKeyword()
+```
+
+See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsThisType
+```javascript
+t.tsThisType()
+```
+
+See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsTupleType
+```javascript
+t.tsTupleType(elementTypes)
+```
+
+See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `elementTypes`: `Array<TSType>` (required)
+
+---
+
+### tsTypeAliasDeclaration
+```javascript
+t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
+```
+
+See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
+
+Aliases: `Declaration`, `Statement`
+
+ - `id`: `Identifier` (required)
+ - `typeParameters`: `TSTypeParameterDeclaration` (required)
+ - `typeAnnotation`: `TSType` (required)
+ - `declare`: `boolean` (default: `false`)
+
+---
+
+### tsTypeAnnotation
+```javascript
+t.tsTypeAnnotation(typeAnnotation)
+```
+
+See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
+
+Aliases: none
+
+ - `typeAnnotation`: `TSType` (required)
+
+---
+
+### tsTypeAssertion
+```javascript
+t.tsTypeAssertion(typeAnnotation, expression)
+```
+
+See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
+
+Aliases: `Expression`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `expression`: `Expression` (required)
+
+---
+
+### tsTypeLiteral
+```javascript
+t.tsTypeLiteral(members)
+```
+
+See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
+
+Aliases: `TSType`
+
+ - `members`: `Array<TSTypeElement>` (required)
+
+---
+
+### tsTypeOperator
+```javascript
+t.tsTypeOperator(typeAnnotation)
+```
+
+See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeAnnotation`: `TSType` (required)
+ - `operator`: `string` (default: `""`)
+
+---
+
+### tsTypeParameter
+```javascript
+t.tsTypeParameter()
+```
+
+See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
+
+Aliases: none
+
+ - `constraint`: `TSType` (default: `null`)
+ - `default`: `TSType` (default: `null`)
+ - `name`: `string` (default: `""`)
+
+---
+
+### tsTypeParameterDeclaration
+```javascript
+t.tsTypeParameterDeclaration(params)
+```
+
+See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSTypeParameter>` (required)
+
+---
+
+### tsTypeParameterInstantiation
+```javascript
+t.tsTypeParameterInstantiation(params)
+```
+
+See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
+
+Aliases: none
+
+ - `params`: `Array<TSType>` (required)
+
+---
+
+### tsTypePredicate
+```javascript
+t.tsTypePredicate(parameterName, typeAnnotation)
+```
+
+See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
+
+Aliases: `TSType`
+
+ - `parameterName`: `Identifier | TSThisType` (required)
+ - `typeAnnotation`: `TSTypeAnnotation` (required)
+
+---
+
+### tsTypeQuery
+```javascript
+t.tsTypeQuery(exprName)
+```
+
+See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
+
+Aliases: `TSType`
+
+ - `exprName`: `TSEntityName | TSImportType` (required)
+
+---
+
+### tsTypeReference
+```javascript
+t.tsTypeReference(typeName)
+```
+
+See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
+
+Aliases: `TSType`
+
+ - `typeName`: `TSEntityName` (required)
+ - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+
+---
+
+### tsUndefinedKeyword
+```javascript
+t.tsUndefinedKeyword()
+```
+
+See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsUnionType
+```javascript
+t.tsUnionType(types)
+```
+
+See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
+
+Aliases: `TSType`
+
+ - `types`: `Array<TSType>` (required)
+
+---
+
+### tsUnknownKeyword
+```javascript
+t.tsUnknownKeyword()
+```
+
+See also `t.isTSUnknownKeyword(node, opts)` and `t.assertTSUnknownKeyword(node, opts)`.
+
+Aliases: `TSType`
+
+---
+
+### tsVoidKeyword
+```javascript
+t.tsVoidKeyword()
+```
+
+See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
+
+Aliases: `TSType`
 
 ---
 
@@ -2813,10 +2920,10 @@ t.typeAlias(id, typeParameters, right)
 
 See also `t.isTypeAlias(node, opts)` and `t.assertTypeAlias(node, opts)`.
 
-Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
+Aliases: `Declaration`, `Flow`, `FlowDeclaration`, `Statement`
 
  - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+ - `typeParameters`: `TypeParameterDeclaration` (required)
  - `right`: `FlowType` (required)
 
 ---
@@ -2841,16 +2948,29 @@ t.typeCastExpression(expression, typeAnnotation)
 
 See also `t.isTypeCastExpression(node, opts)` and `t.assertTypeCastExpression(node, opts)`.
 
-Aliases: `Flow`, `ExpressionWrapper`, `Expression`
+Aliases: `Expression`, `ExpressionWrapper`, `Flow`
 
  - `expression`: `Expression` (required)
  - `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
+### typeofTypeAnnotation
+```javascript
+t.typeofTypeAnnotation(argument)
+```
+
+See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
+
+Aliases: `Flow`, `FlowType`
+
+ - `argument`: `FlowType` (required)
+
+---
+
 ### typeParameter
 ```javascript
-t.typeParameter(bound, default, variance)
+t.typeParameter()
 ```
 
 See also `t.isTypeParameter(node, opts)` and `t.assertTypeParameter(node, opts)`.
@@ -2860,7 +2980,7 @@ Aliases: `Flow`
  - `bound`: `TypeAnnotation` (default: `null`)
  - `default`: `FlowType` (default: `null`)
  - `variance`: `Variance` (default: `null`)
- - `name`: `string` (default: `null`)
+ - `name`: `string` (default: `""`)
 
 ---
 
@@ -2890,31 +3010,18 @@ Aliases: `Flow`
 
 ---
 
-### typeofTypeAnnotation
-```javascript
-t.typeofTypeAnnotation(argument)
-```
-
-See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
-
-Aliases: `Flow`, `FlowType`
-
- - `argument`: `FlowType` (required)
-
----
-
 ### unaryExpression
 ```javascript
-t.unaryExpression(operator, argument, prefix)
+t.unaryExpression(operator, argument)
 ```
 
 See also `t.isUnaryExpression(node, opts)` and `t.assertUnaryExpression(node, opts)`.
 
-Aliases: `UnaryLike`, `Expression`
+Aliases: `Expression`, `UnaryLike`
 
  - `operator`: `"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"` (required)
  - `argument`: `Expression` (required)
- - `prefix`: `boolean` (default: `true`)
+ - `prefix`: `boolean` (default: `false`)
 
 ---
 
@@ -2933,7 +3040,7 @@ Aliases: `Flow`, `FlowType`
 
 ### updateExpression
 ```javascript
-t.updateExpression(operator, argument, prefix)
+t.updateExpression(operator, argument)
 ```
 
 See also `t.isUpdateExpression(node, opts)` and `t.assertUpdateExpression(node, opts)`.
@@ -2953,24 +3060,26 @@ t.variableDeclaration(kind, declarations)
 
 See also `t.isVariableDeclaration(node, opts)` and `t.assertVariableDeclaration(node, opts)`.
 
-Aliases: `Statement`, `Declaration`
+Aliases: `Declaration`, `Statement`
 
  - `kind`: `"var" | "let" | "const"` (required)
  - `declarations`: `Array<VariableDeclarator>` (required)
- - `declare`: `boolean` (default: `null`)
+ - `declare`: `boolean` (default: `false`)
 
 ---
 
 ### variableDeclarator
 ```javascript
-t.variableDeclarator(id, init)
+t.variableDeclarator(id)
 ```
 
 See also `t.isVariableDeclarator(node, opts)` and `t.assertVariableDeclarator(node, opts)`.
 
+Aliases: none
+
  - `id`: `LVal` (required)
  - `init`: `Expression` (default: `null`)
- - `definite`: `boolean` (default: `null`)
+ - `definite`: `boolean` (default: `false`)
 
 ---
 
@@ -2994,8 +3103,7 @@ t.voidTypeAnnotation()
 
 See also `t.isVoidTypeAnnotation(node, opts)` and `t.assertVoidTypeAnnotation(node, opts)`.
 
-Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
-
+Aliases: `Flow`, `FlowBaseAnnotation`, `FlowType`
 
 ---
 
@@ -3006,7 +3114,7 @@ t.whileStatement(test, body)
 
 See also `t.isWhileStatement(node, opts)` and `t.assertWhileStatement(node, opts)`.
 
-Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
+Aliases: `BlockParent`, `Loop`, `Scopable`, `Statement`, `While`
 
  - `test`: `Expression` (required)
  - `body`: `BlockStatement | Statement` (required)
@@ -3029,7 +3137,7 @@ Aliases: `Statement`
 
 ### yieldExpression
 ```javascript
-t.yieldExpression(argument, delegate)
+t.yieldExpression()
 ```
 
 See also `t.isYieldExpression(node, opts)` and `t.assertYieldExpression(node, opts)`.
@@ -3040,4 +3148,3 @@ Aliases: `Expression`, `Terminatorless`
  - `delegate`: `boolean` (default: `false`)
 
 ---
-


### PR DESCRIPTION
I ended up writing a script to generate this documentation based of type definitions found in `node_modules/@babel/types/lib/index.d.ts`. It does so by looking through the properties of the export from `@babel/types`, seeing which functions (when turned to string, which is not a great idea) includes a call to `_builder.default`, then it looks into the `index.d.ts` file above, yet again using Regex and string matching, to extract the types.

This script is run by another script `scripts/generate-docs-types-versions.js` which creates a directory for each version, installs that version and generates the `types.md` using `scripts/generate-docs-types.js`. It's not exactly pretty, but it works.

I tried to keep line spacing and such similar to keep the diff as small as possible.

I'm not sure what to do with the version doc for version-6.26.3, as I'm not able to locate the babel package for that on npm.

## Notable changes
- Call signature example only includes required arguments
- Alphabetical ordering for the functions and aliases
- Always includes `Aliases`, even if there are none.
- Assumed default values based on type
  - Array<any> (default: `[]`)
  - boolean (default: `false`)
  - string (default: `""`)
  - default (default: `null`)
- `t.tsUnknownType(types)` "renamed" `t.tsUnknownKeyword()`, fixes #2079 
- `t.import()` has disappeared. 
