### PR TITLE
docs(v7-migration): add core-js v3 path for importing `flatMap`

### DIFF
--- a/docs/v7-migration.md
+++ b/docs/v7-migration.md
@@ -60,7 +60,11 @@ If you want to use proposals, you will need to import these independently. You s
 e.g.
 
 ```js
+// for core-js v2:
 import "core-js/fn/array/flat-map";
+
+// for core-js v3:
+import "core-js/features/array/flat-map";
 ```
 
 Below is a list of Stage < 3 proposal polyfills in `core-js` v2.


### PR DESCRIPTION
The `@latest` version of core-js is now v3, which has a different path to specific polyfills than v2.