### PR TITLE
Fix uncleared floating videos

### DIFF
--- a/website/static/css/video.css
+++ b/website/static/css/video.css
@@ -20,7 +20,7 @@
   margin-right: 5px;
   box-sizing: border-box;
   float: left;
-  width: 32.3%;
+  width: calc((100% / 3) - 10px);
   margin-bottom: 2rem;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 0.25rem;
@@ -57,10 +57,20 @@
   margin-bottom: 0;
 }
 
+@media screen and (min-width: 993px) {
+  .babel-videos:nth-of-type(3n+1) {
+    clear: left;
+  }
+}
+
 @media screen and (max-width: 992px) {
   .babel-videos {
     box-sizing: border-box;
-    width: 48.6%;
+    width: calc(50% - 10px);
+  }
+
+  .babel-videos:nth-of-type(2n+1) {
+    clear: left;
   }
 }
 
@@ -70,5 +80,9 @@
     width: 100%;
     margin-left: 0;
     margin-right: 0;
+  }
+
+  .babel-videos:nth-of-type(2n+1) {
+    clear: none;
   }
 }


### PR DESCRIPTION
### Stuff done

- Clear floated videos responsively
- Uses `calc` to define the video container's widths instead of hardcoding.

### Screenshots

#### Threee column layout

##### Before

![image](https://user-images.githubusercontent.com/7039523/68271295-14761500-002e-11ea-8b7c-20103550c1cb.png)

##### After

![image](https://user-images.githubusercontent.com/7039523/68271359-37a0c480-002e-11ea-8a9f-ed872614fe84.png)

#### Two column layout

##### Before

![image](https://user-images.githubusercontent.com/7039523/68271515-c3b2ec00-002e-11ea-8134-dfde58503718.png)

##### After

![image](https://user-images.githubusercontent.com/7039523/68271537-d75e5280-002e-11ea-9828-8463e948e268.png)

/cc @nicolo-ribaudo 