### PR TITLE
docs: Update MatchPattern function description

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -650,7 +650,7 @@ A root path to include on generated module names.
 
 ### `MatchPattern`
 
-Type: `string | RegExp | (filename: string | void, context: { callee: { name: string } | void, envName: string ) => boolean`
+Type: `string | RegExp | (filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string ) => boolean`
 
 Several Babel options perform tests against file paths. In general, these
 options support a common pattern approach where each pattern can be
@@ -664,10 +664,10 @@ options support a common pattern approach where each pattern can be
 Importantly, if either of these are used, Babel requires that the `filename` option be present,
 and will consider it an error otherwise.
 
-* `(filename: string | void, context: { callee: { name: string } | void, envName: string }) => boolean` is a general callback that should
+* `(filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string }) => boolean` is a general callback that should
   return a boolean to indicate whether it is a match or not. The function is passed the filename
-  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `callee`
-  options that were specified by the top-level call to Babel.
+  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `caller`
+  options that were specified by the top-level call to Babel and `dirname` that is either a directory of the configuration file or the current working directory (if the transformation was called programmatically).
 
 
 ### Merging

--- a/website/versioned_docs/version-7.0.0/options.md
+++ b/website/versioned_docs/version-7.0.0/options.md
@@ -609,7 +609,7 @@ A root path to include on generated module names.
 
 ### `MatchPattern`
 
-Type: `string | RegExp | (filename: string | void, context: { callee: { name: string } | void, envName: string ) => boolean`
+Type: `string | RegExp | (filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string ) => boolean`
 
 Several Babel options perform tests against file paths. In general, these
 options support a common pattern approach where each pattern can be
@@ -623,10 +623,10 @@ options support a common pattern approach where each pattern can be
 Importantly, if either of these are used, Babel requires that the `filename` option be present,
 and will consider it an error otherwise.
 
-* `(filename: string | void, context: { callee: { name: string } | void, envName: string }) => boolean` is a general callback that should
+* `(filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string }) => boolean` is a general callback that should
   return a boolean to indicate whether it is a match or not. The function is passed the filename
-  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `callee`
-  options that were specified by the top-level call to Babel.
+  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `caller`
+  options that were specified by the top-level call to Babel and `dirname` that is either a directory of the configuration file or the current working directory (if the transformation was called programmatically).
 
 
 ### Merging

--- a/website/versioned_docs/version-7.1.0/options.md
+++ b/website/versioned_docs/version-7.1.0/options.md
@@ -651,7 +651,7 @@ A root path to include on generated module names.
 
 ### `MatchPattern`
 
-Type: `string | RegExp | (filename: string | void, context: { callee: { name: string } | void, envName: string ) => boolean`
+Type: `string | RegExp | (filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string ) => boolean`
 
 Several Babel options perform tests against file paths. In general, these
 options support a common pattern approach where each pattern can be
@@ -665,10 +665,10 @@ options support a common pattern approach where each pattern can be
 Importantly, if either of these are used, Babel requires that the `filename` option be present,
 and will consider it an error otherwise.
 
-* `(filename: string | void, context: { callee: { name: string } | void, envName: string }) => boolean` is a general callback that should
+* `(filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string }) => boolean` is a general callback that should
   return a boolean to indicate whether it is a match or not. The function is passed the filename
-  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `callee`
-  options that were specified by the top-level call to Babel.
+  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `caller`
+  options that were specified by the top-level call to Babel and `dirname` that is either a directory of the configuration file or the current working directory (if the transformation was called programmatically).
 
 
 ### Merging

--- a/website/versioned_docs/version-7.8.0/options.md
+++ b/website/versioned_docs/version-7.8.0/options.md
@@ -663,7 +663,7 @@ npx babel src --out-dir lib --ignore "src/**/*.spec.js" --copy-ignored
 
 ### `MatchPattern`
 
-Type: `string | RegExp | (filename: string | void, context: { callee: { name: string } | void, envName: string ) => boolean`
+Type: `string | RegExp | (filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string ) => boolean`
 
 Several Babel options perform tests against file paths. In general, these
 options support a common pattern approach where each pattern can be
@@ -677,10 +677,10 @@ options support a common pattern approach where each pattern can be
 Importantly, if either of these are used, Babel requires that the `filename` option be present,
 and will consider it an error otherwise.
 
-* `(filename: string | void, context: { callee: { name: string } | void, envName: string }) => boolean` is a general callback that should
+* `(filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string }) => boolean` is a general callback that should
   return a boolean to indicate whether it is a match or not. The function is passed the filename
-  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `callee`
-  options that were specified by the top-level call to Babel.
+  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `caller`
+  options that were specified by the top-level call to Babel and `dirname` that is either a directory of the configuration file or the current working directory (if the transformation was called programmatically).
 
 
 ### Merging

--- a/website/versioned_docs/version-7.8.4/options.md
+++ b/website/versioned_docs/version-7.8.4/options.md
@@ -651,7 +651,7 @@ A root path to include on generated module names.
 
 ### `MatchPattern`
 
-Type: `string | RegExp | (filename: string | void, context: { callee: { name: string } | void, envName: string ) => boolean`
+Type: `string | RegExp | (filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string ) => boolean`
 
 Several Babel options perform tests against file paths. In general, these
 options support a common pattern approach where each pattern can be
@@ -665,10 +665,10 @@ options support a common pattern approach where each pattern can be
 Importantly, if either of these are used, Babel requires that the `filename` option be present,
 and will consider it an error otherwise.
 
-* `(filename: string | void, context: { callee: { name: string } | void, envName: string }) => boolean` is a general callback that should
+* `(filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string }) => boolean` is a general callback that should
   return a boolean to indicate whether it is a match or not. The function is passed the filename
-  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `callee`
-  options that were specified by the top-level call to Babel.
+  or `undefined` if one was not given to Babel. It is also passed the current `envName` and `caller`
+  options that were specified by the top-level call to Babel and `dirname` that is either a directory of the configuration file or the current working directory (if the transformation was called programmatically).
 
 
 ### Merging


### PR DESCRIPTION
The purpose of this PR is to update the description of `MatchPattern` function, specifically:
- Change `callee` parameter name to `caller`
- Describe `dirname` property that is a part of the `context`

Link to the source code that confirms the validity of these updates:

https://github.com/babel/babel/blob/779f00b8e9ce568ece4859501dd79682798c7fbf/packages/babel-core/src/config/config-chain.js#L698-L700