### PR TITLE
Extensions does not work with a quote delimited string.

### DIFF
--- a/docs/preset-typescript.md
+++ b/docs/preset-typescript.md
@@ -8,7 +8,7 @@ This preset is recommended if you use [TypeScript](https://www.typescriptlang.or
 
 - [@babel/plugin-transform-typescript](plugin-transform-typescript.md)
 
-> You will need to specify `--extensions ".ts"` for `@babel/cli` & `@babel/node` cli's to handle `.ts` files.
+> You will need to specify `--extensions .ts` for `@babel/cli` & `@babel/node` cli's to handle `.ts` files.
 
 ## Example
 


### PR DESCRIPTION
As I discovered in my own project. When using `.ts` files alongside `.js` files, passing a quote delimited string to `--extensions`, causes Babel to ignore plain `.js` files:

![extensions_string_issue](https://user-images.githubusercontent.com/772937/103475321-17b77e80-4d61-11eb-8da4-f0cda3d5506f.gif)

Commands are as follows:
```
"build": "babel src/ -s --extensions .js,.jsx,.ts,.tsx -d lib/",
"build-broken": "babel src/ -s --extensions '.js,.jsx,.ts,.tsx' -d lib/",
```

There may be other areas that need to be updated ... or perhaps this is just a bug?