### PR TITLE
Fix pipeline proposer picker

### DIFF
--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -382,7 +382,7 @@ class ExpandedContainer extends Component<Props, State> {
                   )}
                 >
                   <option
-                    vale="minimal"
+                    value="minimal"
                     selected={presetsOptions.pipelineProposal === "minimal"}
                   >
                     Minimal


### PR DESCRIPTION
If you ever select a different pipeline proposal than minimal, you cannot select minimal again, cause the option value prop was misspelled.

May all your bug fixes be this easy.