### PR TITLE
docs: clarify modules option in preset-env

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -42,7 +42,15 @@ relative to.
 
 ### `caller`
 
-Type: `Object` with a string-typed `"name"` property.<br />
+Type: An object with the shape of
+```flow
+interface CallerData {
+  name: string;
+  supportsStaticESM: boolean;
+  supportsDynamicImport: boolean;
+  supportsTopLevelAwait: boolean;
+}
+```
 
 Utilities may pass a `caller` object to identify themselves to Babel and pass
 capability-related flags for use by configs, presets and plugins. For example

--- a/docs/options.md
+++ b/docs/options.md
@@ -46,9 +46,9 @@ Type: An object with the shape of
 ```flow
 interface CallerData {
   name: string;
-  supportsStaticESM: boolean;
-  supportsDynamicImport: boolean;
-  supportsTopLevelAwait: boolean;
+  supportsStaticESM?: boolean;
+  supportsDynamicImport?: boolean;
+  supportsTopLevelAwait?: boolean;
 }
 ```
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -187,10 +187,10 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 Enable transformation of ES module syntax to another module type. Note that `cjs` is just an alias for `commonjs`.
 
-Setting this to `false` will preserve ES module. This is only favored if you intend to ship native ES Module to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
+Setting this to `false` will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
 #### `modules: "auto"`
-By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES module and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimized results if bundlers supports new module features.
+By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES modules and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.
 
 ### `debug`
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -185,11 +185,12 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 `"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
-Enable transformation of ES6 module syntax to another module type.
+Enable transformation of ES module syntax to another module type. Note that `cjs` is just an alias for `commonjs`.
 
-Setting this to `false` will not transform modules.
+Setting this to `false` will preserve ES module. This is only favored if you intend to ship native ES Module to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
-Also note that `cjs` is just an alias for `commonjs`.
+#### `modules: "auto"`
+By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES module and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimized results if bundlers supports new module features.
 
 ### `debug`
 

--- a/website/versioned_docs/version-7.0.0/options.md
+++ b/website/versioned_docs/version-7.0.0/options.md
@@ -37,7 +37,13 @@ relative to.
 
 ### `caller`
 
-Type: `Object` with a string-typed `"name"` property.<br />
+Type: An object with the shape of
+```flow
+interface CallerData {
+  name: string;
+  supportsStaticESM?: boolean;
+}
+```
 
 Utilities may pass a `caller` object to identify themselves to Babel and pass
 capability-related flags for use by configs, presets and plugins. For example

--- a/website/versioned_docs/version-7.0.0/preset-env.md
+++ b/website/versioned_docs/version-7.0.0/preset-env.md
@@ -176,11 +176,12 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 `"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
-Enable transformation of ES6 module syntax to another module type.
+Enable transformation of ES module syntax to another module type. Note that `cjs` is just an alias for `commonjs`.
 
-Setting this to `false` will not transform modules.
+Setting this to `false` will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
-Also note that `cjs` is just an alias for `commonjs`.
+#### `modules: "auto"`
+By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES modules and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.
 
 ### `debug`
 

--- a/website/versioned_docs/version-7.1.0/options.md
+++ b/website/versioned_docs/version-7.1.0/options.md
@@ -43,7 +43,13 @@ relative to.
 
 ### `caller`
 
-Type: `Object` with a string-typed `"name"` property.<br />
+Type: An object with the shape of
+```flow
+interface CallerData {
+  name: string;
+  supportsStaticESM: boolean;
+}
+```
 
 Utilities may pass a `caller` object to identify themselves to Babel and pass
 capability-related flags for use by configs, presets and plugins. For example

--- a/website/versioned_docs/version-7.1.0/options.md
+++ b/website/versioned_docs/version-7.1.0/options.md
@@ -47,7 +47,7 @@ Type: An object with the shape of
 ```flow
 interface CallerData {
   name: string;
-  supportsStaticESM: boolean;
+  supportsStaticESM?: boolean;
 }
 ```
 

--- a/website/versioned_docs/version-7.10.0/preset-env.md
+++ b/website/versioned_docs/version-7.10.0/preset-env.md
@@ -186,11 +186,12 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 `"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
-Enable transformation of ES6 module syntax to another module type.
+Enable transformation of ES module syntax to another module type. Note that `cjs` is just an alias for `commonjs`.
 
-Setting this to `false` will not transform modules.
+Setting this to `false` will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
-Also note that `cjs` is just an alias for `commonjs`.
+#### `modules: "auto"`
+By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES modules and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.
 
 ### `debug`
 

--- a/website/versioned_docs/version-7.4.0/preset-env.md
+++ b/website/versioned_docs/version-7.4.0/preset-env.md
@@ -176,11 +176,12 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 `"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
-Enable transformation of ES6 module syntax to another module type.
+Enable transformation of ES module syntax to another module type. Note that `cjs` is just an alias for `commonjs`.
 
-Setting this to `false` will not transform modules.
+Setting this to `false` will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
-Also note that `cjs` is just an alias for `commonjs`.
+#### `modules: "auto"`
+By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES modules and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.
 
 ### `debug`
 

--- a/website/versioned_docs/version-7.8.0/options.md
+++ b/website/versioned_docs/version-7.8.0/options.md
@@ -44,7 +44,15 @@ relative to.
 
 ### `caller`
 
-Type: `Object` with a string-typed `"name"` property.<br />
+Type: An object with the shape of
+```flow
+interface CallerData {
+  name: string;
+  supportsStaticESM: boolean;
+  supportsDynamicImport: boolean;
+  supportsTopLevelAwait: boolean;
+}
+```
 
 Utilities may pass a `caller` object to identify themselves to Babel and pass
 capability-related flags for use by configs, presets and plugins. For example

