### PR TITLE
fix: guess file extension from preset

### DIFF
--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -6,7 +6,12 @@ declare var prettier: any;
 declare var prettierPlugins: any;
 
 import Transitions from "./Transitions";
-import type { CompileConfig, Transition } from "./types";
+import type {
+  BabelPresets,
+  CompileConfig,
+  Transition,
+  SupportedFileExtension,
+} from "./types";
 
 type Return = {
   compiled: ?string,
@@ -31,6 +36,17 @@ const DEFAULT_PRETTIER_CONFIG = {
   trailingComma: "none",
   useTabs: false,
 };
+
+function guessFileExtension(presets: BabelPresets): SupportedFileExtension {
+  let ext = ".js";
+  if (presets.includes("typescript")) {
+    ext = ".ts";
+  }
+  if (presets.includes("react")) {
+    ext = (ext + "x": any);
+  }
+  return (ext: SupportedFileExtension);
+}
 
 export default function compile(code: string, config: CompileConfig): Return {
   const { envConfig, presetsOptions } = config;
@@ -89,7 +105,7 @@ export default function compile(code: string, config: CompileConfig): Return {
   try {
     const babelConfig = {
       babelrc: false,
-      filename: "repl",
+      filename: "repl" + guessFileExtension(config.presets),
       sourceMap: config.sourceMap,
 
       presets: config.presets.map(preset => {

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -141,3 +141,5 @@ export type Transition = {
   visitorType: string,
   currentNode?: string,
 };
+
+export type SupportedFileExtension = ".js" | ".jsx" | ".ts" | ".tsx";


### PR DESCRIPTION
In this PR we guess the REPL file extension from the loaded presets. By doing so we could apply proper TypeScript transform when `typescript` preset is enabled.

Compared to #2019, this PR does _not_ introduce `filename` option as we don't output error message that will point to `filename` configuration when parsing a TypeScript without transform enabled. Also we are not going to expose `filename` option in a such limited UI space.

Manually tested on local build.

Closes #2019 
Fixes #1666 