### PR TITLE
chore: remove deprecated preset sidebar entries

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -26,13 +26,8 @@
     ],
     "Presets": [
       "babel-preset-env",
-      "babel-preset-stage-0",
-      "babel-preset-stage-1",
-      "babel-preset-stage-2",
-      "babel-preset-stage-3",
       "babel-preset-flow",
       "babel-preset-react",
-      "babel-preset-minify",
       "babel-preset-typescript"
     ],
     "Tooling": [


### PR DESCRIPTION
Removed sidebar entries of deprecated/unmaintained presets. For general reference people can still access it from docs search.