### PR TITLE
Fix warning about corejs in provided config

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,6 +35,7 @@ The entire process to set this up involves:
              "safari": "11.1",
            },
            "useBuiltIns": "usage",
+           "corejs": "3.0.0",
          }
        ]
      ]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,7 @@ The entire process to set this up involves:
              "safari": "11.1",
            },
            "useBuiltIns": "usage",
-           "corejs": "3.0.0",
+           "corejs": "3.6.4",
          }
        ]
      ]


### PR DESCRIPTION
When running with the config provided in the usage guide there's a warning.

```
WARNING: We noticed you're using the `useBuiltIns` option without declaring a core-js version. Currently, we assume version 2.x when no version is passed. Since this default version will likely change in future versions of Babel, we recommend explicitly setting the core-js version you are using via the `corejs` option.

You should also be sure that the version you pass to the `corejs` option matches the version specified in your `package.json`'s `dependencies` section. If it doesn't, you need to run one of the following commands:

  npm install --save core-js@2    npm install --save core-js@3
  yarn add core-js@2              yarn add core-js@3
```

This follows the warning recommendation and sets the `corejs` setting