### PR TITLE
[repl] Get the correct job id from CircleCI

### DIFF
--- a/js/repl/CircleCI.js
+++ b/js/repl/CircleCI.js
@@ -41,17 +41,20 @@ export async function loadBuildArtifacts(
 
 export async function loadLatestBuildNumberForBranch(
   repo: ?string,
-  branch: string
+  branch: string,
+  jobName: string,
+  limit: number = 10
 ): Promise<number> {
   try {
     const response = await sendRequest(
       repo,
-      `tree/${branch}?limit=1&filter=successful`
+      `tree/${branch}?limit=${limit}&filter=successful`
     );
-    if (!response || !response.length) {
-      throw new Error("No builds found");
-    }
-    return response[0].build_num;
+    if (!response) throw new Error("No builds found");
+
+    const build = response.find(build => build.workflows.job_name === jobName);
+    if (!build) throw new Error(`No builds found (${jobName})`);
+    return build.build_num;
   } catch (ex) {
     throw new Error(
       `Could not load latest Babel build on ${branch}: ${ex.message}`

--- a/js/repl/loadBundle.js
+++ b/js/repl/loadBundle.js
@@ -64,7 +64,8 @@ export default async function loadBundle(
         // /build/master for backwards compatibility.
         build = await loadLatestBuildNumberForBranch(
           state.circleciRepo,
-          build === "7.0" ? "master" : build
+          build === "7.0" ? "master" : build,
+          "build-standalone"
         );
       }
       const regExp = new RegExp(`${packageName}/${packageFile}$`);


### PR DESCRIPTION
The repl for `master` is currently not loading: try opening https://babeljs.io/repl/build/master in an incognito window.

This is because the repl always gets the _last_ CI build from Circle CI. However, it could happen that it's not `build-standalone` but `e2e-*` (https://circleci.com/api/v1.1/project/github/babel/babel/tree/master?filter=successful&limit=1): in that case, it won't find the artifact.

This PR fixes it by loading the last 10 builds and then finding the correct one.