### PR TITLE
Update Rollup usage/setup guide

### DIFF
--- a/website/data/tools/rollup/install.md
+++ b/website/data/tools/rollup/install.md
@@ -3,11 +3,5 @@ npm install --save-dev rollup
 ```
 
 ```sh
-npm install --save-dev rollup-plugin-babel
-```
-
-Instead of the `es2015` preset:
-
-```sh
-npm install --save-dev babel-preset-es2015-rollup
+npm install --save-dev @rollup/plugin-babel
 ```

--- a/website/data/tools/rollup/usage.md
+++ b/website/data/tools/rollup/usage.md
@@ -1,16 +1,16 @@
 ```js
-var rollup = require("rollup");
-var babel = require("@rollup/plugin-babel");
+import babel from '@rollup/plugin-babel';
 
-rollup.rollup({
-  entry: "src/main.js",
-  plugins: [ babel() ]
-}).then(function (bundle) {
-  bundle.write({
-    dest: "dist/bundle.js",
-    format: "umd"
-  });
-});
+const config = {
+  input: 'src/index.js',
+  output: {
+    dir: 'output',
+    format: 'esm'
+  },
+  plugins: [babel({ babelHelpers: 'bundled' })]
+};
+
+export default config;
 ```
 
 <blockquote class="babel-callout babel-callout-info">

--- a/website/data/tools/rollup/usage.md
+++ b/website/data/tools/rollup/usage.md
@@ -1,6 +1,6 @@
 ```js
 var rollup = require("rollup");
-var babel = require("rollup-plugin-babel");
+var babel = require("@rollup/plugin-babel");
 
 rollup.rollup({
   entry: "src/main.js",
@@ -15,6 +15,6 @@ rollup.rollup({
 
 <blockquote class="babel-callout babel-callout-info">
   <p>
-    For more information see the <a href="https://github.com/rollup/rollup">rollup</a> and <a href="https://github.com/rollup/rollup-plugin-babel">rollup-plugin-babel</a> repos.
+    For more information see the <a href="https://github.com/rollup/rollup">rollup</a> and <a href="https://github.com/rollup/plugins/tree/master/packages/babel">@rollup/plugin-babel</a> repos.
   </p>
 </blockquote>


### PR DESCRIPTION
Adjusted several things for the Rollup setup guide:
* [`rollup-plugin-babel`](https://github.com/rollup/rollup-plugin-babel) has been deprecated for a while now, replaced this with the maintained version `@rollup/plugin-babel` and adjusted the links as well.
* Removed the installation instruction for `babel-preset-es2015-rollup`. The base ES2015 preset from Babel itself is deprecated and so installing it will present the user with...well...deprecation warnings.