### PR TITLE
Update usage.md @babel/env to @babel/preset-env

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,7 +26,7 @@ The entire process to set this up involves:
    {
      "presets": [
        [
-         "@babel/env",
+         "@babel/preset-env",
          {
            "targets": {
              "edge": "17",
@@ -134,7 +134,7 @@ For now, let's create a file called `babel.config.json` with the following conte
 {
 "presets": [
   [
-  "@babel/env",
+  "@babel/preset-env",
     {
       "targets": {
         "edge": "17",
@@ -180,7 +180,7 @@ Now luckily for us, we're using the `env` preset which has a `"useBuiltIns"` opt
 {
   "presets": [
     [
-      "@babel/env",
+      "@babel/preset-env",
       {
         "targets": {
           "edge": "17",


### PR DESCRIPTION
Fix references of @babel/env to @babel/preset-env since copying previous would show error `unknown option: .0.`