### PR TITLE
Add bugfixes preset env option to REPL

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -86,6 +86,7 @@ const pluginConfigs: Array<PluginConfig> = [
 
 const replDefaults: ReplState = {
   browsers: "",
+  bugfixes: false,
   build: "",
   builtIns: false,
   spec: false,

--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -5,7 +5,7 @@ import "regenerator-runtime/runtime";
 import { cx, css } from "emotion";
 import debounce from "lodash.debounce";
 import React from "react";
-import { prettySize } from "./Utils";
+import { prettySize, compareVersions } from "./Utils";
 import ErrorBoundary from "./ErrorBoundary";
 import CodeMirrorPanel from "./CodeMirrorPanel";
 import ReplOptions from "./ReplOptions";
@@ -96,17 +96,6 @@ function toCamelCase(str) {
     .replace(/^(.)/, function($1) {
       return $1.toLowerCase();
     });
-}
-
-function compareVersions(a: string, b: string): 1 | 0 | -1 {
-  const aParts = a.split(".");
-  const bParts = b.split(".");
-
-  for (let i = 0; i < 3; i++) {
-    if (+aParts[i] > +bParts[i]) return 1;
-    if (+aParts[i] < +bParts[i]) return -1;
-  }
-  return 0;
 }
 
 class Repl extends React.Component<Props, State> {
@@ -287,7 +276,7 @@ class Repl extends React.Component<Props, State> {
     const babelState = await loadBundle(this.state.babel, this._workerApi);
     await this._loadInitialExternalPlugins();
 
-    if (compareVersions(babelState.version, "7.8.0") == -1) {
+    if (compareVersions(babelState.version, "7.8.0") === -1) {
       const envState = await this._loadPresetEnvStandalone();
 
       if (envState.didError) {
@@ -578,6 +567,7 @@ class Repl extends React.Component<Props, State> {
 
     const payload = {
       browsers: envConfig.browsers,
+      bugfixes: envConfig.isBugfixesEnabled,
       build: state.babel.build,
       builtIns: builtIns,
       spec: envConfig.isSpecEnabled,

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -8,7 +8,7 @@ import PresetLoadingAnimation from "./PresetLoadingAnimation";
 import ExternalPlugins from "./ExternalPlugins";
 import Svg from "./Svg";
 import { colors, media } from "./styles";
-import { joinListEnglish } from "./Utils";
+import { compareVersions, joinListEnglish } from "./Utils";
 
 import type {
   BabelPlugin,
@@ -213,6 +213,9 @@ class ExpandedContainer extends Component<Props, State> {
 
     const isStage1Enabled =
       presetState["stage-0"].isEnabled || presetState["stage-1"].isEnabled;
+
+    const isBugfixesSupported =
+      babelVersion && compareVersions(babelVersion, "7.9.0") !== -1;
 
     return (
       <div className={styles.expandedContainer}>
@@ -565,6 +568,25 @@ class ExpandedContainer extends Component<Props, State> {
                   type="checkbox"
                 />
               </label>
+              {isBugfixesSupported && (
+                <label className={styles.envPresetRow}>
+                  <LinkToDocs
+                    className={`${styles.envPresetLabel} ${styles.highlight}`}
+                    section="bugfixes"
+                  >
+                    Bug Fixes
+                  </LinkToDocs>
+                  <input
+                    checked={envConfig.isBugfixesEnabled}
+                    className={styles.envPresetCheckbox}
+                    disabled={!envConfig.isEnvPresetEnabled}
+                    onChange={this._onEnvPresetSettingCheck(
+                      "isBugfixesEnabled"
+                    )}
+                    type="checkbox"
+                  />
+                </label>
+              )}
               <label className={styles.envPresetRow}>
                 <LinkToDocs
                   className={`${styles.envPresetLabel} ${styles.highlight}`}

--- a/js/repl/Utils.js
+++ b/js/repl/Utils.js
@@ -39,3 +39,14 @@ export function preferDarkColorScheme(): boolean {
     window.matchMedia("(prefers-color-scheme:dark)").matches
   );
 }
+
+export function compareVersions(a: string, b: string): 1 | 0 | -1 {
+  const aParts = a.split(".");
+  const bParts = b.split(".");
+
+  for (let i = 0; i < 3; i++) {
+    if (+aParts[i] > +bParts[i]) return 1;
+    if (+aParts[i] < +bParts[i]) return -1;
+  }
+  return 0;
+}

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -58,6 +58,7 @@ export default function compile(code: string, config: CompileConfig): Return {
   let useBuiltIns = false;
   let spec = false;
   let loose = false;
+  let bugfixes = false;
   let corejs = "3.6";
   const transitions = new Transitions();
   const meta = {
@@ -95,6 +96,9 @@ export default function compile(code: string, config: CompileConfig): Return {
     if (envConfig.isLooseEnabled) {
       loose = envConfig.isLooseEnabled;
     }
+    if (envConfig.isBugfixesEnabled) {
+      bugfixes = envConfig.isBugfixesEnabled;
+    }
 
     presetEnvOptions = {
       targets,
@@ -104,6 +108,7 @@ export default function compile(code: string, config: CompileConfig): Return {
       corejs,
       spec,
       loose,
+      bugfixes,
     };
   }
 

--- a/js/repl/replUtils.js
+++ b/js/repl/replUtils.js
@@ -152,6 +152,7 @@ export const persistedStateToEnvConfig = (
     isBuiltInsEnabled: !!persistedState.builtIns,
     isSpecEnabled: !!persistedState.spec,
     isLooseEnabled: !!persistedState.loose,
+    isBugfixesEnabled: !!persistedState.bugfixes,
     node: envPresetDefaults.node.default,
     version: persistedState.version,
     builtIns: envPresetDefaults.builtIns.default,

--- a/js/repl/types.js
+++ b/js/repl/types.js
@@ -16,6 +16,7 @@ export type PresetsOptions = {
 export type EnvConfig = {
   browsers: string,
   electron: ?string,
+  isBugfixesEnabled: boolean,
   isEnvPresetEnabled: boolean,
   isElectronEnabled: boolean,
   isBuiltInsEnabled: boolean,
@@ -108,6 +109,7 @@ export type CompileConfig = {
 
 export type ReplState = {
   browsers: string,
+  bugfixes: boolean,
   build: string,
   builtIns: string | boolean,
   spec: boolean,


### PR DESCRIPTION
This PR adds a new `bugfixes` toggle to the preset env options tab in REPL.

Because we validate the top level options, the `bugfixes` toggle is only available when babel version is gte 7.9.0.

Related: https://github.com/babel/babel/pull/11083