--- a/website/versioned_docs/version-7.8.0/options.md
+++ b/website/versioned_docs/version-7.8.0/options.md
@@ -48,9 +48,9 @@ Type: An object with the shape of
 ```flow
 interface CallerData {
   name: string;
-  supportsStaticESM: boolean;
-  supportsDynamicImport: boolean;
-  supportsTopLevelAwait: boolean;
+  supportsStaticESM?: boolean;
+  supportsDynamicImport?: boolean;
+  supportsTopLevelAwait?: boolean;
 }
 ```
 

--- a/website/versioned_docs/version-7.8.0/preset-env.md
+++ b/website/versioned_docs/version-7.8.0/preset-env.md
@@ -176,11 +176,12 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 `"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
-Enable transformation of ES6 module syntax to another module type.
+Enable transformation of ES module syntax to another module type. Note that `cjs` is just an alias for `commonjs`.
 
-Setting this to `false` will not transform modules.
+Setting this to `false` will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
-Also note that `cjs` is just an alias for `commonjs`.
+#### `modules: "auto"`
+By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES modules and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.
 
 ### `debug`
 

--- a/website/versioned_docs/version-7.8.4/options.md
+++ b/website/versioned_docs/version-7.8.4/options.md
@@ -44,7 +44,15 @@ relative to.
 
 ### `caller`
 
-Type: `Object` with a string-typed `"name"` property.<br />
+Type: An object with the shape of
+```flow
+interface CallerData {
+  name: string;
+  supportsStaticESM: boolean;
+  supportsDynamicImport: boolean;
+  supportsTopLevelAwait: boolean;
+}
+```
 
 Utilities may pass a `caller` object to identify themselves to Babel and pass
 capability-related flags for use by configs, presets and plugins. For example

--- a/website/versioned_docs/version-7.8.4/options.md
+++ b/website/versioned_docs/version-7.8.4/options.md
@@ -48,9 +48,9 @@ Type: An object with the shape of
 ```flow
 interface CallerData {
   name: string;
-  supportsStaticESM: boolean;
-  supportsDynamicImport: boolean;
-  supportsTopLevelAwait: boolean;
+  supportsStaticESM?: boolean;
+  supportsDynamicImport?: boolean;
+  supportsTopLevelAwait?: boolean;
 }
 ```
 

--- a/website/versioned_docs/version-7.9.0/options.md
+++ b/website/versioned_docs/version-7.9.0/options.md
@@ -47,9 +47,9 @@ Type: An object with the shape of
 ```flow
 interface CallerData {
   name: string;
-  supportsStaticESM: boolean;
-  supportsDynamicImport: boolean;
-  supportsTopLevelAwait: boolean;
+  supportsStaticESM?: boolean;
+  supportsDynamicImport?: boolean;
+  supportsTopLevelAwait?: boolean;
 }
 ```
 

--- a/website/versioned_docs/version-7.9.0/options.md
+++ b/website/versioned_docs/version-7.9.0/options.md
@@ -43,7 +43,15 @@ relative to.
 
 ### `caller`
 
-Type: `Object` with a string-typed `"name"` property.<br />
+Type: An object with the shape of
+```flow
+interface CallerData {
+  name: string;
+  supportsStaticESM: boolean;
+  supportsDynamicImport: boolean;
+  supportsTopLevelAwait: boolean;
+}
+```
 
 Utilities may pass a `caller` object to identify themselves to Babel and pass
 capability-related flags for use by configs, presets and plugins. For example

--- a/website/versioned_docs/version-7.9.0/preset-env.md
+++ b/website/versioned_docs/version-7.9.0/preset-env.md
@@ -186,11 +186,12 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 
 `"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.
 
-Enable transformation of ES6 module syntax to another module type.
+Enable transformation of ES module syntax to another module type. Note that `cjs` is just an alias for `commonjs`.
 
-Setting this to `false` will not transform modules.
+Setting this to `false` will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
-Also note that `cjs` is just an alias for `commonjs`.
+#### `modules: "auto"`
+By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES modules and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.
 
 ### `debug`
 


### PR DESCRIPTION
`{ modules: false }` has been long used as a fast switch to "preserve ES module" so bundlers can leverage from the module syntax. However the defaults `{ modules: "auto" }` should be preferred because it reads caller support data and reduces cognitive loads -- Idea like "I want to disable module transforms so Webpack can do tree shaking" is not straightforward, it is the defaults that should work out of that for you.

Since Babel 7.11, `preset-env` will assume `{ modules: false }` as to "preserve ES module" _and_ the compiled code will be served without bundling. By doing so `preset-env` can determine whether it should transpile `export * as ns` based on the targets. This assumption only works when it is _not_ passed to bundlers, where bundlers may not support latest module syntax, (e.g. Webpack 5.0.0-beta.21 supports this recently, thus `export * as ns` will break on Webpack 4.

Although `export * as ns` will break on Webpack 4, since it is not included in `preset-env` before, users should have supplied `@babel/plugin-proposal-export-namesapce-from` so they are good when upgrading to Babel 7.11. However users just begin to use `export * as ns` in `preset-env` 7.11 with

```js
{
  presets: ["@babel/preset-env", {
    modules: false,
    targets: { browsers: "latest Chrome 2 versions" }
  }]
}
```
may surprisedly find that `preset-env` does not transpile `export * as ns` and errors are thrown from Webpack.