### PR TITLE
Fix preset-env when using Babel 7.8.0+

### DIFF
--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -295,7 +295,6 @@ class Repl extends React.Component<Props, State> {
         babelState.errorMessage =
           babelState.errorMessage || envState.errorMessage;
       } else {
-        alert("REG!");
         await this._workerApi.registerEnvPreset();
       }
     }

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -295,6 +295,7 @@ class Repl extends React.Component<Props, State> {
         babelState.errorMessage =
           babelState.errorMessage || envState.errorMessage;
       } else {
+        alert("REG!");
         await this._workerApi.registerEnvPreset();
       }
     }

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -109,10 +109,6 @@ function compareVersions(a: string, b: string): 1 | 0 | -1 {
   return 0;
 }
 
-function isEnvStandaloneNeeded(babelVersion: string): boolean {
-  return compareVersions(babelVersion, "7.8.0") === -1;
-}
-
 class Repl extends React.Component<Props, State> {
   _numLoadingPlugins = 0;
   _workerApi = new WorkerApi();
@@ -290,7 +286,18 @@ class Repl extends React.Component<Props, State> {
   async _setupBabel(defaultPresets) {
     const babelState = await loadBundle(this.state.babel, this._workerApi);
     await this._loadInitialExternalPlugins();
-    const { envPresetState } = this.state;
+
+    if (compareVersions(babelState.version, "7.8.0") == -1) {
+      const envState = await this._loadPresetEnvStandalone();
+
+      if (envState.didError) {
+        babelState.didError = true;
+        babelState.errorMessage =
+          babelState.errorMessage || envState.errorMessage;
+      } else {
+        await this._workerApi.registerEnvPreset();
+      }
+    }
 
     this.setState({
       babel: babelState,
@@ -299,25 +306,13 @@ class Repl extends React.Component<Props, State> {
         defaultPresets
       ),
     });
-    if (babelState.isLoaded) {
-      if (
-        !envPresetState.isLoading ||
-        !isEnvStandaloneNeeded(babelState.version)
-      ) {
-        return this._compile(this.state.code, this._checkForUnloadedPlugins);
-      }
-      this._checkForUnloadedPlugins();
-    }
+
+    this._checkForUnloadedPlugins();
   }
 
   async _checkForUnloadedPlugins() {
-    const {
-      envConfig,
-      envPresetState,
-      shippedProposalsState,
-      plugins,
-      runtimePolyfillState,
-    } = this.state;
+    const { plugins, runtimePolyfillState } = this.state;
+
     // Assume all default presets are baked into @babel/standalone.
     // We really only need to worry about plugins.
     for (const key in plugins) {
@@ -375,59 +370,45 @@ class Repl extends React.Component<Props, State> {
         scopedEval.getIframe()
       );
     }
+  }
 
-    // Starting from Babel 7.8.0, preset-env is included in @babel/standalone
-    if (!isEnvStandaloneNeeded(this.state.babel.version)) return;
+  async _loadPresetEnvStandalone() {
+    const result = await loadBundle(this.state.envPresetState, this._workerApi);
 
-    // Babel 'env' preset is large;
-    // Only load it if it's been requested.
-    if (envConfig.isEnvPresetEnabled && !envPresetState.isLoaded) {
-      envPresetState.isLoading = true;
-      loadBundle(envPresetState, this._workerApi).then(() => {
-        // This preset is not built into Babel standalone due to its size.
-        // Before we can use it we need to explicitly register it.
-        // Because it's loaded in a worker, we need to configure it there as well.
-        this._workerApi
-          .registerEnvPreset()
-          .then(() => this._updateCode(this.state.code));
-      });
-    }
-    if (
-      envConfig.isEnvPresetEnabled &&
-      envConfig.shippedProposals &&
-      !shippedProposalsState.isLoaded
-    ) {
-      const availablePlugins = await this._workerApi.getAvailablePlugins();
-      const availablePluginsNames = availablePlugins.map(({ label }) => label);
-      const notRegisteredPackages = shippedProposalsState.config.packages
-        .filter(
-          packageState => !availablePluginsNames.includes(packageState.label)
-        )
-        .map(config =>
-          configToState({ ...config, version: this.state.babel.version }, true)
+    if (result.didError) return result;
+
+    const availablePlugins = await this._workerApi.getAvailablePlugins();
+    const availablePluginsNames = availablePlugins.map(({ label }) => label);
+    const notRegisteredPackages = this.state.shippedProposalsState.config.packages
+      .filter(
+        packageState => !availablePluginsNames.includes(packageState.label)
+      )
+      .map(config =>
+        configToState({ ...config, version: this.state.babel.version }, true)
+      );
+
+    if (notRegisteredPackages.length) {
+      const plugins = await Promise.all(
+        notRegisteredPackages.map(state => loadBundle(state, this._workerApi))
+      );
+      const allPluginsAreLoaded = plugins.every(({ isLoaded }) => isLoaded);
+      if (allPluginsAreLoaded) {
+        await this._workerApi.registerPlugins(
+          plugins.map(({ config }) => ({
+            instanceName: config.instanceName,
+            pluginName: config.label,
+          }))
         );
-
-      if (notRegisteredPackages.length) {
-        shippedProposalsState.isLoading = true;
-        const plugins = await Promise.all(
-          notRegisteredPackages.map(state => loadBundle(state, this._workerApi))
-        );
-        const allPluginsAreLoaded = plugins.every(({ isLoaded }) => isLoaded);
-        if (allPluginsAreLoaded) {
-          await this._workerApi.registerPlugins(
-            plugins.map(({ config }) => ({
-              instanceName: config.instanceName,
-              pluginName: config.label,
-            }))
-          );
-          shippedProposalsState.isLoaded = true;
-          this._updateCode(this.state.code);
-        } else {
-          shippedProposalsState.didError = true;
-        }
-        shippedProposalsState.isLoading = false;
+      } else {
+        return {
+          didError: true,
+          isLoaded: false,
+          errorMessage: "Error while loading @babel/preset-env-standalone",
+        };
       }
     }
+
+    return { didError: false, isLoaded: true, errorMessage: null };
   }
 
   _loadInitialExternalPlugins = () => {
@@ -504,7 +485,7 @@ class Repl extends React.Component<Props, State> {
       .compile(code, {
         plugins: state.externalPlugins.map(plugin => plugin.name),
         debugEnvPreset: state.debugEnvPreset,
-        envConfig: state.envPresetState.isLoaded ? state.envConfig : null,
+        envConfig: state.envConfig,
         presetsOptions: state.presetsOptions,
         evaluate:
           runtimePolyfillState.isEnabled && runtimePolyfillState.isLoaded,

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -181,8 +181,6 @@ class ExpandedContainer extends Component<Props, State> {
     const {
       babelVersion,
       envConfig,
-      envPresetState,
-      shippedProposalsState,
       fileSize,
       timeTravel,
       sourceType,
@@ -207,11 +205,6 @@ class ExpandedContainer extends Component<Props, State> {
       isPresetsTabExpanded,
       isSettingsTabExpanded,
     } = this.state;
-
-    const disableEnvSettings =
-      !envPresetState.isLoaded ||
-      !envConfig.isEnvPresetEnabled ||
-      shippedProposalsState.isLoading;
 
     const isStage2Enabled =
       presetState["stage-0"].isEnabled ||
@@ -420,12 +413,7 @@ class ExpandedContainer extends Component<Props, State> {
                   type="checkbox"
                   onChange={this._onEnvPresetSettingCheck("isEnvPresetEnabled")}
                 />
-
-                {envPresetState.isLoading ? (
-                  <PresetLoadingAnimation />
-                ) : (
-                  "Enabled"
-                )}
+                Enabled
               </label>
 
               <div className={styles.envPresetColumn}>
@@ -438,7 +426,7 @@ class ExpandedContainer extends Component<Props, State> {
                   Browsers
                 </LinkToDocs>
                 <textarea
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   className={`${styles.envPresetInput} ${
                     styles.envPresetTextarea
                   }`}
@@ -459,7 +447,6 @@ class ExpandedContainer extends Component<Props, State> {
                     styles.envPresetInput
                   }`}
                   disabled={
-                    !envPresetState.isLoaded ||
                     !envConfig.isEnvPresetEnabled ||
                     !envConfig.isElectronEnabled
                   }
@@ -473,7 +460,7 @@ class ExpandedContainer extends Component<Props, State> {
                 <input
                   checked={envConfig.isElectronEnabled}
                   className={styles.envPresetCheckbox}
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   onChange={this._onEnvPresetSettingCheck("isElectronEnabled")}
                   type="checkbox"
                 />
@@ -490,9 +477,7 @@ class ExpandedContainer extends Component<Props, State> {
                     styles.envPresetInput
                   }`}
                   disabled={
-                    !envPresetState.isLoaded ||
-                    !envConfig.isEnvPresetEnabled ||
-                    !envConfig.isNodeEnabled
+                    !envConfig.isEnvPresetEnabled || !envConfig.isNodeEnabled
                   }
                   type="number"
                   min={envPresetDefaults.node.min}
@@ -504,7 +489,7 @@ class ExpandedContainer extends Component<Props, State> {
                 <input
                   checked={envConfig.isNodeEnabled}
                   className={styles.envPresetCheckbox}
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   onChange={this._onEnvPresetSettingCheck("isNodeEnabled")}
                   type="checkbox"
                 />
@@ -521,7 +506,6 @@ class ExpandedContainer extends Component<Props, State> {
                   className={styles.envPresetSelect}
                   onChange={this._onEnvPresetSettingChange("builtIns")}
                   disabled={
-                    !envPresetState.isLoaded ||
                     !envConfig.isEnvPresetEnabled ||
                     !envConfig.isBuiltInsEnabled ||
                     runtimePolyfillState.isEnabled
@@ -533,7 +517,7 @@ class ExpandedContainer extends Component<Props, State> {
                 <input
                   checked={envConfig.isBuiltInsEnabled}
                   className={styles.envPresetCheckbox}
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   onChange={this._onEnvPresetSettingCheck("isBuiltInsEnabled")}
                   type="checkbox"
                 />
@@ -548,7 +532,7 @@ class ExpandedContainer extends Component<Props, State> {
                 <input
                   checked={envConfig.isSpecEnabled}
                   className={styles.envPresetCheckbox}
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   onChange={this._onEnvPresetSettingCheck("isSpecEnabled")}
                   type="checkbox"
                 />
@@ -563,29 +547,23 @@ class ExpandedContainer extends Component<Props, State> {
                 <input
                   checked={envConfig.isLooseEnabled}
                   className={styles.envPresetCheckbox}
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   onChange={this._onEnvPresetSettingCheck("isLooseEnabled")}
                   type="checkbox"
                 />
               </label>
               <label className={styles.envPresetRow}>
-                {shippedProposalsState.isLoading ? (
-                  <span className={styles.envPresetLoaderWrapper}>
-                    <PresetLoadingAnimation size={1.6} />
-                  </span>
-                ) : (
-                  <LinkToDocs
-                    className={`${styles.envPresetLabel} ${styles.highlight}`}
-                    section="shippedproposals"
-                  >
-                    Shipped Proposals
-                  </LinkToDocs>
-                )}
+                <LinkToDocs
+                  className={`${styles.envPresetLabel} ${styles.highlight}`}
+                  section="shippedproposals"
+                >
+                  Shipped Proposals
+                </LinkToDocs>
                 <input
                   checked={envConfig.shippedProposals}
                   className={styles.envPresetCheckbox}
                   // TODO
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   onChange={this._onEnvPresetSettingCheck("shippedProposals")}
                   type="checkbox"
                 />
@@ -600,7 +578,7 @@ class ExpandedContainer extends Component<Props, State> {
                 <input
                   checked={envConfig.forceAllTransforms}
                   className={styles.envPresetCheckbox}
-                  disabled={disableEnvSettings}
+                  disabled={!envConfig.isEnvPresetEnabled}
                   onChange={this._onEnvPresetSettingCheck("forceAllTransforms")}
                   type="checkbox"
                 />

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -64,6 +64,8 @@ export default function compile(code: string, config: CompileConfig): Return {
     rawSize: new Blob([code], { type: "text/plain" }).size,
   };
 
+  let presetEnvOptions = {};
+
   if (envConfig && envConfig.isEnvPresetEnabled) {
     const targets = {};
     const { forceAllTransforms, shippedProposals } = envConfig;
@@ -90,7 +92,7 @@ export default function compile(code: string, config: CompileConfig): Return {
       loose = envConfig.isLooseEnabled;
     }
 
-    const options: { [string]: any } = {
+    presetEnvOptions = {
       targets,
       forceAllTransforms,
       shippedProposals,
@@ -98,8 +100,6 @@ export default function compile(code: string, config: CompileConfig): Return {
       spec,
       loose,
     };
-
-    config.presets.push(["env", options]);
   }
 
   try {
@@ -109,7 +109,11 @@ export default function compile(code: string, config: CompileConfig): Return {
       sourceMap: config.sourceMap,
 
       presets: config.presets.map(preset => {
-        if (typeof preset === "string" && /^stage-[0-2]$/.test(preset)) {
+        if (typeof preset !== "string") return preset;
+        if (preset === "env") {
+          return ["env", presetEnvOptions];
+        }
+        if (/^stage-[0-2]$/.test(preset)) {
           const decoratorsLegacy = presetsOptions.decoratorsLegacy;
           const decoratorsBeforeExport = decoratorsLegacy
             ? undefined


### PR DESCRIPTION
Try opening this url in a private window, to have a clean state: https://babeljs.io/repl/#?presets=env&version=7.8.3

You will see an error message about `@babel/preset-env` being registered twice. This is because `@babel/standalone` already includes it, and then we are re-loading it.

In this PR I chose to load `env-standalone` together with `@babel/standalone` when using an older version. This will increase the loading time for old Babel version, but it improves removes the `isLoaded`/`isLoading` logic which isn't needed anymore with the new bundled preset.

**EDIT**: ~~It still doesn't work.~~
https://deploy-preview-2157--babel.netlify.com/repl#?presets=env&version=7.8.3 Try enabling and disabling the preset a few times.

**EDIT**: It's working now