### PR TITLE
Updated plugin acceptance docs for include/exclude options in preset-env

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -205,7 +205,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - without prefix: `transform-spread` and with prefixes [`@babel/`, `@babel/plugin-`, `babel-`, `babel-plugin-`]: [`@babel/transform-spread`, `@babel/plugin-transform-spread`, `babel-transform-spread`, `babel-plugin-transform-spread`] are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -167,7 +167,7 @@ Note, browsers' results are overridden by explicit items from `targets`.
 
 By default, `@babel/preset-env` (and Babel plugins in general) grouped ECMAScript syntax features into collections of closely related smaller features. These groups can be large and include a lot of edge cases, for example "function arguments" includes destructured, default and rest parameters. From this grouping information, Babel enables or disables each group based on the browser support target you specify to `@babel/preset-env`’s `targets` option.
 
-When this option is enabled, `@babel/preset-env` tries to compile the broken syntax to the closest *non-broken modern syntax* supported by your target browsers. Depending on your `targets` and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [`@babel/preset-modules`](https://github.com/babel/preset-modules) without having to use another preset.
+When this option is enabled, `@babel/preset-env` tries to compile the broken syntax to the closest _non-broken modern syntax_ supported by your target browsers. Depending on your `targets` and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [`@babel/preset-modules`](https://github.com/babel/preset-modules) without having to use another preset.
 
 ### `spec`
 
@@ -205,7 +205,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - both with (`@babel/plugin-transform-spread`) and without prefix (`plugin-transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 
@@ -440,4 +440,5 @@ The following are currently supported:
 ## Caveats
 
 ### Ineffective browserslist queries
+
 While `op_mini all` is a valid browserslist query, preset-env currently ignores it due to [lack of support data](https://github.com/kangax/compat-table/issues/1057) for Opera Mini.

--- a/website/versioned_docs/version-6.26.3/preset-env.md
+++ b/website/versioned_docs/version-6.26.3/preset-env.md
@@ -24,11 +24,14 @@ This example only includes the polyfills and code transforms needed for the last
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "browsers": ["last 2 versions", "safari >= 7"]
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": ["last 2 versions", "safari >= 7"]
+        }
       }
-    }]
+    ]
   ]
 }
 ```
@@ -38,11 +41,14 @@ Similarly, if you're targeting Node.js instead of the browser, you can configure
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "node": "6.10"
+    [
+      "env",
+      {
+        "targets": {
+          "node": "6.10"
+        }
       }
-    }]
+    ]
   ]
 }
 ```
@@ -52,11 +58,14 @@ For convenience, you can use `"node": "current"` to only include the necessary p
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "node": "current"
+    [
+      "env",
+      {
+        "targets": {
+          "node": "current"
+        }
       }
-    }]
+    ]
   ]
 }
 ```
@@ -213,7 +222,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel-preset-env/blob/master/data/plugin-features.js) - both with (`babel-plugin-transform-es2015-spread`) and without prefix (`transform-es2015-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel-preset-env/blob/master/data/plugin-features.js) - both with `babel-plugin-` (`babel-plugin-transform-es2015-spread`) and without prefix (`transform-es2015-spread`) are supported.
 
 - [Built-ins](https://github.com/babel/babel-preset-env/blob/master/data/built-in-features.js), such as `map`, `set`, or `object.assign`.
 
@@ -291,11 +300,14 @@ export class A {}
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "chrome": 52
+    [
+      "env",
+      {
+        "targets": {
+          "chrome": 52
+        }
       }
-    }]
+    ]
   ]
 }
 ```
@@ -314,13 +326,16 @@ exports.A = A;
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "chrome": 52
-      },
-      "modules": false,
-      "loose": true
-    }]
+    [
+      "env",
+      {
+        "targets": {
+          "chrome": 52
+        },
+        "modules": false,
+        "loose": true
+      }
+    ]
   ]
 }
 ```
@@ -338,12 +353,15 @@ export class A {}
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "chrome": 52,
-        "browsers": ["last 2 versions", "safari 7"]
+    [
+      "env",
+      {
+        "targets": {
+          "chrome": 52,
+          "browsers": ["last 2 versions", "safari 7"]
+        }
       }
-    }]
+    ]
   ]
 }
 ```
