### PR TITLE
Update mocha doc telling to import @babel/register instead of babel-register

### DIFF
--- a/website/data/tools/mocha/install.md
+++ b/website/data/tools/mocha/install.md
@@ -1,3 +1,3 @@
 ```sh
-npm install --save-dev babel-register
+npm install --save-dev @babel/register
 ```

--- a/website/data/tools/mocha/usage.md
+++ b/website/data/tools/mocha/usage.md
@@ -7,7 +7,7 @@ In your `package.json` file make the following changes:
 ```json
 {
   "scripts": {
-    "test": "mocha --require babel-register"
+    "test": "mocha --require @babel/register"
   }
 }
 ```
@@ -21,7 +21,7 @@ npm install --save-dev babel-polyfill
 ```json
 {
   "scripts": {
-    "test": "mocha --require babel-polyfill --require babel-register"
+    "test": "mocha --require babel-polyfill --require @babel/register"
   }
 }
 ```
@@ -32,7 +32,7 @@ npm install --save-dev babel-polyfill
 ```json
 {
   "scripts": {
-    "test": "mocha --compilers js:babel-register"
+    "test": "mocha --compilers js:@babel/register"
   }
 }
 ```
@@ -42,7 +42,7 @@ With polyfill:
 ```json
 {
   "scripts": {
-    "test": "mocha --require babel-polyfill --compilers js:babel-register"
+    "test": "mocha --require babel-polyfill --compilers js:@babel/register"
   }
 }
 ```


### PR DESCRIPTION
I ran into below while I was following setup recommendations with mocha

```
error: bundling failed: Error: Requires Babel "^7.0.0-0", but was
loaded with "6.26.3". If you are sure you have a compatible version of
@babel/core, it is likely that something in your build process is
loading the wrong version. Inspect the stack trace of this error to
look for the first entry that doesn't mention "@babel/core" or
"babel-core" to see what is calling Babel.
```

Doc says to import `babel-register` although it sounds like this has been moved to `@babel/register`

See more info in the [bug ticket](https://github.com/babel/website/issues/2305) and [stackoverflow post](https://stackoverflow.com/questions/51873516/requires-babel-7-0-0-0-but-was-loaded-with-6-26-3)