### PR TITLE
add new options to `plugin-transform-react-jsx` docs

### DIFF
--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -8,7 +8,7 @@ sidebar_label: transform-react-jsx
 
 ### React Automatic Runtime
 
-Automatic runtime is a feature avaliable in v7.9.0. With this runtime enabled, the functions that JSX compiles to will be imported automatically.
+Automatic runtime is a feature available in v7.9.0. With this runtime enabled, the functions that JSX compiles to will be imported automatically.
 
 **In**
 
@@ -158,7 +158,7 @@ const profile = Preact.h(
 
 ### Fragments
 
-Fragments are a feature available in React 16.2.0+.
+[Fragments](https://reactjs.org/docs/fragments.html) are a feature available in React 16.2.0+.
 
 #### React
 
@@ -186,7 +186,7 @@ const descriptions = items.map(item =>
 );
 ```
 
-#### Custom for Classic Runtime
+#### Customizing with the Classic Runtime
 
 **In**
 
@@ -222,7 +222,7 @@ var descriptions = items.map(item =>
 );
 ```
 
-Note that if a custom pragma is specified, then a custom fragment pragma must also be specified if the `<></>` is used. Otherwise, an error will be thrown.
+Note that if a custom pragma is specified, then a custom fragment pragma must also be specified if the fragment sytnax `<></>` is used. Otherwise, an error will be thrown.
 
 ## Installation
 
@@ -295,7 +295,7 @@ Though the JSX spec allows this, it is disabled by default since React's JSX doe
 
 Decides which runtime to use.
 
-`automatic` auto imports the functions that JSX transpiles to. `classic` does not automatic import anything.
+`automatic` auto imports the functions that JSX transpiles to. `classic` does not automatically import anything.
 
 ### React Automatic Runtime
 

--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -6,7 +6,9 @@ sidebar_label: transform-react-jsx
 
 ## Example
 
-### React
+### React Automatic Runtime
+
+Automatic runtime is a feature avaliable in v7.9.0. With this runtime enabled, the functions that JSX compiles to will be imported automatically.
 
 **In**
 
@@ -14,7 +16,7 @@ sidebar_label: transform-react-jsx
 const profile = (
   <div>
     <img src="avatar.png" className="profile" />
-    <h3>{[user.firstName, user.lastName].join(' ')}</h3>
+    <h3>{[user.firstName, user.lastName].join(" ")}</h3>
   </div>
 );
 ```
@@ -22,25 +24,119 @@ const profile = (
 **Out**
 
 ```javascript
-const profile = React.createElement("div", null,
+import { jsx as _jsx } from "react";
+import { jsxs as _jsxs } from "react";
+
+const profile = _jsxs("div", {
+  children: [
+    _jsx("img", {
+      src: "avatar.png",
+      className: "profile",
+    }),
+    _jsx("h3", {
+      children: [user.firstName, user.lastName].join(" "),
+    }),
+  ],
+});
+```
+
+#### Customizing the Automatic Runtime Import
+
+**In**
+
+```javascript
+/** @jsxImportSource custom-jsx-library */
+
+const profile = (
+  <div>
+    <img src="avatar.png" className="profile" />
+    <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+  </div>
+);
+```
+
+**Out**
+
+```javascript
+import { jsx as _jsx } from "custom-jsx-library";
+import { jsxs as _jsxs } from "custom-jsx-library";
+
+const profile = _jsxs("div", {
+  children: [
+    _jsx("img", {
+      src: "avatar.png",
+      className: "profile",
+    }),
+    _jsx("h3", {
+      children: [user.firstName, user.lastName].join(" "),
+    }),
+  ],
+});
+```
+
+**In**
+
+```javascript
+/** @jsxRuntime classic */
+
+const profile = (
+  <div>
+    <img src="avatar.png" className="profile" />
+    <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+  </div>
+);
+```
+
+**Out**
+
+```javascript
+const profile = React.createElement(
+  "div",
+  null,
   React.createElement("img", { src: "avatar.png", className: "profile" }),
   React.createElement("h3", null, [user.firstName, user.lastName].join(" "))
 );
 ```
 
-### Custom
+### React Classic Runtime
+
+If you do not want (or cannot use) auto importing, you can use the classic runtime, which is the default behavior for v7 and prior.
+
+**In**
+
+```javascript
+const profile = (
+  <div>
+    <img src="avatar.png" className="profile" />
+    <h3>{[user.firstName, user.lastName].join(" ")}</h3>
+  </div>
+);
+```
+
+**Out**
+
+```javascript
+const profile = React.createElement(
+  "div",
+  null,
+  React.createElement("img", { src: "avatar.png", className: "profile" }),
+  React.createElement("h3", null, [user.firstName, user.lastName].join(" "))
+);
+```
+
+#### Customizing the Classic Runtime Import
 
 **In**
 
 ```javascript
 /** @jsx Preact.h */
 
-import Preact from 'preact';
+import Preact from "preact";
 
 const profile = (
   <div>
     <img src="avatar.png" className="profile" />
-    <h3>{[user.firstName, user.lastName].join(' ')}</h3>
+    <h3>{[user.firstName, user.lastName].join(" ")}</h3>
   </div>
 );
 ```
@@ -50,9 +146,11 @@ const profile = (
 ```javascript
 /** @jsx Preact.h */
 
-import Preact from 'preact';
+import Preact from "preact";
 
-const profile = Preact.h("div", null,
+const profile = Preact.h(
+  "div",
+  null,
   Preact.h("img", { src: "avatar.png", className: "profile" }),
   Preact.h("h3", null, [user.firstName, user.lastName].join(" "))
 );
@@ -78,15 +176,17 @@ const descriptions = items.map(item => (
 **Out**
 
 ```javascript
-const descriptions = items.map(item => React.createElement(
-  React.Fragment,
-  null,
-  React.createElement("dt", null, item.name),
-  React.createElement("dd", null, item.value)
-));
+const descriptions = items.map(item =>
+  React.createElement(
+    React.Fragment,
+    null,
+    React.createElement("dt", null, item.name),
+    React.createElement("dd", null, item.value)
+  )
+);
 ```
 
-#### Custom
+#### Custom for Classic Runtime
 
 **In**
 
@@ -94,7 +194,7 @@ const descriptions = items.map(item => React.createElement(
 /** @jsx Preact.h */
 /** @jsxFrag Preact.Fragment */
 
-import Preact from 'preact';
+import Preact from "preact";
 
 var descriptions = items.map(item => (
   <>
@@ -110,14 +210,16 @@ var descriptions = items.map(item => (
 /** @jsx Preact.h */
 /** @jsxFrag Preact.Fragment */
 
-import Preact from 'preact';
+import Preact from "preact";
 
-var descriptions = items.map(item => Preact.h(
-  Preact.Fragment,
-  null,
-  Preact.h("dt", null, item.name),
-  Preact.h("dd", null, item.value)
-));
+var descriptions = items.map(item =>
+  Preact.h(
+    Preact.Fragment,
+    null,
+    Preact.h("dt", null, item.name),
+    Preact.h("dd", null, item.value)
+  )
+);
 ```
 
 Note that if a custom pragma is specified, then a custom fragment pragma must also be specified if the `<></>` is used. Otherwise, an error will be thrown.
@@ -145,11 +247,14 @@ With options:
 ```json
 {
   "plugins": [
-    ["@babel/plugin-transform-react-jsx", {
-      "pragma": "Preact.h", // default pragma is React.createElement
-      "pragmaFrag": "Preact.Fragment", // default is React.Fragment
-      "throwIfNamespace": false // defaults to true
-    }]
+    [
+      "@babel/plugin-transform-react-jsx",
+      {
+        "throwIfNamespace": false, // defaults to true
+        "runtime": "automatic", // defaults to classic
+        "importSource": "custom-jsx-library" // defaults to react
+      }
+    ]
   ]
 }
 ```
@@ -164,13 +269,45 @@ babel --plugins @babel/plugin-transform-react-jsx script.js
 
 ```javascript
 require("@babel/core").transform("code", {
-  plugins: ["@babel/plugin-transform-react-jsx"]
+  plugins: ["@babel/plugin-transform-react-jsx"],
 });
 ```
 
 ## Options
 
-### `pragma`
+### Both Runtimes
+
+#### `throwIfNamespace`
+
+`boolean`, defaults to `true`.
+
+Toggles whether or not to throw an error if an XML namespaced tag name is used. For example:
+
+    <f:image />
+
+Though the JSX spec allows this, it is disabled by default since React's JSX does not currently have support for it.
+
+> You can read more about configuring plugin options [here](https://babeljs.io/docs/en/plugins#plugin-options)
+
+#### `runtime`
+
+`classic | automatic`, defaults to `classic`
+
+Decides which runtime to use.
+
+`automatic` auto imports the functions that JSX transpiles to. `classic` does not automatic import anything.
+
+### React Automatic Runtime
+
+#### importSource
+
+`string`, defaults to `react`.
+
+Replaces the import source when importing functions.
+
+### React Classic Runtime
+
+#### `pragma`
 
 `string`, defaults to `React.createElement`.
 
@@ -178,7 +315,7 @@ Replace the function used when compiling JSX expressions.
 
 Note that the `@jsx React.DOM` pragma has been deprecated as of React v0.12
 
-### `pragmaFrag`
+#### `pragmaFrag`
 
 `string`, defaults to `React.Fragment`.
 
@@ -195,15 +332,3 @@ When spreading props, use `Object.assign` directly instead of Babel's extend hel
 `boolean`, defaults to `false`.
 
 When spreading props, use inline object with spread elements directly instead of Babel's extend helper or `Object.assign`.
-
-### `throwIfNamespace`
-
-`boolean`, defaults to `true`.
-
-Toggles whether or not to throw an error if an XML namespaced tag name is used. For example:
-
-    <f:image />
-
-Though the JSX spec allows this, it is disabled by default since React's JSX does not currently have support for it.
-
-> You can read more about configuring plugin options [here](https://babeljs.io/docs/en/plugins#plugin-options)

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -12,8 +12,12 @@ This preset always includes the following plugins:
 
 And with the `development` option:
 
+Classic runtime adds:
+
 - [@babel/plugin-transform-react-jsx-self](plugin-transform-react-jsx-self.md)
 - [@babel/plugin-transform-react-jsx-source](plugin-transform-react-jsx-source.md)
+
+Automatic runtime adds the functionality for these plugins automatically when the `development` option is enabled. If you have automatic runtime enabled, adding [@babel/plugin-transform-react-jsx-self](plugin-transform-react-jsx-self.md) or [@babel/plugin-transform-react-jsx-source](plugin-transform-react-jsx-source.md) will error.
 
 > Note: Flow syntax support is no longer enabled in v7. For that, you will need to add the [Flow preset](preset-flow.md).
 
@@ -45,9 +49,11 @@ With options:
     [
       "@babel/preset-react",
       {
-        "pragma": "dom", // default pragma is React.createElement
-        "pragmaFrag": "DomFrag", // default is React.Fragment
-        "throwIfNamespace": false // defaults to true
+        "pragma": "dom", // default pragma is React.createElement (only in classic runtime)
+        "pragmaFrag": "DomFrag", // default is React.Fragment (only in classic runtime)
+        "throwIfNamespace": false, // defaults to true
+        "runtime": "classic" // defaults to classic
+        // "importSource": "custom-jsx-library" // defaults to react (only in automatic runtime)
       }
     ]
   ]
@@ -70,39 +76,25 @@ require("@babel/core").transform("code", {
 
 ## Options
 
-### `pragma`
+### Both Runtimes
 
-`string`, defaults to `React.createElement`.
+#### `runtime`
 
-Replace the function used when compiling JSX expressions.
+`classic | automatic`, defaults to `classic`
 
-### `pragmaFrag`
+Decides which runtime to use.
 
-`string`, defaults to `React.Fragment`.
+`automatic` auto imports the functions that JSX transpiles to. `classic` does not automatic import anything.
 
-Replace the component used when compiling JSX fragments.
-
-### `useBuiltIns`
+#### `development`
 
 `boolean`, defaults to `false`.
 
-Will use the native built-in instead of trying to polyfill behavior for any plugins that require one.
-
-### `useSpread`
-
-`boolean`, defaults to `false`.
-
-When spreading props, use inline object with spread elements directly instead of Babel's extend helper or `Object.assign`.
-
-### `development`
-
-`boolean`, defaults to `false`.
-
-Toggles plugins that aid in development, such as [`@babel/plugin-transform-react-jsx-self`](plugin-transform-react-jsx-self.md) and [`@babel/plugin-transform-react-jsx-source`](plugin-transform-react-jsx-source.md).
+This toggles behavior specific to development, such as adding `__source` and `__self`.
 
 This is useful when combined with the [env option](options.md#env) configuration or [js config files](config-files.md#javascript).
 
-### `throwIfNamespace`
+#### `throwIfNamespace`
 
 `boolean`, defaults to `true`.
 
@@ -112,7 +104,41 @@ Toggles whether or not to throw an error if a XML namespaced tag name is used. F
 
 Though the JSX spec allows this, it is disabled by default since React's JSX does not currently have support for it.
 
-#### .babelrc.js
+### React Automatic Runtime
+
+#### importSource
+
+`string`, defaults to `react`.
+
+Replaces the import source when importing functions.
+
+### React Classic Runtime
+
+#### `pragma`
+
+`string`, defaults to `React.createElement`.
+
+Replace the function used when compiling JSX expressions.
+
+#### `pragmaFrag`
+
+`string`, defaults to `React.Fragment`.
+
+Replace the component used when compiling JSX fragments.
+
+#### `useBuiltIns`
+
+`boolean`, defaults to `false`.
+
+Will use the native built-in instead of trying to polyfill behavior for any plugins that require one.
+
+#### `useSpread`
+
+`boolean`, defaults to `false`.
+
+When spreading props, use inline object with spread elements directly instead of Babel's extend helper or `Object.assign`.
+
+### .babelrc.js
 
 ```js
 module.exports = {
@@ -127,7 +153,7 @@ module.exports = {
 };
 ```
 
-#### .babelrc
+### .babelrc
 
 > Note: the `env` option will likely get deprecated soon
 


### PR DESCRIPTION
This PR adds `automatic | classic` runtime options and `importSource` to the `plugin-transform-react-jsx` docs.