### PR TITLE
Move me to contributors, add JLHwung, order core by name

### DIFF
--- a/website/data/team.yml
+++ b/website/data/team.yml
@@ -2,12 +2,15 @@ core:
   - name: Babel
     github: babel
     twitter: babeljs
-  - name: Daniel Tschinder
-    github: danez
-    twitter: TschinderDaniel
   - name: Brian Ng
     github: existentialism
     twitter: existentialism
+  - name: Henry Zhu
+    github: hzoo
+    twitter: left_pad
+  - name: Huáng Jùnliàng
+    github: JLHwung
+    twitter: JLHwung
   - name: Logan Smyth
     github: loganfsmyth
     twitter: loganfsmyth
@@ -17,9 +20,6 @@ core:
   - name: Sven Sauleau
     github: xtuc
     twitter: svensauleau
-  - name: Henry Zhu
-    github: hzoo
-    twitter: left_pad
 members:
   - name: Andrew Levine
     github: drewml
@@ -32,7 +32,10 @@ members:
     twitter: heisenbugger
   - name: Buu Nguyen
     github: buunguyen
-    twitter: buunguyen    
+    twitter: buunguyen
+  - name: Daniel Tschinder
+    github: danez
+    twitter: TschinderDaniel
   - name: Denis Pushkarev
     github: zloirock
     twitter: zloirock


### PR DESCRIPTION
Well as you noticed I am not really active in babel, I'm struggling with live and the pandemic is not helping with that. But what I wanted to say: I don't feel it's fair to be represented as core member anymore. I'm happy to help in the future and I'm always reachable, but I'm already so far away from the project and it feels that will not change any time soon. 

I also noticed that Huáng is not represented on the team page, but looking at the babel commits I only see his face :joy: So I guess you should be added.