### PR TITLE
Add trivago to the sponsors list

### DIFF
--- a/website/data/sponsors.yml
+++ b/website/data/sponsors.yml
@@ -1,3 +1,10 @@
+- type: opencollective
+  tier: base-support-sponsor
+  name: Trivago
+  url: https://tech.trivago.com/opensource/
+  image: https://images.opencollective.com/trivago/9bdcb07/logo.png
+  description: trivago Engineering is a great place to learn, grow, and do great things together.
+
 - name: AMP Project
   url: https://www.ampproject.org
   logo: amp-work.svg

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -37,7 +37,7 @@ const users = loadYaml("./data/users.yml").map(user => ({
 
 const sponsorsManual = loadYaml("./data/sponsors.yml").map(sponsor => ({
   ...sponsor,
-  image: path.join("/img/sponsors/", sponsor.logo),
+  image: sponsor.image || path.join("/img/sponsors/", sponsor.logo),
 }));
 const sponsorsDownloaded = require(path.join(__dirname, "/data/sponsors.json"));
 


### PR DESCRIPTION
They are effectively a base support sponsor, but since they use the "one time" donation every year rather than using the yearly subscription, they aren't automatically showed on our website.
Also, they are currently our top sponsor after Handshake.