### PR TITLE
Remove yearly presets from the REPL

### DIFF
--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -24,18 +24,20 @@ import type {
 } from "./types";
 
 const PRESET_ORDER = [
-  "es2015",
-  "es2015-loose",
-  "es2016",
-  "es2017",
-  "stage-0",
-  "stage-1",
-  "stage-2",
-  "stage-3",
   "react",
   "flow",
   "typescript",
+  "stage-3",
+  "stage-2",
+  "stage-1",
+  "stage-0",
 ];
+
+// These presets are deprecated. We only show them if they are enabled, so that
+// when they are enabled because of an old URL or local storage they can still
+// be disabled.
+// Otherwise we don't show them, to prevent people from enabling them.
+const HIDDEN_PRESETS = ["es2015", "es2015-loose", "es2016", "es2017"];
 
 type ToggleEnvPresetSetting = (name: string, value: any) => void;
 type ToggleExpanded = (isExpanded: boolean) => void;
@@ -287,6 +289,24 @@ class ExpandedContainer extends Component<Props, State> {
                   <option value="unambiguous">Unambiguous</option>
                 </select>
               </label>
+              <div className={styles.verticalLabeledOption}>
+                <LinkToDocs
+                  className={`${styles.verticalLabeledOptionLabel} ${
+                    styles.envPresetLabel
+                  } ${styles.highlight}`}
+                  section="targets"
+                >
+                  Targets
+                </LinkToDocs>
+                <textarea
+                  className={`${styles.envPresetInput} ${
+                    styles.envPresetTextarea
+                  }`}
+                  onChange={this._onEnvPresetSettingChange("browsers")}
+                  placeholder={envPresetDefaults.browsers.placeholder}
+                  value={envConfig.browsers}
+                />
+              </div>
             </AccordionTab>
             <AccordionTab
               className={styles.section}
@@ -306,6 +326,21 @@ class ExpandedContainer extends Component<Props, State> {
                     key={preset}
                     onSettingChange={onSettingChange}
                     state={state}
+                  />
+                );
+              })}
+              {HIDDEN_PRESETS.map(preset => {
+                const state = presetState[preset];
+
+                if (!state?.isEnabled) return null;
+
+                return (
+                  <PluginToggle
+                    config={state.config}
+                    key={preset}
+                    onSettingChange={onSettingChange}
+                    state={state}
+                    hidden
                   />
                 );
               })}
@@ -450,25 +485,6 @@ class ExpandedContainer extends Component<Props, State> {
                 Enabled
               </label>
 
-              <div className={styles.envPresetColumn}>
-                <LinkToDocs
-                  className={`${styles.envPresetColumnLabel} ${
-                    styles.envPresetLabel
-                  } ${styles.highlight}`}
-                  section="browserslist-integration"
-                >
-                  Browsers
-                </LinkToDocs>
-                <textarea
-                  disabled={!envConfig.isEnvPresetEnabled}
-                  className={`${styles.envPresetInput} ${
-                    styles.envPresetTextarea
-                  }`}
-                  onChange={this._onEnvPresetSettingChange("browsers")}
-                  placeholder={envPresetDefaults.browsers.placeholder}
-                  value={envConfig.browsers}
-                />
-              </div>
               <label className={styles.envPresetRow}>
                 <LinkToDocs
                   className={`${styles.envPresetLabel} ${styles.highlight}`}
@@ -756,6 +772,7 @@ type PluginToggleProps = {
   label?: string,
   state: PluginState,
   onSettingChange: ToggleSetting,
+  hidden?: boolean,
 };
 
 const PluginToggle = ({
@@ -763,8 +780,17 @@ const PluginToggle = ({
   label,
   state,
   onSettingChange,
+  hidden,
 }: PluginToggleProps) => (
-  <label key={config.label} className={styles.settingsLabel}>
+  <label
+    key={config.label}
+    className={styles.settingsLabel}
+    title={
+      hidden
+        ? "This plugin has been deprecated: this option will disappear once disabled."
+        : null
+    }
+  >
     <input
       checked={state.isEnabled && !state.didError}
       className={styles.inputCheckboxLeft}
@@ -774,6 +800,7 @@ const PluginToggle = ({
       }
       type="checkbox"
     />
+    {hidden && <span>{"❗ "}</span>}
     {state.isLoading ? <PresetLoadingAnimation /> : label || config.label}
   </label>
 );
@@ -979,6 +1006,7 @@ const styles = {
     margin: "0 -0.5rem",
     padding: "0 1rem",
     transition: "background-color 250ms ease-in-out, color 250ms ease-in-out",
+    cursor: "pointer",
 
     "&:hover": {
       backgroundColor: colors.inverseBackgroundDark,
@@ -1024,13 +1052,13 @@ const styles = {
     padding: "0.2rem 1.5rem 0.2rem 0.5rem",
     backgroundPosition: "calc(100% - 0.5rem) calc(100% - 0.3rem)",
   }),
-  envPresetColumn: css({
+  verticalLabeledOption: css({
     display: "flex",
     flexDirection: "column",
     margin: "0.5rem",
     flex: "0 0 auto",
   }),
-  envPresetColumnLabel: css({
+  verticalLabeledOptionLabel: css({
     marginBottom: "0.75rem",
   }),
   envPresetRow: css({


### PR DESCRIPTION
They have been deprecated since 7.0.0, and they are not even available anymore on npm (the npm packages are empty).

Since existing repl urls and existing settings saved in localStorage still have those presets, I didn't fully remove the option (to avoid breaking existing URLs). Instead, they are just hidden if they are not already enabled.

I also moved the "targets" option to the top: if we are removing the yearly presets it should have a more prominent role, since it's the main way to choose what to transpile. Also, this will better align with the top-level option of Babel 7.13.0.

Preview: https://deploy-preview-2439--babel.netlify.app/repl
Preview with the es2017 preset enabled: https://deploy-preview-2439--babel.netlify.app/repl#?presets=es2017