### PR TITLE
Document loose babel-plugin-transform-spread behaviour on array with holes

### DIFF
--- a/docs/plugin-transform-spread.md
+++ b/docs/plugin-transform-spread.md
@@ -78,6 +78,8 @@ require("@babel/core").transform("code", {
 
 In loose mode, **all** iterables are assumed to be arrays.
 
+Loose mode preserves "holes" when spreading an array (for example, `[ ...Array(2) ]` produces `[ (hole), (hole) ]`). Set loose to `false` to avoid this behaviour.
+
 > You can read more about configuring plugin options [here](https://babeljs.io/docs/en/plugins#plugin-options)
 
 ### `allowArrayLike`

--- a/website/versioned_docs/version-7.0.0/plugin-transform-spread.md
+++ b/website/versioned_docs/version-7.0.0/plugin-transform-spread.md
@@ -79,6 +79,8 @@ require("@babel/core").transform("code", {
 
 In loose mode, **all** iterables are assumed to be arrays.
 
+Loose mode preserves "holes" when spreading an array (for example, `[ ...Array(2) ]` produces `[ (hole), (hole) ]`). Set loose to `false` to avoid this behaviour.
+
 > You can read more about configuring plugin options [here](https://babeljs.io/docs/en/plugins#plugin-options)
 
 ## References

--- a/website/versioned_docs/version-7.10.0/plugin-transform-spread.md
+++ b/website/versioned_docs/version-7.10.0/plugin-transform-spread.md
@@ -79,6 +79,8 @@ require("@babel/core").transform("code", {
 
 In loose mode, **all** iterables are assumed to be arrays.
 
+Loose mode preserves "holes" when spreading an array (for example, `[ ...Array(2) ]` produces `[ (hole), (hole) ]`). Set loose to `false` to avoid this behaviour.
+
 > You can read more about configuring plugin options [here](https://babeljs.io/docs/en/plugins#plugin-options)
 
 ### `allowArrayLike`


### PR DESCRIPTION
Adds documentation as suggested here: https://github.com/babel/babel/issues/11683#issuecomment-639753629

This explains the scenario where `[...Array(2)].map((_, index) => index)` produces `[1,2]` in the browser, but an array with two holes after transpiling.

Resolves https://github.com/babel/babel/issues/11683