### PR TITLE
add config file example

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,6 +151,12 @@ Ignore the configuration from the project's `.babelrc.json` file and use the cli
 npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
 ```
 
+### Custom config path
+
+```sh
+npx babel --config-file /path/to/my/babel.config.json --out-dir dist ./src
+```
+
 ### Set File Extensions
 
 By default, Babel will override the extension of the transpiled file and use `.js` instead.

--- a/website/versioned_docs/version-7.0.0/cli.md
+++ b/website/versioned_docs/version-7.0.0/cli.md
@@ -146,6 +146,13 @@ Ignore the configuration from the project's `.babelrc` file and use the cli opti
 npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
 ```
 
+### Custom config path
+
+```sh
+npx babel --config-file /path/to/my/babel.config.json --out-dir dist ./src
+```
+
+
 ### Advanced Usage
 
 There are many more options available, see [options](options.md), `babel --help` and other sections for more information.

--- a/website/versioned_docs/version-7.8.0/cli.md
+++ b/website/versioned_docs/version-7.8.0/cli.md
@@ -146,6 +146,12 @@ Ignore the configuration from the project's `.babelrc.json` file and use the cli
 npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
 ```
 
+### Custom config path
+
+```sh
+npx babel --config-file /path/to/my/babel.config.json --out-dir dist ./src
+```
+
 ### Set File Extensions
 
 By default, Babel will override the extension of the transpiled file and use `.js` instead.

--- a/website/versioned_docs/version-7.8.4/cli.md
+++ b/website/versioned_docs/version-7.8.4/cli.md
@@ -152,6 +152,12 @@ Ignore the configuration from the project's `.babelrc.json` file and use the cli
 npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
 ```
 
+### Custom config path
+
+```sh
+npx babel --config-file /path/to/my/babel.config.json --out-dir dist ./src
+```
+
 ### Set File Extensions
 
 By default, Babel will override the extension of the transpiled file and use `.js` instead.


### PR DESCRIPTION
add `--config-file` example for `@babel/cli`.

Resolves https://github.com/babel/babel/issues/11174.