### PR TITLE
Simple sugar typo fix

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -82,7 +82,7 @@ square(2, 4, 7.5, 8, 11.5, 21); // returns: [4, 16, 56.25, 64, 132.25, 441]
 
 ### Classes
 
-ES2015 classes are a simple sugar over the prototype-based OO pattern.  Having a
+ES2015 classes are syntactic sugar over the prototype-based OO pattern.  Having a
 single convenient declarative form makes class patterns easier to use, and
 encourages interoperability.  Classes support prototype-based inheritance, super
 calls, instance and static methods and constructors.

--- a/website/versioned_docs/version-6.26.3/learn.md
+++ b/website/versioned_docs/version-6.26.3/learn.md
@@ -83,7 +83,7 @@ square(2, 4, 7.5, 8, 11.5, 21); // returns: [4, 16, 56.25, 64, 132.25, 441]
 
 ### Classes
 
-ES2015 classes are a simple sugar over the prototype-based OO pattern.  Having a
+ES2015 classes are syntactic sugar over the prototype-based OO pattern.  Having a
 single convenient declarative form makes class patterns easier to use, and
 encourages interoperability.  Classes support prototype-based inheritance, super
 calls, instance and static methods and constructors.

--- a/website/versioned_docs/version-7.0.0/learn.md
+++ b/website/versioned_docs/version-7.0.0/learn.md
@@ -83,7 +83,7 @@ square(2, 4, 7.5, 8, 11.5, 21); // returns: [4, 16, 56.25, 64, 132.25, 441]
 
 ### Classes
 
-ES2015 classes are a simple sugar over the prototype-based OO pattern.  Having a
+ES2015 classes are syntactic sugar over the prototype-based OO pattern.  Having a
 single convenient declarative form makes class patterns easier to use, and
 encourages interoperability.  Classes support prototype-based inheritance, super
 calls, instance and static methods and constructors.


### PR DESCRIPTION
This PR fixes a minor typo in the documentation for Classes ([see here](https://babeljs.io/docs/en/learn/#classes)) where "simple sugar" was used instead of [syntactic sugar](https://en.wikipedia.org/wiki/Syntactic_sugar).