### PR TITLE
remove empty highlights section, change others to h2

### DIFF
--- a/website/blog/2018-09-17-7.1.0.md
+++ b/website/blog/2018-09-17-7.1.0.md
@@ -16,9 +16,7 @@ There's already another release! 7.1.0 includes support for Stage 2 Decorators a
 
 <!-- link to github release/changelog -->
 
-## Highlights
-
-### Decorators (Stage 2)
+## Decorators (Stage 2)
 
 > https://github.com/babel/babel/pull/7976, by [Nicolò](https://github.com/nicolo-ribaudo)
 
@@ -33,7 +31,7 @@ It's been many years in the making, but thanks to the amazing work by [Nicolò](
 
 Please check out our separate [blog post](https://babeljs.io/blog/2018/09/17/decorators) for more information regarding some history, changes from the previous proposal, and what's next!
 
-### Private Static Fields (Stage 3)
+## Private Static Fields (Stage 3)
 
 > https://github.com/babel/babel/pull/8205, by Bloomberg
 
@@ -47,7 +45,7 @@ Thanks to [Rob](https://github.com/robpalme), [Robin](https://github.com/rricard
 
 Private Class Methods support is [WIP](https://github.com/babel/proposals/issues/22)!
 
-### Better Monorepo Support
+## Better Monorepo Support
 
 > https://github.com/babel/babel/pull/8660, by [Logan](https://github.com/loganfsmyth)
 

--- a/website/blog/2018-12-03-7.2.0.md
+++ b/website/blog/2018-12-03-7.2.0.md
@@ -20,9 +20,7 @@ A big shout out to Bloomberg for sponsoring the implementation of private class 
 
 If you or your company wants to support Babel and the evolution of JavaScript, but aren't sure how, you can donate to us on [OpenCollective](https://opencollective.com/babel) and, better yet, work with us on the implementation of [new ECMAScript proposals](https://github.com/babel/proposals) directly!
 
-## Highlights
-
-### Private Instance Methods ([#8654](https://github.com/babel/babel/pull/8654))
+## Private Instance Methods ([#8654](https://github.com/babel/babel/pull/8654))
 
 ```javascript=
 class Person {
@@ -45,7 +43,7 @@ You can test private methods by adding the `@babel/plugin-proposal-private-metho
 
 Private accessors [are also coming](https://github.com/babel/babel/pull/9101), and we have done some big internal refactoring that allows us to add support for private elements to decorators soon 🎉.
 
-### "Smart" Pipeline Operator Parsing ([#8289](https://github.com/babel/babel/pull/8289))
+## "Smart" Pipeline Operator Parsing ([#8289](https://github.com/babel/babel/pull/8289))
 
 Thanks to the work of [James DiGioia](https://github.com/mAAdhaTTah) and [J. S. Choi](https://github.com/js-choi), `@babel/parser` now also can parse the [Smart Pipeline Operator](https://github.com/js-choi/proposal-smart-pipelines/), in addition to the [minimal version](https://github.com/tc39/proposal-pipeline-operator).
 
@@ -73,7 +71,7 @@ const ast = babel.parse(code, {
 
 We don't support transpiling this syntax yet, but it will come soon.
 
-### Plugin Names ([#8769](https://github.com/babel/babel/pull/8769))
+## Plugin Names ([#8769](https://github.com/babel/babel/pull/8769))
 
 Every official plugin now provides Babel its name. Although this doesn't affect normal Babel use, it provides a consistent identifier for each plugin. This is particularly useful for things like [Time Travel](https://github.com/babel/website/pull/1736), which allows you to see exactly what each plugin is doing to your code. You can see this in effect via our [repl](https://babeljs.io/repl/build/master#?timeTravel=true):
 

--- a/website/blog/2019-01-21-7.3.0.md
+++ b/website/blog/2019-01-21-7.3.0.md
@@ -22,9 +22,7 @@ Another shout out goes to the [AMP Project](https://www.ampproject.org), which i
 
 If you or your company want to support Babel and the evolution of JavaScript, but aren't sure how, you can donate to us on [OpenCollective](https://opencollective.com/babel) and, better yet, work with us on the implementation of [new ECMAScript proposals](https://github.com/babel/proposals) directly! As a volunteer-driven project, we rely on the community's support to both fund our efforts in supporting the wide range of JavaScript users and taking ownership of the code.
 
-## Highlights
-
-### Private instance accessors (getters and setters) ([#9101](https://github.com/babel/babel/pull/9101))
+## Private instance accessors (getters and setters) ([#9101](https://github.com/babel/babel/pull/9101))
 
 ```javascript
 class Person {
@@ -57,7 +55,7 @@ Class private features support is almost complete!
 
 </div>
 
-### Smart pipeline operator ([#9179](https://github.com/babel/babel/pull/9179))
+## Smart pipeline operator ([#9179](https://github.com/babel/babel/pull/9179))
 
 > Babel implements multiple variants of this [proposal](https://github.com/tc39/proposal-pipeline-operator/wiki#proposal-1-f-sharp-only) to help TC39 test and gather feedback from the community. As with all proposals, expect changes in the future.
 
@@ -88,7 +86,7 @@ You can enable it in your project using the `@babel/plugin-proposal-pipeline-ope
 
 > Previously, the "minimal" proposal was added in back in [v7.0.0-beta.3] via [#6335](https://github.com/babel/babel/pull/6335)
 
-### Named capturing groups ([#7105](https://github.com/babel/babel/pull/7105))
+## Named capturing groups ([#7105](https://github.com/babel/babel/pull/7105))
 
 ```javascript
 let stringRe = /(?<quote>"|')(?<contents>.*?)\k<quote>/;
@@ -102,11 +100,11 @@ Support for the biggest ECMAScript 2018 feature missing in Babel is now here! Pr
 
 Note that the runtime features (i.e. the `groups` property) only work in browsers with proper support for ES6 regular expressions. If you need to support older environments, you can include a polyfill for `RegExp`'s methods.
 
-### TypeScript updates ([#9302](https://github.com/babel/babel/pull/9302), [#9309](https://github.com/babel/babel/pull/9309))
+## TypeScript updates ([#9302](https://github.com/babel/babel/pull/9302), [#9309](https://github.com/babel/babel/pull/9309))
 
 Thanks to the work by [Armano](https://github.com/armano2) on `@babel/parser` and [Henry](https://github.com/hzoo)/[Brian](https://github.com/existentialism) on `@babel/generator` (have you seen the [live stream](https://www.youtube.com/watch?v=L-PxPBDUf6w&t=4s)?), we now support `let x: typeof import('./x');`, added in [TypeScript 2.9](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html). We now also support the `bigint` type keyword, added in [TypeScript 3.2](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html).
 
-### `babel-eslint` v11.0.0-beta.0: Automatic Syntax Detection by Reading Config ([babel/babel-eslint#711](https://github.com/babel/babel-eslint/pull/711)) 
+## `babel-eslint` v11.0.0-beta.0: Automatic Syntax Detection by Reading Config ([babel/babel-eslint#711](https://github.com/babel/babel-eslint/pull/711)) 
 
 Thanks to [Kai](https://github.com/kaicataldo) (also on the ESLint TSC) for finishing this work!
 

--- a/website/blog/2019-03-19-7.4.0.md
+++ b/website/blog/2019-03-19-7.4.0.md
@@ -37,9 +37,7 @@ When managing a big open source project, not everything is code: we need to mana
 
 If you or your company want to support Babel and the evolution of JavaScript, but aren't sure how, you can donate to us on [OpenCollective](https://opencollective.com/babel) and, better yet, work with us on the implementation of [new ECMAScript proposals](https://github.com/babel/proposals) directly! As a volunteer-driven project, we rely on the community's support to both fund our efforts in supporting the wide range of JavaScript users and taking ownership of the code. Reach out to Henry at henry@babeljs.io if you'd like to talk more!
 
-## Highlights
-
-### `core-js` 3 ([#7646](https://github.com/babel/babel/pull/7646))
+## `core-js` 3 ([#7646](https://github.com/babel/babel/pull/7646))
 
 We've received lots of kudos for our work on `@babel/preset-env`, but much of that should really go to the awesome work done by [Denis](https://github.com/zloirock). He maintains `core-js` which provides all the polyfills loaded by `@babel/polyfill`, `@babel/runtime` and `@babel/preset-env`.
 
@@ -60,7 +58,7 @@ _includesInstanceProperty(foo).call(foo, "a");
 
 Previously, `@babel/preset-env` relied entirely on `compat-table` data for determining which polyfills needed to be loaded for a particular environment. `core-js@3` introduces its own compatibility data set with an exhaustive test suite that should result in much more accurate polyfilling!
 
-#### Migration from `core-js@2`
+### Migration from `core-js@2`
 
 Since versions `2` and `3` of `core-js` are incompatible with each other (we don't want to break your code!), it isn't enabled by default.
 
@@ -143,7 +141,7 @@ Since versions `2` and `3` of `core-js` are incompatible with each other (we don
   
   In case you are interested, you should check the old source of `@babel/polyfill` for `core-js@2`:  [packages/babel-polyfill/src/index.js](https://github.com/babel/babel/blob/cf4bd8bb8d7e9feb7de8d97ef0eabcdc7499fce2/packages/babel-polyfill/src/index.js).
 
-### Partial Application ([#9343](https://github.com/babel/babel/pull/9343) and [#9474](https://github.com/babel/babel/pull/9474))
+## Partial Application ([#9343](https://github.com/babel/babel/pull/9343) and [#9474](https://github.com/babel/babel/pull/9474))
 
 This release includes both `@babel/parser` and transform support for the [partial application proposal](https://github.com/tc39/proposal-partial-application), which is currently at Stage 1 (last presented in July 2018). All the implementation work has been done by [Behrang Yarahmadi](https://github.com/byara), sponsored by Trivago.
 
@@ -178,7 +176,7 @@ You can test it by adding `@babel/plugin-proposal-partial-application` to your c
 
 > ℹ️ NOTE: Although the proposal's readme also describes partial application for tagged template literals, it has not been implemented because [it will likely be removed](https://github.com/babel/babel/pull/9343#issuecomment-457307782).
 
-### Static private methods ([#9446](https://github.com/babel/babel/pull/9446))
+## Static private methods ([#9446](https://github.com/babel/babel/pull/9446))
 
 ```javascript
 class Person {
@@ -210,7 +208,7 @@ Class private features support is only one step away from being complete! 😄
 
 </div>
 
-### TypeScript 3.4 RC support ([#9529](https://github.com/babel/babel/pull/9529) and [#9534](https://github.com/babel/babel/pull/9534))
+## TypeScript 3.4 RC support ([#9529](https://github.com/babel/babel/pull/9529) and [#9534](https://github.com/babel/babel/pull/9534))
 
 TypeScript 3.4 RC was [released](https://devblogs.microsoft.com/typescript/announcing-typescript-3-4-rc/) a few days ago, and thanks to [Tan Li Hau](https://github.com/tanhauhau) it is already supported by Babel!
 
@@ -227,7 +225,7 @@ const vowels: readonly string[] = ["a", "e", "i", "o", "u"];
 
 Keep in mind that TypeScript 3.4 RC is not a stable release, so you should wait until TypeScript 3.4 is officially released: you can subscribe to the [TypeScript blog](https://devblogs.microsoft.com/typescript/) to be notified when it will be available. 🙂
 
-### Parenthesized expressions ([#8025](https://github.com/babel/babel/issues/8025))
+## Parenthesized expressions ([#8025](https://github.com/babel/babel/issues/8025))
 
 Parentheses are not usually meaningful for JavaScript compilers or code generators: they are only "hints" used to tell the parser that some nodes have different precedence from the default one:
 
@@ -259,7 +257,7 @@ We already had a `ParenthesizedExpression` node to represent parentheses, but it
 
 </div>
 
-### `@babel/parser` spec compliancy
+## `@babel/parser` spec compliancy
 
 [Daniel](https://github.com/danez) is making `@babel/parser` more and more compliant to the ECMAScript specification: it is now passing 98.97% of the tests in the [Test262](https://github.com/tc39/test262) suite. 😎
 
@@ -286,7 +284,7 @@ class C {
 }
 ```
 
-### Code placeholders ([#9364](https://github.com/babel/babel/pull/9364))
+## Code placeholders ([#9364](https://github.com/babel/babel/pull/9364))
 
 Code is not always meant to be directly written by humans: what if some code needs to be generated, maybe using a predefined template?
 

--- a/website/blog/2019-07-03-7.5.0.md
+++ b/website/blog/2019-07-03-7.5.0.md
@@ -33,9 +33,7 @@ Special thanks go to [Handshake](https://handshake.org), a decentralized, permis
 
 If you or your company want to support Babel and the evolution of JavaScript, but aren't sure how, you can sponsor us on [Open Collective](https://opencollective.com/babel) and, better yet, work with us on the implementation of [new ECMAScript proposals](https://github.com/babel/proposals) directly! As a volunteer-driven project, we rely on the community's support to both fund our efforts in supporting the wide range of JavaScript users and taking ownership of the code. Reach out to Henry at henry@babeljs.io if you'd like to talk more!
 
-## Highlights
-
-### F# pipeline operator ([#9450](https://github.com/babel/babel/pull/9450) and [#9984](https://github.com/babel/babel/pull/9984))
+## F# pipeline operator ([#9450](https://github.com/babel/babel/pull/9450) and [#9984](https://github.com/babel/babel/pull/9984))
 
 > ⚠️ The pipeline operator proposal is still at Stage 1, and thus its specification is still being defined.
 
@@ -166,7 +164,7 @@ module.exports = {
 
 You can also try it out in the [repl](https://babeljs.io/repl/version/%5E7.5.0#?presets=stage-1), by enabling the "Stage 1" preset.
 
-### Dynamic import ([#9552](https://github.com/babel/babel/pull/9552) and [#10109](https://github.com/babel/babel/pull/10109))
+## Dynamic import ([#9552](https://github.com/babel/babel/pull/9552) and [#10109](https://github.com/babel/babel/pull/10109))
 
 Although Babel has had support for parsing dynamic imports `import(source)` for a long time, there hasn't been a consistent way of transforming it.
 - If you used `webpack` or `rollup`, you would only include `@babel/plugin-syntax-dynamic-import` and not transform it with Babel
@@ -200,7 +198,7 @@ If you want to only allow parsing of `import()` expressions without transforming
 
 If you are using `@babel/preset-env`, dynamic import support will be enabled by default. You don't need to worry about `webpack` or `rollup` support, since both `babel-loader` and `rollup-plugin-babel` automatically disable the Babel transform to allow the bundler to handle it correctly.
 
-### `defaults` browserslist query in `@babel/preset-env` ([#8897](https://github.com/babel/babel/pull/8897))
+## `defaults` browserslist query in `@babel/preset-env` ([#8897](https://github.com/babel/babel/pull/8897))
 
 When `@babel/preset-env` is not passed any targets, it runs every syntax transform on your code (emulating the now deprecated `babel-preset-latest`).
 
@@ -222,7 +220,7 @@ You can also set it using a `.browserslistrc` file, which is also used by other 
 
 The default behavior of `@babel/preset-env` is still to compile everything, but we might switch it in Babel 8 to use this `defaults` query.
 
-### Experimental TypeScript `namespaces` support ([#9785](https://github.com/babel/babel/pull/9785))
+## Experimental TypeScript `namespaces` support ([#9785](https://github.com/babel/babel/pull/9785))
 
 Until now, [namespaces](https://www.typescriptlang.org/docs/handbook/namespaces.html) were the second biggest TypeScript feature not supported by Babel (the first one is type-checking! 😛). Thanks to the work done by community member [Wesley Wolfe](https://twitter.com/wolvereness), you can now enable _experimental_ support for them in the TypeScript plugin, using the `allowNamespaces` option of `@babel/plugin-transform-typescript`:
 
@@ -251,7 +249,7 @@ namespace Validation {
 }
 ```
 
-> #### ⚠️ Warning ⚠️
+> ### ⚠️ Warning ⚠️
 >
 > When TypeScript support was initially added to Babel, `namespaces` were not included since they require type information that only a full TypeScript compiler and type-checker can provide. For this reason, this current (experimental) support has some limitations:
 >

--- a/website/blog/2019-09-05-7.6.0.md
+++ b/website/blog/2019-09-05-7.6.0.md
@@ -22,9 +22,7 @@ Another big shout out goes to [**Frontend Masters**](https://frontendmasters.com
 
 If you or your company want to support Babel and the evolution of JavaScript, but aren't sure how, you can donate to us on [OpenCollective](https://opencollective.com/babel) and, better yet, work with us on the implementation of [new ECMAScript proposals](https://github.com/babel/proposals) directly! As a volunteer-driven project, we rely on the community's support to both fund our efforts in supporting the wide range of JavaScript users and taking ownership of the code. Reach out to Henry at [henry@babeljs.io](mailto:henry@babeljs.io) if you'd like to talk more!
 
-## Highlights
-
-### Private static accessors (getters and setters) ([#10217](https://github.com/babel/babel/pull/10217))
+## Private static accessors (getters and setters) ([#10217](https://github.com/babel/babel/pull/10217))
 
 ```javascript=
 class Resource {
@@ -65,7 +63,7 @@ Class private features support is finally complete 🎉
 
 </div>
 
-### V8 intrinsic runtime functions parsing ([#10148](https://github.com/babel/babel/pull/10148))
+## V8 intrinsic runtime functions parsing ([#10148](https://github.com/babel/babel/pull/10148))
 
 > ⚠️ This is a non-standard extension to the language, which can only be used in V8 when enabling the `--allow-natives-syntax` command-line flag.
 
@@ -95,7 +93,7 @@ parse(code, {
 })
 ```
 
-### Nullish coalescing operator (`??`) updates ([#10269](https://github.com/babel/babel/pull/10269))
+## Nullish coalescing operator (`??`) updates ([#10269](https://github.com/babel/babel/pull/10269))
 
 The nullish coalescing stage 3 proposal recently got some updates: to avoid confusion over precedence with other logical operators (`&&` and `||`), the spec has been changed to disallow mixing them.
 

--- a/website/blog/2019-11-05-7.7.0.md
+++ b/website/blog/2019-11-05-7.7.0.md
@@ -32,10 +32,7 @@ Another special thanks goes to [Bloomberg](https://www.techatbloomberg.com/) for
 
 If you or your company want to support Babel and the evolution of JavaScript, but aren't sure how, you can donate to us on [OpenCollective](https://opencollective.com/babel) and, better yet, work with us on the implementation of [new ECMAScript proposals](https://github.com/babel/proposals) directly! As a volunteer-driven project, we rely on the community's support to both fund our efforts in supporting the wide range of JavaScript users and taking ownership of the code. Reach out to Henry at [henry@babeljs.io](mailto:henry@babeljs.io) if you'd like to talk more!
 
-
-## Highlights
-
-### Top-level `await` parsing ([#10449](https://github.com/babel/babel/pull/10449))
+## Top-level `await` parsing ([#10449](https://github.com/babel/babel/pull/10449))
 
 The top-level `await` [proposal](https://github.com/tc39/proposal-top-level-await) allows you to `await` promises in modules as if they were wrapped in a big async function. This is useful, for example, to conditionally load a dependency or to perform app initialization:
 
@@ -77,7 +74,7 @@ Please note that usage of top-level `await` assumes support within your module b
 
 Starting from this release, `@babel/preset-env` will automatically enable `@babel/plugin-syntax-top-level-await` if the `caller` supports it. *Note*: `babel-loader` and `rollup-plugin-babel` don't yet tell Babel that they support this syntax, but we are working on it with the respective maintainers.
 
-### Parser error recovery ([#10363](https://github.com/babel/babel/pull/10363))
+## Parser error recovery ([#10363](https://github.com/babel/babel/pull/10363))
 
 Like many other JavaScript parsers, `@babel/parser` throws an error whenever some invalid syntax is encountered. This behavior works well for Babel, since in order to transform a JavaScript program to another program we must first be sure that the input is valid.
 
@@ -131,7 +128,7 @@ ast.errors == [
 
 `@babel/parser` can still throw as not every error is currently recoverable. We'll continue to improve these cases!
 
-### New configuration file extensions ([#10501](https://github.com/babel/babel/pull/10501), [#10599](https://github.com/babel/babel/pull/10599))
+## New configuration file extensions ([#10501](https://github.com/babel/babel/pull/10501), [#10599](https://github.com/babel/babel/pull/10599))
 
 Babel 6 only supported a single configuration file: `.babelrc`, whose contents must be specified using JSON.
 
@@ -145,7 +142,7 @@ For these reasons, Babel 7.7.0 introduces support for a new configuration file: 
 
 We also added support for two different configuration files: `babel.config.cjs` and `.babelrc.cjs`, which must be used when using node's [`"type": "module"`](https://nodejs.org/api/esm.html#esm_code_package_json_code_code_type_code_field) option in `package.json` (because Babel doesn't support ECMAScript modules in config files). Apart from this `"type": "module"` difference, they behave exactly like `babel.config.js` and `.babelrc.js`.
 
-### TypeScript 3.7 ([#10543](https://github.com/babel/babel/pull/10543), [#10545](https://github.com/babel/babel/pull/10545))
+## TypeScript 3.7 ([#10543](https://github.com/babel/babel/pull/10543), [#10545](https://github.com/babel/babel/pull/10545))
 
 [TypeScript 3.7 RC](https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-rc) includes support for optional chaining, nullish coalescing operator, assertion functions, type-only field declarations and many more type-related features.
 
@@ -175,7 +172,7 @@ To avoid breaking changes, we introduced support for `declare` in class fields b
 }
 ```
 
-### Use object spread in compiled JSX ([#10572](https://github.com/babel/babel/pull/10572))
+## Use object spread in compiled JSX ([#10572](https://github.com/babel/babel/pull/10572))
 
 When using spread properties in JSX elements, Babel injects a runtime helper by default:
 
@@ -223,7 +220,7 @@ You can enable it using the `useSpread` option with either `@babel/preset-react`
 }
 ```
 
-### Memory usage improvements ([#10480](https://github.com/babel/babel/pull/10480))
+## Memory usage improvements ([#10480](https://github.com/babel/babel/pull/10480))
 
 Since the beginning, we have been making efforts ([#433](https://github.com/babel/babel/pull/433), [#3475](https://github.com/babel/babel/pull/3475), [#7028](https://github.com/babel/babel/pull/7028), etc.) to improve performance. Babel 7.7.0 now uses 20% less memory, and transforms large files 8% faster when compared to 7.6.0.
 

--- a/website/blog/2020-01-11-7.8.0.md
+++ b/website/blog/2020-01-11-7.8.0.md
@@ -30,9 +30,7 @@ If you or your company wants to support Babel and the evolution of JavaScript, b
 
 > We recently published a [funding post](https://babeljs.io/blog/2019/11/08/babels-funding-plans) detailing our funding plans and our goals. Check it out!
 
-## Highlights
-
-### ECMAScript 2020 default support ([#10811](https://github.com/babel/babel/pull/10811), [#10817](https://github.com/babel/babel/pull/10817), [#10819](https://github.com/babel/babel/pull/10819), [#10843](https://github.com/babel/babel/pull/10843))
+## ECMAScript 2020 default support ([#10811](https://github.com/babel/babel/pull/10811), [#10817](https://github.com/babel/babel/pull/10817), [#10819](https://github.com/babel/babel/pull/10819), [#10843](https://github.com/babel/babel/pull/10843))
 
 During the last [meeting](https://github.com/tc39/agendas/blob/master/2019/12.md), TC39 moved both the nullish coalescing and optional chaining proposals to Stage 4!
 
@@ -77,7 +75,7 @@ You can now safely use these new features in your code! If you are already using
 
 These features are now also enabled by default in `@babel/parser`: if you were using it directly, you can remove the `nullishCoalescingOperator` and `optionalChaining` parser plugins. We also enabled parsing for dynamic `import()` (which has been included in `@babel/preset-env` since [v7.5.0](https://babeljs.io/blog/2019/07/03/7.5.0#dynamic-import-9552-https-githubcom-babel-babel-pull-9552-and-10109-https-githubcom-babel-babel-pull-10109)), so you can safely remove the `dynamicImport` plugin.
 
-### Support every configuration file extension ([#10783](https://github.com/babel/babel/pull/10783) and [#10903](https://github.com/babel/babel/pull/10903))
+## Support every configuration file extension ([#10783](https://github.com/babel/babel/pull/10783) and [#10903](https://github.com/babel/babel/pull/10903))
 
 Babel 6 supported a single, JSON-based, configuration file: `.babelrc`.
 
@@ -121,7 +119,7 @@ Please remember that ECMAScript modules are **asynchronous**: that's why, for ex
 
 For these reasons, they can only be used when calling Babel via the promise-based or callback-based entry points. They already work with `@babel/cli`, `babel-loader` and `gulp-babel`, and they will work with the next release of `rollup-plugin-babel`. Note that they are not supported by `babel-eslint` yet.
 
-### New CLI options ([#9144](https://github.com/babel/babel/pull/9144) and [#10887](https://github.com/babel/babel/pull/10887))
+## New CLI options ([#9144](https://github.com/babel/babel/pull/9144) and [#10887](https://github.com/babel/babel/pull/10887))
 
 We added two new flags to `@babel/cli`: `--copy-ignored` and `--out-file-extension`.
 
@@ -137,7 +135,7 @@ This is similar to how the `--copy-files` option works, but `--copy-files` is me
 $ babel src --out-dir lib-cjs --out-file-extension cjs
 ```
 
-### Preparing for Babel 8
+## Preparing for Babel 8
 
 We are starting to work on the Babel 8.0.0 release in our umbrella issue: [#10746](https://github.com/babel/babel/issues/10746).
 
@@ -145,7 +143,7 @@ Babel 8 will only contain breaking changes: we will release a minor version the 
 
 While we don't anticipate a huge migration path, there are two issues which we want to bring to your attention:
 
-#### Extract targets parser and compat data from preset-env ([#10899](https://github.com/babel/babel/pull/10899))
+### Extract targets parser and compat data from preset-env ([#10899](https://github.com/babel/babel/pull/10899))
 
 Various 3rd party presets are currently using `@babel/preset-env`'s internal logic to parse compilation targets or to retrieve information about necessary plugins and polyfills.
 
@@ -167,7 +165,7 @@ We have decided to officially support these two use cases by providing two new p
 
 We plan to disallow using internal files starting from Babel 8. If you are relying on other internal APIs, please let us know!
 
-#### Introduce opt-in stricter AST validation ([#10917](https://github.com/babel/babel/pull/10917))
+### Introduce opt-in stricter AST validation ([#10917](https://github.com/babel/babel/pull/10917))
 
 `@babel/types` already performs many checks to ensure that the AST you are building is valid. For example, this code will throw because you can't use a statement in place of an expression:
 

--- a/website/blog/2020-03-16-7.9.0.md
+++ b/website/blog/2020-03-16-7.9.0.md
@@ -30,9 +30,7 @@ Special thanks go to [Luna Ruan](https://twitter.com/lunaruan) from the React Te
 
 If you or your company want to support Babel and the evolution of JavaScript, but aren't sure how, you can donate to us on our [Open Collective](https://opencollective.com/babel) and, better yet, work with us on the implementation of [new ECMAScript proposals](https://github.com/babel/proposals) directly! As a volunteer-driven project, we rely on the community's support to fund our efforts in supporting the wide range of JavaScript users. Reach out at [team@babeljs.io](mailto:team@babeljs.io) if you'd like to discuss more!
 
-## Highlights
-
-### `@babel/preset-env`'s `bugfixes` option ([#11083](https://github.com/babel/babel/pull/11083))
+## `@babel/preset-env`'s `bugfixes` option ([#11083](https://github.com/babel/babel/pull/11083))
 
 The new `bugfixes` option in `@babel/preset-env` is the successor to using `@babel/preset-modules` directly.
 
@@ -110,7 +108,7 @@ You can enable this option today by adding it to `@babel/preset-env` in your con
 
 Moving forward, we would like to work with the community (including browsers) to allow for this kind of approach to work smoothly as we continually transition in JavaScript's development. In the ideal scenario, Babel would be able to implement and help influence the future of new proposals as they are suggested and refined, and smooth over these edge cases for existing standards so that the minimum compiled output is possible for all users of JavaScript based on their targets.
 
-### TypeScript 3.8: type-only imports and exports ([#11171](https://github.com/babel/babel/pull/11171))
+## TypeScript 3.8: type-only imports and exports ([#11171](https://github.com/babel/babel/pull/11171))
 
 You can now explicitly mark imports and exports as type-only, similarly to what you can already do in Flow:
 
@@ -140,7 +138,7 @@ We recommend configuring `@babel/preset-typescript` or `@babel/plugin-transform-
 
 > ℹ️ These features were contributed by the Babel team together, and by [Siddhant N Trivedi](https://twitter.com/sidntrivedi012/). If you have interested in seeing how it's all done, please check how we did it [on YouTube](https://www.youtube.com/playlist?list=PLoB4QYcbtyGbpTpRs_ZZLTVxi96iCl7-A)!
 
-### Flow `declare` fields ([#11178](https://github.com/babel/babel/pull/11178))
+## Flow `declare` fields ([#11178](https://github.com/babel/babel/pull/11178))
 
 The class fields proposal specifies uninitialized class fields are initialized to `undefined`: this is different from what Babel does with Flow, because it simply ignores them.
 
@@ -167,7 +165,7 @@ To avoid breaking changes, we introduced support for declare in class fields beh
 }
 ```
 
-### A new JSX transform ([#11154](https://github.com/babel/babel/pull/11154))
+## A new JSX transform ([#11154](https://github.com/babel/babel/pull/11154))
 
 The React team created an [RFC](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md) back in February of last year to discuss simplifying element creation.
 


### PR DESCRIPTION
Noticed by reviewing https://github.com/babel/website/pull/2260

![image](https://user-images.githubusercontent.com/588473/82921698-ac920800-9f46-11ea-8143-ff80e9c3f4af.png)

There's only 1 h2, which is "highlights" so it is unnecessary. Seems like I just added that in for 7.1 post for no reason so my bad 😄 

![image](https://user-images.githubusercontent.com/588473/82921777-c4698c00-9f46-11ea-93ce-8647f177fd99.png)
