### PR TITLE
docs(@babel/parser): Document createParenthesizedExpressions option.

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -55,7 +55,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression` AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets `extra.parenthesized` on the expression nodes. When this option is set to `true`, `ParenthesizedExpression` AST nodes are created instead.
 
 - **errorRecovery**: By default, Babel always throws an error when it finds some invalid
   code. When this option is set to `true`, it will store the parsing error and try to continue

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -55,7 +55,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression` AST nodes.
 
 - **errorRecovery**: By default, Babel always throws an error when it finds some invalid
   code. When this option is set to `true`, it will store the parsing error and try to continue

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -55,6 +55,8 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+
 - **errorRecovery**: By default, Babel always throws an error when it finds some invalid
   code. When this option is set to `true`, it will store the parsing error and try to continue
   parsing the invalid input file.

--- a/website/versioned_docs/version-7.4.0/parser.md
+++ b/website/versioned_docs/version-7.4.0/parser.md
@@ -47,7 +47,7 @@ mind. When in doubt, use `.parse()`.
   outside of class and object methods. Set this to `true` to accept such
   code.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.

--- a/website/versioned_docs/version-7.4.0/parser.md
+++ b/website/versioned_docs/version-7.4.0/parser.md
@@ -47,6 +47,8 @@ mind. When in doubt, use `.parse()`.
   outside of class and object methods. Set this to `true` to accept such
   code.
 
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.
 

--- a/website/versioned_docs/version-7.4.0/parser.md
+++ b/website/versioned_docs/version-7.4.0/parser.md
@@ -47,7 +47,7 @@ mind. When in doubt, use `.parse()`.
   outside of class and object methods. Set this to `true` to accept such
   code.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets `extra.parenthesized` on the expression nodes. When this option is set to `true`, `ParenthesizedExpression` AST nodes are created instead.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.

--- a/website/versioned_docs/version-7.5.0/parser.md
+++ b/website/versioned_docs/version-7.5.0/parser.md
@@ -55,6 +55,8 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.
 

--- a/website/versioned_docs/version-7.5.0/parser.md
+++ b/website/versioned_docs/version-7.5.0/parser.md
@@ -55,7 +55,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets `extra.parenthesized` on the expression nodes. When this option is set to `true`, `ParenthesizedExpression` AST nodes are created instead.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.

--- a/website/versioned_docs/version-7.5.0/parser.md
+++ b/website/versioned_docs/version-7.5.0/parser.md
@@ -55,7 +55,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.

--- a/website/versioned_docs/version-7.6.0/parser.md
+++ b/website/versioned_docs/version-7.6.0/parser.md
@@ -55,6 +55,8 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.
 

--- a/website/versioned_docs/version-7.6.0/parser.md
+++ b/website/versioned_docs/version-7.6.0/parser.md
@@ -55,7 +55,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets `extra.parenthesized` on the expression nodes. When this option is set to `true`, `ParenthesizedExpression` AST nodes are created instead.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.

--- a/website/versioned_docs/version-7.6.0/parser.md
+++ b/website/versioned_docs/version-7.6.0/parser.md
@@ -55,7 +55,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.

--- a/website/versioned_docs/version-7.7.0/parser.md
+++ b/website/versioned_docs/version-7.7.0/parser.md
@@ -56,7 +56,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets `extra.parenthesized` on the expression nodes. When this option is set to `true`, `ParenthesizedExpression` AST nodes are created instead.
 
 - **errorRecovery**: By default, Babel always throws an error when it finds some invalid
   code. When this option is set to `true`, it will store the parsing error and try to continue

--- a/website/versioned_docs/version-7.7.0/parser.md
+++ b/website/versioned_docs/version-7.7.0/parser.md
@@ -56,7 +56,7 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
-- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create `ParenthesizedExpression`  AST nodes.
 
 - **errorRecovery**: By default, Babel always throws an error when it finds some invalid
   code. When this option is set to `true`, it will store the parsing error and try to continue

--- a/website/versioned_docs/version-7.7.0/parser.md
+++ b/website/versioned_docs/version-7.7.0/parser.md
@@ -56,6 +56,8 @@ mind. When in doubt, use `.parse()`.
   to set this option to `true` to prevent the parser from prematurely
   complaining about undeclared exports that will be added later.
 
+- **createParenthesizedExpressions**: By default, the parser sets extra.parenthesized on the expression nodes. When this option is set to `true`, create ParenthesizedExpression AST nodes.
+
 - **errorRecovery**: By default, Babel always throws an error when it finds some invalid
   code. When this option is set to `true`, it will store the parsing error and try to continue
   parsing the invalid input file.


### PR DESCRIPTION
Documents the changes from babel/babel#8025 implemented by @arv