### PR TITLE
Add corejs option to preset env

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -63,6 +63,9 @@ const envPresetDefaults = {
   builtIns: {
     default: "usage",
   },
+  corejs: {
+    default: "3.6",
+  },
 };
 
 const runtimePolyfillConfig: PluginConfig = {

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -502,6 +502,19 @@ class ExpandedContainer extends Component<Props, State> {
                   Built-ins
                 </LinkToDocs>
                 <select
+                  value={envConfig.corejs}
+                  className={styles.envPresetSelect}
+                  onChange={this._onEnvPresetSettingChange("corejs")}
+                  disabled={
+                    !envConfig.isEnvPresetEnabled ||
+                    !envConfig.isBuiltInsEnabled ||
+                    runtimePolyfillState.isEnabled
+                  }
+                >
+                  <option value="2">core-js 2</option>
+                  <option value="3.6">core-js 3.6</option>
+                </select>
+                <select
                   value={envConfig.builtIns}
                   className={styles.envPresetSelect}
                   onChange={this._onEnvPresetSettingChange("builtIns")}
@@ -998,6 +1011,7 @@ const styles = {
     maxWidth: "7rem",
     fontWeight: 400,
     color: colors.textareaForeground,
+    margin: "0 0 0 0.75rem",
 
     "&:disabled": {
       opacity: 0.5,

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -58,6 +58,7 @@ export default function compile(code: string, config: CompileConfig): Return {
   let useBuiltIns = false;
   let spec = false;
   let loose = false;
+  let corejs = "3.6";
   const transitions = new Transitions();
   const meta = {
     compiledSize: 0,
@@ -81,6 +82,9 @@ export default function compile(code: string, config: CompileConfig): Return {
     }
     if (envConfig.isBuiltInsEnabled) {
       useBuiltIns = !config.evaluate && envConfig.builtIns;
+      if (envConfig.corejs) {
+        corejs = envConfig.corejs;
+      }
     }
     if (envConfig.isNodeEnabled) {
       targets.node = envConfig.node;
@@ -97,6 +101,7 @@ export default function compile(code: string, config: CompileConfig): Return {
       forceAllTransforms,
       shippedProposals,
       useBuiltIns,
+      corejs,
       spec,
       loose,
     };

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -155,6 +155,7 @@ export const persistedStateToEnvConfig = (
     node: envPresetDefaults.node.default,
     version: persistedState.version,
     builtIns: envPresetDefaults.builtIns.default,
+    corejs: envPresetDefaults.corejs.default,
   };
 
   decodeURIComponent(persistedState.targets)

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -23,6 +23,7 @@ export type EnvConfig = {
   isSpecEnabled: boolean,
   isLooseEnabled: boolean,
   builtIns: string | false,
+  corejs: string,
   forceAllTransforms: boolean,
   shippedProposals: boolean,
   version?: any,


### PR DESCRIPTION
Simply adds a new option to select which core-js version to target.

![Screenshot 2020-02-14 at 13 26 20](https://user-images.githubusercontent.com/231804/74531663-98914000-4f2d-11ea-8e70-6e6bdaf71459.png)