### PR TITLE
update landing page code example

### DIFF
--- a/js/minirepl.js
+++ b/js/minirepl.js
@@ -3,10 +3,9 @@
 import debounce from "lodash.debounce";
 
 const miniReplExamples = [
-  "[1, 2, 3].map(n => n ** 2);",
-  "var [a,,b] = [1,2,3];",
-  "const x = [1, 2, 3];\nfoo([...x]);",
-  'var obj = {\n  shorthand,\n  method() {\n    return "😀";\n  }\n};',
+  "element.index ?? -1;",
+  "const styles = {\n" + "  ...defaults,\n" + '  color: "#f5da55",\n' + "};",
+  "const city = address?.city",
   'var name = "Guy Fieri";\nvar place = "Flavortown";\n\n`Hello ${name}, ready for ${place}?`;',
   'let yourTurn = "Type some code in here!";',
 ];


### PR DESCRIPTION
As a follow up to #2223 , after we updated the mini repl preset to a more modernized one, it turns out some of our code examples does not get transformed at all.

This PR update code examples to showcase some of the latest ES features that we still need to apply babel transforms.