### PR TITLE
Update node.md

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -71,7 +71,7 @@ babel-node [options] [ -e script | script.js ] [arguments]
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-npx babel-node --inspect --presets es2015 -- script.js --inspect
+npx babel-node --inspect --presets @babel/env -- script.js --inspect
 ```
 
 ### Options


### PR DESCRIPTION
> As of Babel v6, all the yearly presets have been deprecated. We recommend using @babel/preset-env instead.