### PR TITLE
Add missing parser plugins

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -189,6 +189,7 @@ require("@babel/parser").parse("code", {
 | `classProperties` ([proposal](https://github.com/tc39/proposal-class-public-fields)) | `class A { b = 1; }` |
 | `classPrivateProperties` ([proposal](https://github.com/tc39/proposal-private-fields)) | `class A { #b = 1; }` |
 | `classPrivateMethods` ([proposal](https://github.com/tc39/proposal-private-methods)) | `class A { #c() {} }` |
+| `classStaticBlock` ([proposal](https://github.com/tc39/proposal-class-static-block)) | `class A { static {} }` |
 | `decorators` ([proposal](https://github.com/tc39/proposal-decorators)) <br> `decorators-legacy` | `@a class A {}` |
 | `doExpressions` ([proposal](https://github.com/tc39/proposal-do-expressions)) | `var a = do { if (true) { 'hi'; } };` |
 | `dynamicImport` ([proposal](https://github.com/tc39/proposal-dynamic-import)) | `import('./guy').then(a)` |

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -197,6 +197,7 @@ require("@babel/parser").parse("code", {
 | `exportNamespaceFrom` ([proposal](https://github.com/leebyron/ecmascript-export-ns-from)) | `export * as ns from "mod"` |
 | `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind)) | `a::b`, `::console.log` |
 | `functionSent` | `function.sent` |
+| `importAssertions` ([proposal](https://github.com/tc39/proposal-import-assertions)) | `import json from "./foo.json" assert { type: "json" };` |
 | `importMeta` ([proposal](https://github.com/tc39/proposal-import-meta)) | `import.meta.url` |
 | `logicalAssignment` ([proposal](https://github.com/tc39/proposal-logical-assignment)) | `a &&= b` |
 | `nullishCoalescingOperator` ([proposal](https://github.com/babel/proposals/issues/14)) | `a ?? b` |

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -476,6 +476,7 @@ The [Browserslist environment](https://github.com/browserslist/browserslist#conf
   <summary>History</summary>
 | Version | Changes |
 | --- | --- |
+| `v7.12.0` | Include class static block and import assertions |
 | `v7.10.0` | Include class properties and private methods |
 | `v7.9.0` | Include numeric separator |
 </details>


### PR DESCRIPTION
Add parser documentation for syntax added in 7.12. I also think the `moduleStringNames` should be mentioned, but I don't know where to put it.