### PR TITLE
fix: increase the limits on recent builds to CircleCI API defaults

### DIFF
--- a/js/repl/CircleCI.js
+++ b/js/repl/CircleCI.js
@@ -43,7 +43,7 @@ export async function loadLatestBuildNumberForBranch(
   repo: ?string,
   branch: string,
   jobName: string,
-  limit: number = 10
+  limit: number = 30
 ): Promise<number> {
   try {
     const response = await sendRequest(


### PR DESCRIPTION
We have added so many CircleCI tasks that the standalone build task is not included in limit=10 jobs.

This PR increases `limit` to CircleCI defaults: https://circleci.com/docs/api/v1/#recent-builds-for-a-single-project

Fixed issue: Can not access Babel REPL main build (https://babel.dev/repl/build/main) even the build is successful.

