### PR TITLE
Update docs/node.md on @babel/cli

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -27,13 +27,13 @@ it will compile ES6 code before running it.
 
 Launch a REPL (Read-Eval-Print-Loop).
 
-> You should install `@babel/node` and `@babel/core` first before `npx babel-node`, otherwise `npx` will install out-of-dated legacy `babel-node` 6.x.
+> You should install `@babel/node`, `@babel/core` and `@babel/cli` first before `npx babel-node`, otherwise `npx` will install out-of-dated legacy `babel-node` 6.x.
 
 ```sh
 npx babel-node
 ```
 
-If you prefer not to install `@babel/node` and `@babel/core`, you can install them on-the-fly:
+If you prefer not to install these packages, you can install them on-the-fly:
 ```sh
 npx -p @babel/core -p @babel/node -p @babel/cli babel-node
 ```

--- a/docs/node.md
+++ b/docs/node.md
@@ -9,7 +9,7 @@ babel-node is a CLI that works exactly the same as the Node.js CLI, with the add
 ## Install
 
 ```sh
-npm install --save-dev @babel/core @babel/node
+npm install --save-dev @babel/core @babel/node @babel/cli
 ```
 
 > #### Not meant for production use
@@ -35,7 +35,7 @@ npx babel-node
 
 If you prefer not to install `@babel/node` and `@babel/core`, you can install them on-the-fly:
 ```sh
-npx -p @babel/core -p @babel/node babel-node
+npx -p @babel/core -p @babel/node -p @babel/cli babel-node
 ```
 
 Evaluate code.


### PR DESCRIPTION
We have a pipeline that was breaking today because of `@babel/cli`. Not installing it was causing the following error when running `npx node-babel ...`:

```bash
You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.

    npm uninstall -g babel
    npm install --save-dev babel-cli

See http://babeljs.io/docs/usage/cli/ for setup instructions.
Error: Process completed with exit code 1.
```

I guess it's related to the old `babel` package being installed as a peer dependency of `@babel/node` or `@babel/core`. 

This PR updates the docs to include the new `@babel/cli` as described in here: https://babeljs.io/docs/en/babel-cli/#usage

Other approach would be tracking down this package dependency.

What do you think?