### PR TITLE
fix: redundant pluginActions background-color

### DIFF
--- a/js/repl/ExternalPlugins.js
+++ b/js/repl/ExternalPlugins.js
@@ -76,9 +76,13 @@ export default class ExternalPlugins extends React.Component<Props, State> {
               {p.name}{" "}
               <span className={currentStyles.pluginVersion}>v{p.version}</span>
             </span>
-            <div className={currentStyles.pluginActions}>
-              <a onClick={() => onRemove(p.name)}>✕</a>
-            </div>
+            <button
+              className={currentStyles.pluginActions}
+              onClick={() => onRemove(p.name)}
+              type="button"
+            >
+              ✕
+            </button>
           </li>
         ))}
       </ul>
@@ -170,15 +174,12 @@ const currentStyles = {
   `,
   pluginActions: css`
     align-items: center;
-    background: #23252b;
+    background-color: transparent;
+    border: none;
     bottom: 0;
     flex-shrink: 0;
     padding-left: 1rem;
     cursor: pointer;
-    a,
-    a:visited {
-      color: #fff;
-      cursor: pointer;
-    }
+    color: #fff;
   `,
 };


### PR DESCRIPTION
The recently-introduced Dark Mode reveals a UI glitch in the external plugins section

![image](https://user-images.githubusercontent.com/3607926/69894580-8a009880-12ef-11ea-8c78-5f658a631c7a.png)

The PR changes the `background-color` to be transparent. DOM structure is also simplified for better a11y and aesthetic view.

![image](https://user-images.githubusercontent.com/3607926/69894609-f8455b00-12ef-11ea-8ba9-54744a3876f6.png)

