### PR TITLE
wip: use unpkg.com

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -34,13 +34,13 @@ const shippedProposalsPackages: Array<PluginConfig> = [
   return {
     label: pluginName,
     package: packageName,
-    baseUrl: "https://bundle.run",
+    baseUrl: "https://unpkg.com",
     instanceName: normalizePluginName(pluginName),
   };
 });
 
 const shippedProposalsConfig: MultiPackagesConfig = {
-  baseUrl: "https://bundle.run",
+  baseUrl: "https://unpkg.com",
   label: "Shipped Proposals",
   packages: shippedProposalsPackages,
   package: "",

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -418,7 +418,7 @@ class Repl extends React.Component<Props, State> {
   };
 
   _loadExternalPlugin = (plugin: BabelPlugin) => {
-    const bundledUrl = `https://bundle.run/${plugin.name}@${plugin.version}`;
+    const bundledUrl = `https://unpkg.com/${plugin.name}@${plugin.version}`;
     return this._workerApi.loadExternalPlugin(bundledUrl).then(loaded => {
       if (loaded === false) {
         this.setState({

--- a/js/repl/WorkerApi.js
+++ b/js/repl/WorkerApi.js
@@ -98,7 +98,7 @@ export default class WorkerApi {
   loadPlugin(state: PluginState): Promise<boolean> {
     const { config } = state;
 
-    const base = config.baseUrl || "https://bundle.run";
+    const base = config.baseUrl || "https://unpkg.com";
     const url = `${base}/${config.package}@${config.version || ""}`;
 
     state.isLoading = true;

--- a/js/repl/loadPlugin.js
+++ b/js/repl/loadPlugin.js
@@ -16,7 +16,7 @@ export default function loadPlugin(
   state.isLoading = true;
 
   const { config } = state;
-  const base = config.baseUrl || "https://bundle.run";
+  const base = config.baseUrl || "https://unpkg.com";
   const url = `${base}/${config.package}@${config.version || ""}`;
 
   loadScript(


### PR DESCRIPTION
Fixes #2138 

Recently bundle.run throws 503 error on visiting, rendering the external plugins useless. In this PR we replace `bundle.run` by `unpkg.com` to workaround this issue.