### PR TITLE
docs: link getting started page on flow/typescript preset

### DIFF
--- a/docs/preset-flow.md
+++ b/docs/preset-flow.md
@@ -4,7 +4,7 @@ title: @babel/preset-flow
 sidebar_label: flow
 ---
 
-This preset includes the following plugins:
+This preset is recommended if you use [Flow](https://flow.org/en/docs/getting-started/), a static type checker for JavaScript code. It includes the following plugins:
 
 - [@babel/plugin-transform-flow-strip-types](plugin-transform-flow-strip-types.md)
 

--- a/docs/preset-typescript.md
+++ b/docs/preset-typescript.md
@@ -4,7 +4,7 @@ title: @babel/preset-typescript
 sidebar_label: typescript
 ---
 
-This preset includes the following plugins:
+This preset is recommended if you use [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html), a typed superset of JavaScript. It includes the following plugins:
 
 - [@babel/plugin-transform-typescript](plugin-transform-typescript.md)
 

--- a/website/versioned_docs/version-7.9.0/preset-flow.md
+++ b/website/versioned_docs/version-7.9.0/preset-flow.md
@@ -5,7 +5,7 @@ sidebar_label: flow
 original_id: babel-preset-flow
 ---
 
-This preset includes the following plugins:
+This preset is recommended if you use [Flow](https://flow.org/en/docs/getting-started/), a static type checker for JavaScript code. It includes the following plugins:
 
 - [@babel/plugin-transform-flow-strip-types](plugin-transform-flow-strip-types.md)
 

--- a/website/versioned_docs/version-7.9.0/preset-typescript.md
+++ b/website/versioned_docs/version-7.9.0/preset-typescript.md
@@ -5,7 +5,7 @@ sidebar_label: typescript
 original_id: babel-preset-typescript
 ---
 
-This preset includes the following plugins:
+This preset is recommended if you use [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html), a typed superset of JavaScript. It includes the following plugins:
 
 - [@babel/plugin-transform-typescript](plugin-transform-typescript.md)
 
@@ -26,6 +26,8 @@ const x = 0;
 ```
 
 ## Installation
+
+> You can also check out the [TypeScript in 5 minutes page](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
 
 ```sh
 npm install --save-dev @babel/preset-typescript


### PR DESCRIPTION
We linked to React Get Started Page: https://babeljs.io/docs/en/babel-preset-react#installation

I think it makes sense to extends to TypeScript/Flow.

Fixes #2287 

