### PR TITLE
Update presets

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,7 +148,7 @@ npx babel script.js --out-file script-compiled.js --presets=@babel/preset-env,@b
 Ignore the configuration from the project's `.babelrc.json` file and use the cli options e.g. for a custom build
 
 ```sh
-npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
+npx babel --no-babelrc script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/preset-react
 ```
 
 ### Custom config path

--- a/docs/node.md
+++ b/docs/node.md
@@ -71,7 +71,7 @@ babel-node [options] [ -e script | script.js ] [arguments]
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-npx babel-node --inspect --presets es2015 -- script.js --inspect
+npx babel-node --inspect --presets @babel/preset-env -- script.js --inspect
 ```
 
 ### Options

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -234,13 +234,11 @@ It is important to remember that with presets, the order is _reversed_. The foll
 
 ```json
 {
-  "presets": ["es2015", "react", "stage-2"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }
 ```
 
-Will run in the following order: `stage-2`, `react`, then `es2015`.
-
-This is mostly for ensuring backwards compatibility, since most users list "es2015" before "stage-0". For more information, see [notes on potential traversal API changes](https://github.com/babel/notes/blob/master/2016/2016-08/august-01.md#potential-api-changes-for-traversal).
+Will run in the following order: `@babel/preset-react` then `@babel/preset-env`.
 
 ## Plugin Options
 

--- a/docs/v7-migration.md
+++ b/docs/v7-migration.md
@@ -275,7 +275,7 @@ In Babel 7, values are resolved consistently either relative to the config file 
 For `presets` and `plugins` values, this change means that the CLI will behave nicely in cases such as
 
 ```bash
-babel --presets @babel/preset-es2015 ../file.js
+babel --presets @babel/preset-env ../file.js
 ```
 
 Assuming your `node_modules` folder is in `.`, in Babel 6 this would fail because the preset could not be found.

--- a/website/data/tools/nodemon/usage.md
+++ b/website/data/tools/nodemon/usage.md
@@ -19,5 +19,5 @@ nodemon --exec npm run babel-node -- path/to/script.js
 Calling nodemon with babel-node may lead to arguments getting parsed incorrectly if you forget to use a double dash. Using npm-scripts helpers prevent this. If you chose to skip using npm-scripts, it can be expressed as:
 
 ```sh
-nodemon --exec babel-node --presets=es2015 --ignore='foo\|bar\|baz' -- path/to/script.js
+nodemon --exec babel-node --presets=@babel/preset-env --ignore='foo\|bar\|baz' -- path/to/script.js
 ```

--- a/website/versioned_docs/version-6.26.3/cli.md
+++ b/website/versioned_docs/version-6.26.3/cli.md
@@ -136,7 +136,7 @@ npx babel script.js --out-file script-compiled.js --plugins=transform-runtime,tr
 Use the `--presets` option to specify presets to use in compilation
 
 ```sh
-npx babel script.js --out-file script-compiled.js --presets=es2015,react
+npx babel script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/preset-react
 ```
 
 ### Ignoring .babelrc
@@ -144,7 +144,7 @@ npx babel script.js --out-file script-compiled.js --presets=es2015,react
 Ignore the configuration from the projects .babelrc file and use the cli options e.g. for a custom build
 
 ```sh
-npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
+npx babel --no-babelrc script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/preset-react
 ```
 
 ### Advanced Usage
@@ -205,7 +205,7 @@ babel-node [options] [ -e script | script.js ] [arguments]
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-npx babel-node --inspect --presets es2015 -- script.js --inspect
+npx babel-node --inspect --presets @babel/preset-env -- script.js --inspect
 ```
 
 ### Options

--- a/website/versioned_docs/version-7.0.0/cli.md
+++ b/website/versioned_docs/version-7.0.0/cli.md
@@ -142,7 +142,7 @@ npx babel script.js --out-file script-compiled.js --presets=@babel/preset-env,@b
 Ignore the configuration from the project's `.babelrc` file and use the cli options e.g. for a custom build
 
 ```sh
-npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
+npx babel --no-babelrc script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/preset-react
 ```
 
 ### Custom config path

--- a/website/versioned_docs/version-7.0.0/node.md
+++ b/website/versioned_docs/version-7.0.0/node.md
@@ -72,7 +72,7 @@ babel-node [options] [ -e script | script.js ] [arguments]
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-npx babel-node --inspect --presets es2015 -- script.js --inspect
+npx babel-node --inspect --presets @babel/preset-env -- script.js --inspect
 ```
 
 ### Options

--- a/website/versioned_docs/version-7.0.0/plugins.md
+++ b/website/versioned_docs/version-7.0.0/plugins.md
@@ -233,17 +233,11 @@ It is important to remember that with presets, the order is _reversed_. The foll
 
 ```json
 {
-  "presets": [
-    "es2015",
-    "react",
-    "stage-2"
-  ]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }
 ```
 
-Will run in the following order: `stage-2`, `react`, then `es2015`.
-
-This is mostly for ensuring backwards compatibility, since most users list "es2015" before "stage-0". For more information, see [notes on potential traversal API changes](https://github.com/babel/notes/blob/master/2016/2016-08/august-01.md#potential-api-changes-for-traversal).
+Will run in the following order: `@babel/preset-react` then `@babel/preset-env`.
 
 ## Plugin Options
 

--- a/website/versioned_docs/version-7.0.0/standalone.md
+++ b/website/versioned_docs/version-7.0.0/standalone.md
@@ -33,7 +33,7 @@ Load `babel.js` or `babel.min.js` in your environment. This will expose [Babel's
 
 ```js
 var input = 'const getMessage = () => "Hello World";';
-var output = Babel.transform(input, { presets: ['es2015'] }).code;
+var output = Babel.transform(input, { presets: ['@babel/preset-env'] }).code;
 ```
 
 When loaded in a browser, @babel/standalone will automatically compile and execute all script tags with type `text/babel` or `text/jsx`:
@@ -50,7 +50,7 @@ document.getElementById('output').innerHTML = getMessage();
 
 You can use the `data-plugins` and `data-presets` attributes to specify the Babel plugins/presets to use:
 ```html
-<script type="text/babel" data-presets="es2015,stage-2">
+<script type="text/babel" data-presets="@babel/preset-env">
 ```
 
 Loading external scripts via `src` attribute is supported too:

--- a/website/versioned_docs/version-7.0.0/v7-migration.md
+++ b/website/versioned_docs/version-7.0.0/v7-migration.md
@@ -272,7 +272,7 @@ In Babel 7, values are resolved consistently either relative to the config file 
 For `presets` and `plugins` values, this change means that the CLI will behave nicely in cases such as
 
 ```bash
-babel --presets @babel/preset-es2015 ../file.js
+babel --presets @babel/preset-env ../file.js
 ```
 
 Assuming your `node_modules` folder is in `.`, in Babel 6 this would fail because the preset could not be found.

--- a/website/versioned_docs/version-7.2.0/plugins.md
+++ b/website/versioned_docs/version-7.2.0/plugins.md
@@ -231,13 +231,11 @@ It is important to remember that with presets, the order is _reversed_. The foll
 
 ```json
 {
-  "presets": ["es2015", "react", "stage-2"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }
 ```
 
-Will run in the following order: `stage-2`, `react`, then `es2015`.
-
-This is mostly for ensuring backwards compatibility, since most users list "es2015" before "stage-0". For more information, see [notes on potential traversal API changes](https://github.com/babel/notes/blob/master/2016/2016-08/august-01.md#potential-api-changes-for-traversal).
+Will run in the following order: `@babel/preset-react` then `@babel/preset-env`.
 
 ## Plugin Options
 

--- a/website/versioned_docs/version-7.3.0/plugins.md
+++ b/website/versioned_docs/version-7.3.0/plugins.md
@@ -232,13 +232,11 @@ It is important to remember that with presets, the order is _reversed_. The foll
 
 ```json
 {
-  "presets": ["es2015", "react", "stage-2"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }
 ```
 
-Will run in the following order: `stage-2`, `react`, then `es2015`.
-
-This is mostly for ensuring backwards compatibility, since most users list "es2015" before "stage-0". For more information, see [notes on potential traversal API changes](https://github.com/babel/notes/blob/master/2016/2016-08/august-01.md#potential-api-changes-for-traversal).
+Will run in the following order: `@babel/preset-react` then `@babel/preset-env`.
 
 ## Plugin Options
 

--- a/website/versioned_docs/version-7.4.0/plugins.md
+++ b/website/versioned_docs/version-7.4.0/plugins.md
@@ -233,13 +233,11 @@ It is important to remember that with presets, the order is _reversed_. The foll
 
 ```json
 {
-  "presets": ["es2015", "react", "stage-2"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }
 ```
 
-Will run in the following order: `stage-2`, `react`, then `es2015`.
-
-This is mostly for ensuring backwards compatibility, since most users list "es2015" before "stage-0". For more information, see [notes on potential traversal API changes](https://github.com/babel/notes/blob/master/2016/2016-08/august-01.md#potential-api-changes-for-traversal).
+Will run in the following order: `@babel/preset-react` then `@babel/preset-env`.
 
 ## Plugin Options
 

--- a/website/versioned_docs/version-7.6.0/v7-migration.md
+++ b/website/versioned_docs/version-7.6.0/v7-migration.md
@@ -276,7 +276,7 @@ In Babel 7, values are resolved consistently either relative to the config file 
 For `presets` and `plugins` values, this change means that the CLI will behave nicely in cases such as
 
 ```bash
-babel --presets @babel/preset-es2015 ../file.js
+babel --presets @babel/preset-env ../file.js
 ```
 
 Assuming your `node_modules` folder is in `.`, in Babel 6 this would fail because the preset could not be found.

--- a/website/versioned_docs/version-7.8.0/cli.md
+++ b/website/versioned_docs/version-7.8.0/cli.md
@@ -142,7 +142,7 @@ npx babel script.js --out-file script-compiled.js --presets=@babel/preset-env,@b
 Ignore the configuration from the project's `.babelrc.json` file and use the cli options e.g. for a custom build
 
 ```sh
-npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
+npx babel --no-babelrc script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/preset-react
 ```
 
 ### Custom config path

--- a/website/versioned_docs/version-7.8.0/node.md
+++ b/website/versioned_docs/version-7.8.0/node.md
@@ -72,7 +72,7 @@ babel-node [options] [ -e script | script.js ] [arguments]
 When arguments for user script have names conflicting with node options, double dash placed before script name can be used to resolve ambiguities
 
 ```sh
-npx babel-node --inspect --presets es2015 -- script.js --inspect
+npx babel-node --inspect --presets @babel/preset-env -- script.js --inspect
 ```
 
 ### Options

--- a/website/versioned_docs/version-7.8.4/cli.md
+++ b/website/versioned_docs/version-7.8.4/cli.md
@@ -148,7 +148,7 @@ npx babel script.js --out-file script-compiled.js --presets=@babel/preset-env,@b
 Ignore the configuration from the project's `.babelrc.json` file and use the cli options e.g. for a custom build
 
 ```sh
-npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
+npx babel --no-babelrc script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/preset-react
 ```
 
 ### Custom config path

--- a/website/versioned_docs/version-7.9.0/cli.md
+++ b/website/versioned_docs/version-7.9.0/cli.md
@@ -149,7 +149,7 @@ npx babel script.js --out-file script-compiled.js --presets=@babel/preset-env,@b
 Ignore the configuration from the project's `.babelrc.json` file and use the cli options e.g. for a custom build
 
 ```sh
-npx babel --no-babelrc script.js --out-file script-compiled.js --presets=es2015,react
+npx babel --no-babelrc script.js --out-file script-compiled.js --presets=@babel/preset-env,@babel/preset-react
 ```
 
 ### Custom config path


### PR DESCRIPTION
> As of Babel v6, all the yearly presets have been deprecated. We recommend using @babel/preset-env instead.