### PR TITLE
fix: compile code when no plugins are enabled

### DIFF
--- a/js/repl/Repl.js
+++ b/js/repl/Repl.js
@@ -324,6 +324,10 @@ class Repl extends React.Component<Props, State> {
         });
       }
     }
+    // If no plugins are enabled, immediately invoke a new compilation
+    if (this._numLoadingPlugins === 0) {
+      this._compile(this.state.code, this._persistState);
+    }
 
     // Babel (runtime) polyfill is large;
     // It's only needed if we're actually executing the compiled code.


### PR DESCRIPTION
This PR fixes a regression introduced at #2157: When `Prettify` is not enabled, the compilation is never invoked so the transformed code is not print to the right panel.

Manually tested on my local build.

[This PR](https://deploy-preview-2217--babel.netlify.com/repl#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=MYGwhgzhAEDC0G8BQ1oGIAOBuF0C2AFAJSK6oBmA9gE7QEAuAFgJYQB0m0l50A2gLpEcqAL5IRQA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Cstage-3%2Cenv&prettier=false&targets=&version=7.8.7&externalPlugins=) vs. [master](https://babeljs.io/repl#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=MYGwhgzhAEDC0G8BQ1oGIAOBuF0C2AFAJSK6oBmA9gE7QEAuAFgJYQB0m0l50A2gLpEcqAL5IRQA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Cstage-3%2Cenv&prettier=false&targets=&version=7.8.7&externalPlugins=).