### PR TITLE
Fix syntax error which breaks syntax highlighting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,7 +143,7 @@ config /path/to/cwd/babel.config.json
 {
   "sourceType": "script",
   "plugins": [
-    "@foo/babel-plugin-1
+    "@foo/babel-plugin-1"
   ],
   "extends": "./my-extended.js"
 }


### PR DESCRIPTION
The missing quote causes syntax highlighting issues in the docs website.