### PR TITLE
Update ES6 minifier recommendation note

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -390,11 +390,8 @@ environment(s). Enable this option if you want to force running _all_
 transforms, which is useful if the output will be run through UglifyJS or an
 environment that only supports ES5.
 
-> NOTE: Uglify has a work-in-progress "Harmony" branch to address the lack of
-> ES6 support, but it is not yet stable. You can follow its progress in
-> [UglifyJS2 issue #448](https://github.com/mishoo/UglifyJS2/issues/448). If you
-> require an alternative minifier which _does_ support ES6 syntax, we recommend
-> using [babel-minify](preset-minify.md).
+> NOTE: If you require an alternative minifier which _does_ support ES6 syntax, 
+> we recommend [babel-minify](preset-minify.md) or [Terser](https://www.npmjs.com/package/terser).
 
 ### `configPath`
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -391,7 +391,7 @@ transforms, which is useful if the output will be run through UglifyJS or an
 environment that only supports ES5.
 
 > NOTE: If you require an alternative minifier which _does_ support ES6 syntax, 
-> we recommend [babel-minify](preset-minify.md) or [Terser](https://www.npmjs.com/package/terser).
+> we recommend [Terser](https://www.npmjs.com/package/terser) or [babel-minify](preset-minify.md).
 
 ### `configPath`
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -391,7 +391,7 @@ transforms, which is useful if the output will be run through UglifyJS or an
 environment that only supports ES5.
 
 > NOTE: If you require an alternative minifier which _does_ support ES6 syntax, 
-> we recommend [Terser](https://www.npmjs.com/package/terser) or [babel-minify](preset-minify.md).
+> we recommend [Terser](https://www.npmjs.com/package/terser).
 
 ### `configPath`
 


### PR DESCRIPTION
The note is outdated, because the branch that supports ES6+ in UglifyJS is not maintained anymore, which means UglifyJS will never be compatible with ES6+. 
But there's a fork called `Terser` that supports ES6+ and acts as a successor of UglifyJS.