### PR TITLE
breaking: remove minify toggle

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -74,12 +74,6 @@ const runtimePolyfillConfig: PluginConfig = {
 const pluginConfigs: Array<PluginConfig> = [
   {
     baseUrl: "https://unpkg.com",
-    label: "Minify",
-    package: "babili-standalone", // TODO Switch to babel-minify-standalone
-    version: "0",
-  },
-  {
-    baseUrl: "https://unpkg.com",
     label: "Prettify",
     package: "prettier",
     version: "1.13.0",
@@ -88,7 +82,6 @@ const pluginConfigs: Array<PluginConfig> = [
 ];
 
 const replDefaults: ReplState = {
-  babili: false,
   browsers: "",
   build: "",
   builtIns: false,

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -107,7 +107,6 @@ class Repl extends React.Component<Props, State> {
 
     const persistedState = replState();
     const defaultPlugins = {
-      "babili-standalone": persistedState.babili,
       prettier: persistedState.prettier,
     };
 
@@ -480,10 +479,6 @@ class Repl extends React.Component<Props, State> {
 
     const presetsArray = this._presetsToArray(state);
 
-    const babili = state.plugins["babili-standalone"];
-    if (babili.isEnabled && babili.isLoaded) {
-      presetsArray.push("babili");
-    }
     this._workerApi
       .compile(code, {
         plugins: state.externalPlugins.map(plugin => plugin.name),
@@ -573,11 +568,6 @@ class Repl extends React.Component<Props, State> {
 
     const presetsArray = this._presetsToArray();
 
-    const babili = state.plugins["babili-standalone"];
-    if (babili.isEnabled) {
-      presetsArray.push("babili");
-    }
-
     if (envConfig.isEnvPresetEnabled) {
       presetsArray.push("env");
     }
@@ -585,7 +575,6 @@ class Repl extends React.Component<Props, State> {
     const builtIns = envConfig.isBuiltInsEnabled && envConfig.builtIns;
 
     const payload = {
-      babili: plugins["babili-standalone"].isEnabled,
       browsers: envConfig.browsers,
       build: state.babel.build,
       builtIns: builtIns,

--- a/js/repl/UriUtils.js
+++ b/js/repl/UriUtils.js
@@ -5,7 +5,6 @@ import LZString from "lz-string";
 import type { ReplState } from "./types";
 
 const URL_KEYS = [
-  "babili",
   "browsers",
   "build",
   "builtIns",

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -106,7 +106,6 @@ export type CompileConfig = {
 };
 
 export type ReplState = {
-  babili: boolean,
   browsers: string,
   build: string,
   builtIns: string | boolean,


### PR DESCRIPTION
Closes #1868 

Remove babel-minify toggle on the REPL since it is currently unmaintained.