### PR TITLE
Remove mentioning of instance methods from `usage.md`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -162,7 +162,7 @@ The [@babel/polyfill](polyfill.md) module includes [core-js](https://github.com/
 
 This means you can use new built-ins like `Promise` or `WeakMap`, static methods like `Array.from` or `Object.assign`, instance methods like `Array.prototype.includes`, and generator functions (when used alongside the regenerator plugin). The polyfill adds to the global scope as well as native prototypes like `String` in order to do this.
 
-For library/tool authors this may be too much. If you don't need the instance methods like `Array.prototype.includes` you can do without polluting the global scope altogether by using the [transform runtime](plugin-transform-runtime.md) plugin instead of `@babel/polyfill`.
+For library/tool authors this may be too much. If you don't want to pollute the global scope you can do without polluting the global scope altogether by using the [transform runtime](plugin-transform-runtime.md) plugin instead of `@babel/polyfill`.
 
 To go one step further, if you know exactly what features you need polyfills for, you can require them directly from [core-js](https://github.com/zloirock/core-js#commonjs).
 


### PR DESCRIPTION
core-js@3 can polyfill the instance methods without touching global scope. the documentation of babel-plugin-transform-runtime also mentions this: 

https://babeljs.io/docs/en/next/babel-plugin-transform-runtime#corejs

I'm not really sure 'pollute' is right word to choose, so I'd love to get some feedback and edit it!