### PR TITLE
Add additional information for plugin-syntax-dynamic-import

### DIFF
--- a/docs/plugin-syntax-dynamic-import.md
+++ b/docs/plugin-syntax-dynamic-import.md
@@ -4,6 +4,17 @@ title: @babel/plugin-syntax-dynamic-import
 sidebar_label: syntax-dynamic-import
 ---
 
+`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+
+In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
+
+If you want to transpile import():
+
+1. If you are using `@babel/preset-env`, it's automatically handled
+2. If you are using Webpack or Rollup, you shouldn't transpile import() with Babel and let the bundler handle it for you
+3. Otherwise, you need `@babel/plugin-proposal-dynamic-import`
+
+
 ## Installation
 
 ```sh

--- a/docs/plugin-syntax-dynamic-import.md
+++ b/docs/plugin-syntax-dynamic-import.md
@@ -4,7 +4,7 @@ title: @babel/plugin-syntax-dynamic-import
 sidebar_label: syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
+`@babel/plugin-syntax-dynamic-import` is needed to enable support for parsing `import()`
 
 This plugin is enabled by default since Babel 7.8.0, so you shouldn't need to enable this plugin separately.
 

--- a/docs/plugin-syntax-dynamic-import.md
+++ b/docs/plugin-syntax-dynamic-import.md
@@ -4,7 +4,7 @@ title: @babel/plugin-syntax-dynamic-import
 sidebar_label: syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for import().
 
 In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
 

--- a/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
@@ -5,7 +5,7 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for import().
 
 In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
 

--- a/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
@@ -5,15 +5,13 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for import().
+`babel-plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
 
-In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
+**Usage notes:**
 
-If you want to transpile import():
-
-1. If you are using `@babel/preset-env`, it's automatically handled
-2. If you are using Webpack or Rollup, you shouldn't transpile import() with Babel and let the bundler handle it for you
-3. Otherwise, you need `@babel/plugin-proposal-dynamic-import`
+1. If you are using `babel-preset-env`, it's automatically handled
+2. If you are using Webpack or Rollup, you shouldn't transpile `import()` with Babel and let the bundler handle it for you
+3. Otherwise, you need `babel-plugin-proposal-dynamic-import`
 
 ## Installation
 

--- a/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
@@ -5,6 +5,16 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
+`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+
+In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
+
+If you want to transpile import():
+
+1. If you are using `@babel/preset-env`, it's automatically handled
+2. If you are using Webpack or Rollup, you shouldn't transpile import() with Babel and let the bundler handle it for you
+3. Otherwise, you need `@babel/plugin-proposal-dynamic-import`
+
 ## Installation
 
 ```sh

--- a/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-6.26.3/plugin-syntax-dynamic-import.md
@@ -5,7 +5,7 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`babel-plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
+`babel-plugin-syntax-dynamic-import` is needed to enable support for parsing `import()`
 
 **Usage notes:**
 

--- a/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
@@ -5,7 +5,7 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for import().
 
 In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
 

--- a/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
@@ -5,14 +5,12 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for import().
+`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
 
-In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
-
-If you want to transpile import():
+**Usage notes:**
 
 1. If you are using `@babel/preset-env`, it's automatically handled
-2. If you are using Webpack or Rollup, you shouldn't transpile import() with Babel and let the bundler handle it for you
+2. If you are using Webpack or Rollup, you shouldn't transpile `import()` with Babel and let the bundler handle it for you
 3. Otherwise, you need `@babel/plugin-proposal-dynamic-import`
 
 ## Installation

--- a/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
@@ -5,6 +5,16 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
+`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+
+In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
+
+If you want to transpile import():
+
+1. If you are using `@babel/preset-env`, it's automatically handled
+2. If you are using Webpack or Rollup, you shouldn't transpile import() with Babel and let the bundler handle it for you
+3. Otherwise, you need `@babel/plugin-proposal-dynamic-import`
+
 ## Installation
 
 ```sh

--- a/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.0.0/plugin-syntax-dynamic-import.md
@@ -5,7 +5,7 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
+`@babel/plugin-syntax-dynamic-import` is needed to enable support for parsing `import()`
 
 **Usage notes:**
 

--- a/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
@@ -5,7 +5,7 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for import().
 
 In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
 

--- a/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
@@ -5,14 +5,12 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for import().
+`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
 
-In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
-
-If you want to transpile import():
+**Usage notes:**
 
 1. If you are using `@babel/preset-env`, it's automatically handled
-2. If you are using Webpack or Rollup, you shouldn't transpile import() with Babel and let the bundler handle it for you
+2. If you are using Webpack or Rollup, you shouldn't transpile `import()` with Babel and let the bundler handle it for you
 3. Otherwise, you need `@babel/plugin-proposal-dynamic-import`
 
 ## Installation

--- a/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
@@ -5,6 +5,16 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
+`@babel/plugin-syntax-dynamic-import` needed to enable parsing for import().
+
+In Babel 7.8.0 it's enabled by default, so this plugin shouldn't be needed if you are using `@babel/core@>7.8.0`.
+
+If you want to transpile import():
+
+1. If you are using `@babel/preset-env`, it's automatically handled
+2. If you are using Webpack or Rollup, you shouldn't transpile import() with Babel and let the bundler handle it for you
+3. Otherwise, you need `@babel/plugin-proposal-dynamic-import`
+
 ## Installation
 
 ```sh

--- a/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.4.0/plugin-syntax-dynamic-import.md
@@ -5,7 +5,7 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
+`@babel/plugin-syntax-dynamic-import` is needed to enable support for parsing `import()`
 
 **Usage notes:**
 

--- a/website/versioned_docs/version-7.8.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.8.0/plugin-syntax-dynamic-import.md
@@ -5,7 +5,7 @@ sidebar_label: syntax-dynamic-import
 original_id: babel-plugin-syntax-dynamic-import
 ---
 
-`@babel/plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.
+`@babel/plugin-syntax-dynamic-import` is needed to enable support for parsing `import()`
 
 This plugin is enabled by default since Babel 7.8.0, so you shouldn't need to enable this plugin separately.
 

--- a/website/versioned_docs/version-7.8.0/plugin-syntax-dynamic-import.md
+++ b/website/versioned_docs/version-7.8.0/plugin-syntax-dynamic-import.md
@@ -1,7 +1,8 @@
 ---
-id: babel-plugin-syntax-dynamic-import
+id: version-7.8.0-babel-plugin-syntax-dynamic-import
 title: @babel/plugin-syntax-dynamic-import
 sidebar_label: syntax-dynamic-import
+original_id: babel-plugin-syntax-dynamic-import
 ---
 
 `@babel/plugin-syntax-dynamic-import` is needed to enable parsing for `import()`.


### PR DESCRIPTION
Adds addition context and information about what the plugin does and when to use it. Information is from @nicolo-ribaudo on slack: https://babeljs.slack.com/archives/C0DFJT81H/p1583965874176800