### PR TITLE
Clarify typescript preset/plugin scope

### DIFF
--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -6,7 +6,9 @@ sidebar_label: Typescript Plugin
 
 > **NOTE**: This plugin is included in `@babel/preset-typescript`
 
-This plugin adds support for the syntax used by the [TypeScript programming language][ts]. However, this plugin does not add the ability to type-check the JavaScript passed to it. For that, you will need to install and set up TypeScript.
+This plugin adds support for the types syntax used by the [TypeScript programming language][ts]. However, this plugin does not add the ability to type-check the JavaScript passed to it. For that, you will need to install and set up TypeScript.
+
+Note that although the TypeScript compiler `tsc` actively supports certain JavaScript proposals such as optional chaining (`?.`), nullish coalescing (`??`) and class properties (`this.#x`), this preset does not include these features because they are not the types syntax available in TypeScript only. We recommend using `preset-env` with `preset-typescript` if you want to transpile these features.
 
 ## Example
 


### PR DESCRIPTION
Constantly we have feature requests like https://github.com/babel/babel/issues/10690 https://github.com/babel/babel/issues/12030 to include staged 3 features that are supported in TypeScript compilers. Since we are not making `preset-typescript` a `preset-whatever-tsc-can-do`, we should clarify this point on the docs.

Resolves https://github.com/babel/babel/issues/12030
Fixes #2311 