### PR TITLE
Enable `darcula` theme in REPL when dark colour scheme is preferred

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ website/i18n/*
 website/translated_docs
 
 package-lock.json
+/.idea

--- a/js/repl/CodeMirror.js
+++ b/js/repl/CodeMirror.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { injectGlobal } from "emotion";
+import { injectGlobal, css } from "emotion";
 import CodeMirror from "codemirror";
 import React from "react";
 import { colors } from "./styles";
@@ -134,9 +134,7 @@ injectGlobal({
     width: "100% !important",
     "-webkit-overflow-scrolling": "touch",
   },
-  ".CodeMirror pre.CodeMirror-placeholder.CodeMirror-line-like": {
-    color: preferDarkColorScheme()
-      ? colors.foregroundDark
-      : colors.foregroundLight,
-  },
+  ".CodeMirror pre.CodeMirror-placeholder.CodeMirror-line-like": css({
+    color: colors.foregroundLight,
+  }),
 });

--- a/js/repl/CodeMirror.js
+++ b/js/repl/CodeMirror.js
@@ -4,6 +4,7 @@ import { injectGlobal } from "emotion";
 import CodeMirror from "codemirror";
 import React from "react";
 import { colors } from "./styles";
+import { preferDarkColorScheme } from "./Utils";
 
 const DEFAULT_CODE_MIRROR_OPTIONS = {
   autoCloseBrackets: true,
@@ -14,6 +15,7 @@ const DEFAULT_CODE_MIRROR_OPTIONS = {
   showCursorWhenSelecting: true,
   styleActiveLine: true,
   tabWidth: 2,
+  theme: preferDarkColorScheme() ? "darcula" : "default",
 };
 
 type Props = {
@@ -132,7 +134,9 @@ injectGlobal({
     width: "100% !important",
     "-webkit-overflow-scrolling": "touch",
   },
-  ".CodeMirror-lines pre.CodeMirror-placeholder": {
-    color: colors.foregroundLight,
+  ".CodeMirror pre.CodeMirror-placeholder.CodeMirror-line-like": {
+    color: preferDarkColorScheme()
+      ? colors.foregroundDark
+      : colors.foregroundLight,
   },
 });

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -947,7 +947,7 @@ const styles = {
   }),
   optionSelect: css({
     appearance: "none",
-    backgroundColor: "#2D3035",
+    backgroundColor: colors.selectBackground,
     // eslint-disable-next-line
     backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='${
       colors.inverseForegroundLight
@@ -960,7 +960,7 @@ const styles = {
     transition: "all 0.25s ease-in",
 
     "&:hover": {
-      backgroundColor: "#32353A",
+      backgroundColor: colors.selectHover,
     },
 
     "&::-ms-expand": {
@@ -1009,11 +1009,11 @@ const styles = {
   }),
   envPresetLabel: css({
     flex: 1,
-    color: "#FFF",
+    color: colors.inverseForeground,
 
     ":hover": {
       textDecoration: "none",
-      color: "#FFF",
+      color: colors.inverseForeground,
     },
   }),
   envPresetSelect: css({

--- a/js/repl/Utils.js
+++ b/js/repl/Utils.js
@@ -32,3 +32,10 @@ export function joinListEnglish(list: string[]): string {
   if (list.length === 1) return list[0];
   return `${list.slice(0, -1).join(", ")} and ${list[list.length - 1]}`;
 }
+
+export function preferDarkColorScheme(): boolean {
+  return (
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme:dark)").matches
+  );
+}

--- a/js/repl/styles.js
+++ b/js/repl/styles.js
@@ -7,6 +7,7 @@ const colors = {
   errorForeground: "#ff0000",
 
   foregroundLight: "#aaaaaa",
+  foregroundDark: "#777777",
 
   // Inspired by: Nuclide's "One Dark" theme
   inverseBackground: "#21252b",

--- a/js/repl/styles.js
+++ b/js/repl/styles.js
@@ -1,25 +1,46 @@
 // @flow
+import { preferDarkColorScheme } from "./Utils";
 
-const colors = {
+const lightColors = {
   // Inspired by: Chrome's console.error() colors
   errorBackground: "#fff0f0",
   errorBorder: "#ffd6d6",
   errorForeground: "#ff0000",
 
   foregroundLight: "#aaaaaa",
-  foregroundDark: "#777777",
 
   // Inspired by: Nuclide's "One Dark" theme
   inverseBackground: "#21252b",
   inverseBackgroundDark: "#181a1f",
   inverseBackgroundLight: "#292d36",
-  inverseForeground: "#ffffff",
+  inverseForeground: "#faffff",
   inverseForegroundLight: "#9da5b4",
 
   // Inspired by: Chrome's console.warn() colors
   infoBackground: "#fffbe5",
   infoBorder: "#fff5c2",
   infoForeground: "#5c3c00",
+
+  selectBackground: "#2D3035",
+  selectHover: "#32353A",
+
+  textareaForeground: "#323330",
+};
+
+const darkColors = {
+  ...lightColors,
+
+  foregroundLight: "#777777",
+
+  inverseBackground: "#2C3138",
+  inverseBackgroundDark: "#1D2025",
+  inverseBackgroundLight: "#363942",
+
+  inverseForegroundLight: "#838C9B",
+  inverseForeground: "#A7ABB4",
+
+  selectBackground: "#3F4248",
+  selectHover: "#43474D",
 
   textareaForeground: "#323330",
 };
@@ -31,5 +52,6 @@ const media = {
   mediumAndUp: "@media(min-width: 601px)",
   large: "@media(min-width: 1001px)",
 };
+const colors = preferDarkColorScheme() ? darkColors : lightColors;
 
 export { colors, media };

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@babel/generator": "^7.4.4",
-    "codemirror": "5.30.0",
+    "codemirror": "5.49.2",
     "core-js": "^3.0.1",
     "emotion": "^9.1.3",
     "lodash.camelcase": "^4.3.0",

--- a/website/pages/en/repl.js
+++ b/website/pages/en/repl.js
@@ -1,21 +1,24 @@
 "use strict";
 
 const React = require("react");
-const styles = ["https://unpkg.com/codemirror@5.30.0/lib/codemirror.css"];
+const styles = [
+  "https://unpkg.com/codemirror@5.49.2/lib/codemirror.css",
+  "https://unpkg.com/codemirror@5.49.2/theme/darcula.css",
+];
 
 const scripts = [
   "https://unpkg.com/react@16.3.2/umd/react.production.min.js",
   "https://unpkg.com/react-dom@16.3.2/umd/react-dom.production.min.js",
-  "https://unpkg.com/codemirror@5.30.0/lib/codemirror.js",
-  "https://unpkg.com/codemirror@5.30.0/mode/javascript/javascript.js",
-  "https://unpkg.com/codemirror@5.30.0/mode/xml/xml.js",
-  "https://unpkg.com/codemirror@5.30.0/mode/jsx/jsx.js",
-  "https://unpkg.com/codemirror@5.30.0/keymap/sublime.js",
-  "https://unpkg.com/codemirror@5.30.0/addon/comment/comment.js",
-  "https://unpkg.com/codemirror@5.30.0/addon/display/placeholder.js",
-  "https://unpkg.com/codemirror@5.30.0/addon/edit/matchbrackets.js",
-  "https://unpkg.com/codemirror@5.30.0/addon/search/searchcursor.js",
-  "https://unpkg.com/codemirror@5.30.0/addon/selection/active-line.js",
+  "https://unpkg.com/codemirror@5.49.2/lib/codemirror.js",
+  "https://unpkg.com/codemirror@5.49.2/mode/javascript/javascript.js",
+  "https://unpkg.com/codemirror@5.49.2/mode/xml/xml.js",
+  "https://unpkg.com/codemirror@5.49.2/mode/jsx/jsx.js",
+  "https://unpkg.com/codemirror@5.49.2/keymap/sublime.js",
+  "https://unpkg.com/codemirror@5.49.2/addon/comment/comment.js",
+  "https://unpkg.com/codemirror@5.49.2/addon/display/placeholder.js",
+  "https://unpkg.com/codemirror@5.49.2/addon/edit/matchbrackets.js",
+  "https://unpkg.com/codemirror@5.49.2/addon/search/searchcursor.js",
+  "https://unpkg.com/codemirror@5.49.2/addon/selection/active-line.js",
   "https://unpkg.com/lz-string@1.4.4/libs/base64-string.js",
   "https://unpkg.com/lz-string@1.4.4/libs/lz-string.min.js",
   "/js/build/repl.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,10 +1853,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@5.30.0:
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.30.0.tgz#86e57dd5ea5535acbcf9c720797b4cefe05b5a70"
-  integrity sha512-pfJV/7fLAUUenuGK3iANkQu1AxNLuWpeF7HV6YFDjSBMp53F8FTa2F6oPs9NKAHFweT2m08usmXUIA+7sohdew==
+codemirror@5.49.2:
+  version "5.49.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.49.2.tgz#c84fdaf11b19803f828b0c67060c7bc6d154ccad"
+  integrity sha512-dwJ2HRPHm8w51WB5YTF9J7m6Z5dtkqbU9ntMZ1dqXyFB9IpjoUFDj80ahRVEoVanfIp6pfASJbOlbWdEf8FOzQ==
 
 collapse-white-space@^1.0.2, collapse-white-space@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
In this PR we bump CodeMirror to 5.49.2 so that the dark theme `darcula` is included. When the UA supports `(prefers-color-scheme)` media query, we will enable `darcula` theme in the CodeMirror panel, otherwise it will fallback to the `default` theme.

I am open to other [dark themes](https://codemirror.net/demo/theme.html#default) as long as we can reach consensus. In this PR `darcula` is chosen because it is the default dark scheme available in WebStorm.

Screenshots:
![image](https://user-images.githubusercontent.com/3607926/69379269-2e466780-0c7e-11ea-9aef-512c2e33fb08.png)

