### PR TITLE
Update optional chaining documentation with deletion change

### DIFF
--- a/docs/plugin-proposal-optional-chaining.md
+++ b/docs/plugin-proposal-optional-chaining.md
@@ -95,7 +95,6 @@ const obj = {
   },
 };
 
-// Prior to version 7.8, a delete operation would return undefined
 const ret = delete obj?.foo?.bar?.baz; // true
 ```
 

--- a/docs/plugin-proposal-optional-chaining.md
+++ b/docs/plugin-proposal-optional-chaining.md
@@ -86,7 +86,7 @@ new Test?.(); // test instance
 new exists?.(); // undefined
 ```
 
-### Delete deeply nested properties
+### Deleting deeply nested properties
 
 ```js
 const obj = {

--- a/docs/plugin-proposal-optional-chaining.md
+++ b/docs/plugin-proposal-optional-chaining.md
@@ -86,6 +86,19 @@ new Test?.(); // test instance
 new exists?.(); // undefined
 ```
 
+### Delete deeply nested properties
+
+```js
+const obj = {
+  foo: {
+    bar: {}
+  },
+};
+
+// Prior to version 7.8, a delete operation would return undefined
+const ret = delete obj?.foo?.bar?.baz; // true
+```
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
# Description
Per #2142, the `7.8` release includes a change to the return value of a `delete` operation on a nullish base. Previously, it had returned `undefined`, but now returns `true`. This PR adds documentation that indicates this change.

## Screenshot
[![Image from Gyazo](https://i.gyazo.com/8fd017b150ea3f333c6652c807c873d5.png)](https://gyazo.com/8fd017b150ea3f333c6652c807c873d5)