### PR TITLE
Added note for babel-register not compiling native Node.js ESM

### DIFF
--- a/docs/register.md
+++ b/docs/register.md
@@ -142,3 +142,5 @@ require("./my-plugin");
 Because it is your own code that triggered the load, and not the logic within
 `@babel/register` itself, this should successfully compile any plugin/preset
 that loads synchronously.
+
+**Note:** `@babel/register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.

--- a/docs/register.md
+++ b/docs/register.md
@@ -143,4 +143,4 @@ Because it is your own code that triggered the load, and not the logic within
 `@babel/register` itself, this should successfully compile any plugin/preset
 that loads synchronously.
 
-**Note:** `@babel/register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.
+**Note:** `@babel/register` does _not_ support compiling native Node.js ES modules on the fly, since currently there is no stable API for intercepting ES modules loading.

--- a/website/versioned_docs/version-6.26.3/register.md
+++ b/website/versioned_docs/version-6.26.3/register.md
@@ -101,4 +101,4 @@ Disable the cache.
 BABEL_DISABLE_CACHE=1 babel-node script.js
 ```
 
-**Note:** `@babel/register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.
+**Note:** `babel-register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.

--- a/website/versioned_docs/version-6.26.3/register.md
+++ b/website/versioned_docs/version-6.26.3/register.md
@@ -101,4 +101,4 @@ Disable the cache.
 BABEL_DISABLE_CACHE=1 babel-node script.js
 ```
 
-**Note:** `babel-register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.
+**Note:** `babel-register` does _not_ support compiling native Node.js ES modules on the fly, since currently there is no stable API for intercepting ES modules loading.

--- a/website/versioned_docs/version-6.26.3/register.md
+++ b/website/versioned_docs/version-6.26.3/register.md
@@ -101,3 +101,4 @@ Disable the cache.
 BABEL_DISABLE_CACHE=1 babel-node script.js
 ```
 
+**Note:** `@babel/register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.

--- a/website/versioned_docs/version-7.0.0/register.md
+++ b/website/versioned_docs/version-7.0.0/register.md
@@ -144,3 +144,4 @@ Because it is your own code that triggered the load, and not the logic within
 `@babel/register` itself, this should successfully compile any plugin/preset
 that loads synchronously.
 
+**Note:** `@babel/register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.

--- a/website/versioned_docs/version-7.0.0/register.md
+++ b/website/versioned_docs/version-7.0.0/register.md
@@ -144,4 +144,4 @@ Because it is your own code that triggered the load, and not the logic within
 `@babel/register` itself, this should successfully compile any plugin/preset
 that loads synchronously.
 
-**Note:** `@babel/register` currently does not support compiling native Node.js ES modules on the fly. This is because Node.js doesn't have a stable API yet to intercept ES modules loading.
+**Note:** `@babel/register` does _not_ support compiling native Node.js ES modules on the fly, since currently there is no stable API for intercepting ES modules loading.


### PR DESCRIPTION
Doc fix for https://github.com/babel/babel/issues/11108

@nicolo-ribaudo @JLHwung PTAL. Thanks.