### PR TITLE
fix: do not set bugfixes when Babel.version is not >= 7.9.0

### DIFF
--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -1,6 +1,8 @@
 // @flow
 
 // Globals pre-loaded by Worker
+import { compareVersions } from "./Utils";
+
 declare var Babel: any;
 declare var prettier: any;
 declare var prettierPlugins: any;
@@ -108,8 +110,10 @@ export default function compile(code: string, config: CompileConfig): Return {
       corejs,
       spec,
       loose,
-      bugfixes,
     };
+    if (Babel.version && compareVersions(Babel.version, "7.9.0") !== -1) {
+      (presetEnvOptions: any).bugfixes = bugfixes;
+    }
   }
 
   try {


### PR DESCRIPTION
This PR is a follow-up to #2194 . #2194 only controls the UI entry of bugfixes option, but we should also control the config passing, otherwise preset-env will throw on invalid options.