### PR TITLE
Added docs for numbers in jsescOption in babel-generator

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -39,7 +39,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | We leverage `jsesc` for getting ASCII-safe output for string literals. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
+jsescOption            | object   |                 | Use `jsesc` to process literals. `jsesc` is applied to numbers only if `jsescOption.numbers` is present. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -39,6 +39,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
+numbers                | string   | `decimal`       | Set `numbers: octal` in `jsescOption` to get the octal integer representation of any numeric value. Other supported options are `decimal, binary` and `hexadecimal`.
 
 Options for source maps:
 

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -39,7 +39,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsescOption` and more details.
+jsescOption            | string   |                 | We leverage `jsesc` for getting ASCII-safe output for string literals. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -39,7 +39,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-numbers                | string   | `decimal`       | Set `numbers: octal` in `jsescOption` to get the octal integer representation of any numeric value. Other supported options are `decimal, binary` and `hexadecimal`.
+jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsesOption` and more details.
 
 Options for source maps:
 

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -39,7 +39,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsesOption` and more details.
+jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsescOption` and more details.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-6.26.3/generator.md
+++ b/website/versioned_docs/version-6.26.3/generator.md
@@ -42,7 +42,7 @@ quotes                 | `'single'` or `'double'` | autodetect based on `ast.tok
 filename               | string   |                 | Used in warning messages
 flowCommaSeparator     | boolean  | `false`         | Set to `true` to use commas instead of semicolons as Flow property separators
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsescOption` and more details.
+jsescOption            | string   |                 | We leverage `jsesc` for getting ASCII-safe output for string literals. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-6.26.3/generator.md
+++ b/website/versioned_docs/version-6.26.3/generator.md
@@ -42,7 +42,7 @@ quotes                 | `'single'` or `'double'` | autodetect based on `ast.tok
 filename               | string   |                 | Used in warning messages
 flowCommaSeparator     | boolean  | `false`         | Set to `true` to use commas instead of semicolons as Flow property separators
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsesOption` and more details.
+jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsescOption` and more details.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-6.26.3/generator.md
+++ b/website/versioned_docs/version-6.26.3/generator.md
@@ -42,6 +42,7 @@ quotes                 | `'single'` or `'double'` | autodetect based on `ast.tok
 filename               | string   |                 | Used in warning messages
 flowCommaSeparator     | boolean  | `false`         | Set to `true` to use commas instead of semicolons as Flow property separators
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
+numbers                | string   | `decimal`       | Set `numbers: octal` in `jsescOption` to get the octal integer representation of any numeric value. Other supported options are `decimal, binary` and `hexadecimal`.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-6.26.3/generator.md
+++ b/website/versioned_docs/version-6.26.3/generator.md
@@ -42,7 +42,7 @@ quotes                 | `'single'` or `'double'` | autodetect based on `ast.tok
 filename               | string   |                 | Used in warning messages
 flowCommaSeparator     | boolean  | `false`         | Set to `true` to use commas instead of semicolons as Flow property separators
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | We leverage `jsesc` for getting ASCII-safe output for string literals. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
+jsescOption            | object   |                 | Use `jsesc` to process literals. `jsesc` is applied to numbers only if `jsescOption.numbers` is present. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-6.26.3/generator.md
+++ b/website/versioned_docs/version-6.26.3/generator.md
@@ -42,7 +42,6 @@ quotes                 | `'single'` or `'double'` | autodetect based on `ast.tok
 filename               | string   |                 | Used in warning messages
 flowCommaSeparator     | boolean  | `false`         | Set to `true` to use commas instead of semicolons as Flow property separators
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | object   |                 | Use `jsesc` to process literals. `jsesc` is applied to numbers only if `jsescOption.numbers` is present. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-6.26.3/generator.md
+++ b/website/versioned_docs/version-6.26.3/generator.md
@@ -42,7 +42,7 @@ quotes                 | `'single'` or `'double'` | autodetect based on `ast.tok
 filename               | string   |                 | Used in warning messages
 flowCommaSeparator     | boolean  | `false`         | Set to `true` to use commas instead of semicolons as Flow property separators
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-numbers                | string   | `decimal`       | Set `numbers: octal` in `jsescOption` to get the octal integer representation of any numeric value. Other supported options are `decimal, binary` and `hexadecimal`.
+jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsesOption` and more details.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-7.0.0/generator.md
+++ b/website/versioned_docs/version-7.0.0/generator.md
@@ -40,7 +40,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsesOption` and more details.
+jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsescOption` and more details.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-7.0.0/generator.md
+++ b/website/versioned_docs/version-7.0.0/generator.md
@@ -40,7 +40,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | We leverage `jsesc` for getting ASCII-safe output for string literals. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
+jsescOption            | object   |                 | Use `jsesc` to process literals. `jsesc` is applied to numbers only if `jsescOption.numbers` is present. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-7.0.0/generator.md
+++ b/website/versioned_docs/version-7.0.0/generator.md
@@ -40,7 +40,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | object   |                 | Use `jsesc` to process literals. `jsesc` is applied to numbers only if `jsescOption.numbers` is present. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
+jsescOption            | object   |                 | Use `jsesc` to process string literals. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 
@@ -80,4 +80,3 @@ const { code, map } = generate(ast, { sourceMaps: true }, {
 
 // Sourcemap will point to both a.js and b.js where appropriate.
 ```
-

--- a/website/versioned_docs/version-7.0.0/generator.md
+++ b/website/versioned_docs/version-7.0.0/generator.md
@@ -40,7 +40,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-numbers                | string   | `decimal`       | Set `numbers: octal` in `jsescOption` to get the octal integer representation of any numeric value. Other supported options are `decimal, binary` and `hexadecimal`.
+jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsesOption` and more details.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-7.0.0/generator.md
+++ b/website/versioned_docs/version-7.0.0/generator.md
@@ -40,6 +40,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
+numbers                | string   | `decimal`       | Set `numbers: octal` in `jsescOption` to get the octal integer representation of any numeric value. Other supported options are `decimal, binary` and `hexadecimal`.
 
 Options for source maps:
 

--- a/website/versioned_docs/version-7.0.0/generator.md
+++ b/website/versioned_docs/version-7.0.0/generator.md
@@ -40,7 +40,7 @@ minified               | boolean  | `false`         | Should the output be minif
 concise                | boolean  | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)
 filename               | string   |                 | Used in warning messages
 jsonCompatibleStrings  | boolean  | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";
-jsescOption            | string   |                 | Given some data, jsesc returns an ASCII-safe stringified representation of that data. Refer https://github.com/mathiasbynens/jsesc#api for the shape of `jsescOption` and more details.
+jsescOption            | string   |                 | We leverage `jsesc` for getting ASCII-safe output for string literals. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.
 
 Options for source maps:
 


### PR DESCRIPTION
Docs related to https://github.com/babel/babel/pull/11028 .

/cc: @nicolo-ribaudo @JLHwung PTAL. Thanks.