### PR TITLE
Fix package name for plugin-proposal-class-props

### DIFF
--- a/docs/plugin-proposal-private-methods.md
+++ b/docs/plugin-proposal-private-methods.md
@@ -69,7 +69,7 @@ require("@babel/core").transform("code", {
 
 `boolean`, defaults to `false`.
 
-> Note: The `loose` mode configuration setting _must_ be the same as [`@babel/proposal-class-properties`](plugin-proposal-class-properties.md).
+> Note: The `loose` mode configuration setting _must_ be the same as [`@babel/plugin-proposal-class-properties`](plugin-proposal-class-properties.md).
 
 When true, private methods will be assigned directly on its parent
 via `Object.defineProperty` rather than a `WeakSet`. This results in improved


### PR DESCRIPTION
**Problem:** The name in the docs referencing `@babel/plugin-proposal-class-properties` was listed as `@babel/proposal-class-properties`, which doesn't exist.

**Solution:** Fix the name.