@@ -363,11 +381,14 @@ export var A = function A() {
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "node": "current"
+    [
+      "env",
+      {
+        "targets": {
+          "node": "current"
+        }
       }
-    }]
+    ]
   ]
 }
 ```
@@ -386,14 +407,17 @@ exports.A = A;
 ```json
 {
   "presets": [
-    [ "env", {
-      "targets": {
-        "safari": 10
-      },
-      "modules": false,
-      "useBuiltIns": true,
-      "debug": true
-    }]
+    [
+      "env",
+      {
+        "targets": {
+          "safari": 10
+        },
+        "modules": false,
+        "useBuiltIns": true,
+        "debug": true
+      }
+    ]
   ]
 }
 ```
@@ -428,13 +452,16 @@ Using polyfills:
 ```json
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "browsers": ["last 2 versions", "safari >= 7"]
-      },
-      "include": ["transform-es2015-arrow-functions", "es6.map"],
-      "exclude": ["transform-regenerator", "es6.set"]
-    }]
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": ["last 2 versions", "safari >= 7"]
+        },
+        "include": ["transform-es2015-arrow-functions", "es6.map"],
+        "exclude": ["transform-regenerator", "es6.set"]
+      }
+    ]
   ]
 }
 ```
@@ -447,4 +474,3 @@ If you get a `SyntaxError: Unexpected token ...` error when using the [object-re
 
 - [babel-preset-modern-browsers](https://github.com/christophehurpeau/babel-preset-modern-browsers)
 - ?
-

--- a/website/versioned_docs/version-6.26.3/preset-env.md
+++ b/website/versioned_docs/version-6.26.3/preset-env.md
@@ -222,7 +222,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel-preset-env/blob/master/data/plugin-features.js) - both with `babel-plugin-` (`babel-plugin-transform-es2015-spread`) and without prefix (`transform-es2015-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel-preset-env/blob/master/data/plugin-features.js) - without prefix: `transform-es2015-spread` and with prefix `babel-plugin-`: `babel-plugin-transform-es2015-spread` and are supported.
 
 - [Built-ins](https://github.com/babel/babel-preset-env/blob/master/data/built-in-features.js), such as `map`, `set`, or `object.assign`.
 

--- a/website/versioned_docs/version-7.0.0/preset-env.md
+++ b/website/versioned_docs/version-7.0.0/preset-env.md
@@ -196,7 +196,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - both with `babel-plugin-`(`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel-preset-env/blob/master/data/plugin-features.js) - without prefix: `transform-spread` and with prefix: `babel-plugin-`: `babel-plugin-transform-spread` and are supported.
 
 - [Built-ins](https://github.com/babel/babel/blob/master/packages/babel-preset-env/data/built-in-features.js), such as `es6.map`, `es6.set`, or `es6.object.assign`.
 

--- a/website/versioned_docs/version-7.0.0/preset-env.md
+++ b/website/versioned_docs/version-7.0.0/preset-env.md
@@ -196,7 +196,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - both with (`@babel/plugin-transform-spread`) and without prefix (`plugin-transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - both with `babel-plugin-`(`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
 
 - [Built-ins](https://github.com/babel/babel/blob/master/packages/babel-preset-env/data/built-in-features.js), such as `es6.map`, `es6.set`, or `es6.object.assign`.
 
@@ -224,7 +224,7 @@ An array of plugins to always exclude/remove.
 
 The possible options are the same as the `include` option.
 
-This option is useful for "blacklisting" a transform like `@babel/plugin-transform-regenerator` if you don't use generators and don't want to include `regeneratorRuntime` (when using `useBuiltIns`) or for using another plugin like [fast-async](https://github.com/MatAtBread/fast-async) instead of [Babel's async-to-gen](plugin-proposal-async-generator-functions.md).
+This option is useful for "blacklisting" a transform like `transform-regenerator` if you don't use generators and don't want to include `regeneratorRuntime` (when using `useBuiltIns`) or for using another plugin like [fast-async](https://github.com/MatAtBread/fast-async) instead of [Babel's async-to-gen](plugin-proposal-async-generator-functions.md).
 
 ### `useBuiltIns`
 
@@ -384,4 +384,5 @@ The following are currently supported:
 ## Caveats
 
 ### Ineffective browserslist queries
+
 While `op_mini all` is a valid browserslist query, preset-env currently ignores it due to [lack of support data](https://github.com/kangax/compat-table/issues/1057) for Opera Mini.

--- a/website/versioned_docs/version-7.4.0/preset-env.md
+++ b/website/versioned_docs/version-7.4.0/preset-env.md
@@ -196,7 +196,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - without prefix: `transform-spread` and with prefixes [`@babel/`, `@babel/plugin-`, `babel-`, `babel-plugin-`]: [`@babel/transform-spread`, `@babel/plugin-transform-spread`, `babel-transform-spread`, `babel-plugin-transform-spread`] are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 
@@ -361,7 +361,7 @@ By default, only polyfills for stable ECMAScript features are injected: if you w
 With Babel 7's [JavaScript config file](config-files#javascript) support, you can force all transforms to be run if env is set to `production`.
 
 ```js
-module.exports = function (api) {
+module.exports = function(api) {
   return {
     presets: [
       [

--- a/website/versioned_docs/version-7.4.0/preset-env.md
+++ b/website/versioned_docs/version-7.4.0/preset-env.md
@@ -196,7 +196,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - both with (`@babel/plugin-transform-spread`) and without prefix (`plugin-transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 
@@ -361,7 +361,7 @@ By default, only polyfills for stable ECMAScript features are injected: if you w
 With Babel 7's [JavaScript config file](config-files#javascript) support, you can force all transforms to be run if env is set to `production`.
 
 ```js
-module.exports = function(api) {
+module.exports = function (api) {
   return {
     presets: [
       [
@@ -431,4 +431,5 @@ The following are currently supported:
 ## Caveats
 
 ### Ineffective browserslist queries
+
 While `op_mini all` is a valid browserslist query, preset-env currently ignores it due to [lack of support data](https://github.com/kangax/compat-table/issues/1057) for Opera Mini.

--- a/website/versioned_docs/version-7.8.0/preset-env.md
+++ b/website/versioned_docs/version-7.8.0/preset-env.md
@@ -196,7 +196,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - without prefix: `transform-spread` and with prefixes [`@babel/`, `@babel/plugin-`, `babel-`, `babel-plugin-`]: [`@babel/transform-spread`, `@babel/plugin-transform-spread`, `babel-transform-spread`, `babel-plugin-transform-spread`] are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 

--- a/website/versioned_docs/version-7.8.0/preset-env.md
+++ b/website/versioned_docs/version-7.8.0/preset-env.md
@@ -196,7 +196,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - both with (`@babel/plugin-transform-spread`) and without prefix (`plugin-transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 
@@ -431,4 +431,5 @@ The following are currently supported:
 ## Caveats
 
 ### Ineffective browserslist queries
+
 While `op_mini all` is a valid browserslist query, preset-env currently ignores it due to [lack of support data](https://github.com/kangax/compat-table/issues/1057) for Opera Mini.

--- a/website/versioned_docs/version-7.9.0/preset-env.md
+++ b/website/versioned_docs/version-7.9.0/preset-env.md
@@ -206,7 +206,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - without prefix: `transform-spread` and with prefixes [`@babel/`, `@babel/plugin-`, `babel-`, `babel-plugin-`]: [`@babel/transform-spread`, `@babel/plugin-transform-spread`, `babel-transform-spread`, `babel-plugin-transform-spread`] are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 

--- a/website/versioned_docs/version-7.9.0/preset-env.md
+++ b/website/versioned_docs/version-7.9.0/preset-env.md
@@ -168,7 +168,7 @@ Note, browsers' results are overridden by explicit items from `targets`.
 
 By default, `@babel/preset-env` (and Babel plugins in general) grouped ECMAScript syntax features into collections of closely related smaller features. These groups can be large and include a lot of edge cases, for example "function arguments" includes destructured, default and rest parameters. From this grouping information, Babel enables or disables each group based on the browser support target you specify to `@babel/preset-env`’s `targets` option.
 
-When this option is enabled, `@babel/preset-env` tries to compile the broken syntax to the closest *non-broken modern syntax* supported by your target browsers. Depending on your `targets` and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [`@babel/preset-modules`](https://github.com/babel/preset-modules) without having to use another preset.
+When this option is enabled, `@babel/preset-env` tries to compile the broken syntax to the closest _non-broken modern syntax_ supported by your target browsers. Depending on your `targets` and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [`@babel/preset-modules`](https://github.com/babel/preset-modules) without having to use another preset.
 
 ### `spec`
 
@@ -206,7 +206,7 @@ An array of plugins to always include.
 
 Valid options include any:
 
-- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - both with (`@babel/plugin-transform-spread`) and without prefix (`plugin-transform-spread`) are supported.
+- [Babel plugins](https://github.com/babel/babel/blob/master/packages/babel-compat-data/scripts/data/plugin-features.js) - with `@babel/` (`@babel/transform-spread`), with `@babel/plugin-` (`@babel/plugin-transform-spread`), with `babel-` (`babel-transform-spread`), with `babel-plugin-` (`babel-plugin-transform-spread`) and without prefix (`transform-spread`) are supported.
 
 - Built-ins (both for [core-js@2](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs2/built-in-definitions.js) and [core-js@3](https://github.com/babel/babel/blob/master/packages/babel-preset-env/src/polyfills/corejs3/built-in-definitions.js), such as `es.map`, `es.set`, or `es.object.assign`.
 
@@ -441,4 +441,5 @@ The following are currently supported:
 ## Caveats
 
 ### Ineffective browserslist queries
+
 While `op_mini all` is a valid browserslist query, preset-env currently ignores it due to [lack of support data](https://github.com/kangax/compat-table/issues/1057) for Opera Mini.


### PR DESCRIPTION
The docs about include ([https://babeljs.io/docs/en/babel-preset-env#include](https://babeljs.io/docs/en/babel-preset-env#include) say that plugins prefixed with `plugin-` are valid, which is false. The only valid plugin names are those prefixed with `@babel/`, `@babel/plugin-`, `babel-`, `babel-plugin-`. The problem is with the regex normalizing polyfill names here: [https://github.com/babel/babel/blob/9a52019019527be8c179ea7c9025fa2355f16170/packages/babel-preset-env/src/normalize-options.js#L104](https://github.com/babel/babel/blob/9a52019019527be8c179ea7c9025fa2355f16170/packages/babel-preset-env/src/normalize-options.js#L104). Also in versions `6.23.3` and `7.0.0` only `babel-plugin-` prefix is accepted. 
The PR updates every doc version of `preset-env` about which plugin prefixes are accepted in the `include` and `exclude` options.
