### PR TITLE
fix: prettier babel parser filename

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -80,7 +80,7 @@ const pluginConfigs: Array<PluginConfig> = [
     label: "Prettify",
     package: "prettier",
     version: "2",
-    files: ["standalone.js", "parser-babylon.js"],
+    files: ["standalone.js", "parser-babel.js"],
   },
 ];
 

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -30,7 +30,7 @@ type Return = {
 const DEFAULT_PRETTIER_CONFIG = {
   bracketSpacing: true,
   jsxBracketSameLine: false,
-  parser: "babylon",
+  parser: "babel",
   printWidth: 80,
   semi: true,
   singleQuote: false,


### PR DESCRIPTION
`parser-babylon.js` is deprecated in favor of `parser-babel.js`