### PR TITLE
Replace babel {parse,transform} usage to *sync

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,7 @@ Check out the [babel-cli documentation](cli.md) to see more configuration option
 ## Using the API (`@babel/core`)
 
 ```js
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-arrow-functions"]
 });
 ```

--- a/docs/core.md
+++ b/docs/core.md
@@ -38,7 +38,7 @@ babel.transform("code();", options, function(err, result) {
 
 > Compat Note:
 >
-> In Babel 6, this method was synchronous and `transformSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformSync` since this backward-compat may be dropped in future major versions of Babel.
+> In Babel 6, this method was synchronous and `transformSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformSync` since this backward-compat will be dropped in Babel 8.
 
 ## transformSync
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -147,7 +147,7 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-const parsedAst = babel.parse(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
+const parsedAst = babel.parseSync(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
 babel.transformFromAst(parsedAst, sourceCode, options, function(err, result) {
   const { code, map, ast } = result;
 });
@@ -155,7 +155,7 @@ babel.transformFromAst(parsedAst, sourceCode, options, function(err, result) {
 
 > Compat Note:
 >
-> In Babel 6, this method was synchronous and `transformFromAstSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformFromAstSync` since this backward-compat may be dropped in future major versions of Babel.
+> In Babel 6, this method was synchronous and `transformFromAstSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformFromAstSync` since this backward-compat will be dropped in Babel 8.
 
 
 ## transformFromAstSync
@@ -166,7 +166,7 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-const parsedAst = babel.parse(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
+const parsedAst = babel.parseSync(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
 const { code, map, ast } = babel.transformFromAstSync(parsedAst, sourceCode, options);
 ```
 
@@ -199,8 +199,7 @@ enabled.
 >
 > In Babel 7's early betas, this method was synchronous and `parseSync` did not exist. For backward-compatibility,
 > this function will behave synchronously if no callback is given. If you're starting with Babel 7 stable
-> and need synchronous behavior, please use `parseSync` since this backward-compat may be dropped
-> in future major versions of Babel.
+> and need synchronous behavior, please use `parseSync` since this backward-compat will be dropped in Babel 8.
 
 
 ## parseSync

--- a/docs/core.md
+++ b/docs/core.md
@@ -38,7 +38,7 @@ babel.transform("code();", options, function(err, result) {
 
 > Compat Note:
 >
-> In Babel 6, this method was synchronous and `transformSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformSync` since this backward-compat will be dropped in Babel 8.
+> In Babel 6, this method was synchronous and `transformSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformSync` since this backward-compatibility will be dropped in Babel 8.
 
 ## transformSync
 
@@ -155,7 +155,7 @@ babel.transformFromAst(parsedAst, sourceCode, options, function(err, result) {
 
 > Compat Note:
 >
-> In Babel 6, this method was synchronous and `transformFromAstSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformFromAstSync` since this backward-compat will be dropped in Babel 8.
+> In Babel 6, this method was synchronous and `transformFromAstSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformFromAstSync` since this backward-compatibility will be dropped in Babel 8.
 
 
 ## transformFromAstSync
@@ -199,7 +199,7 @@ enabled.
 >
 > In Babel 7's early betas, this method was synchronous and `parseSync` did not exist. For backward-compatibility,
 > this function will behave synchronously if no callback is given. If you're starting with Babel 7 stable
-> and need synchronous behavior, please use `parseSync` since this backward-compat will be dropped in Babel 8.
+> and need synchronous behavior, please use `parseSync` since this backward-compatibility will be dropped in Babel 8.
 
 
 ## parseSync
@@ -316,4 +316,3 @@ Extending this list isn't possible, however @babel/cli does provide ways to supp
 ## Options
 
 See [the full option list here](options.md).
-

--- a/docs/plugin-external-helpers.md
+++ b/docs/plugin-external-helpers.md
@@ -27,7 +27,7 @@ babel --plugins @babel/plugin-external-helpers script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-external-helpers"]
 });
 ```

--- a/docs/plugin-minify-builtins.md
+++ b/docs/plugin-minify-builtins.md
@@ -46,7 +46,7 @@ babel --plugins minify-builtins script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-builtins"]
 });
 ```

--- a/docs/plugin-minify-constant-folding.md
+++ b/docs/plugin-minify-constant-folding.md
@@ -80,7 +80,7 @@ babel --plugins minify-constant-folding script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-constant-folding"]
 });
 ```

--- a/docs/plugin-minify-dead-code-elimination.md
+++ b/docs/plugin-minify-dead-code-elimination.md
@@ -61,7 +61,7 @@ babel --plugins minify-dead-code-elimination script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-dead-code-elimination"]
 });
 ```

--- a/docs/plugin-minify-flip-comparisons.md
+++ b/docs/plugin-minify-flip-comparisons.md
@@ -49,7 +49,7 @@ babel --plugins minify-flip-comparisons script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-flip-comparisons"]
 });
 ```

--- a/docs/plugin-minify-guarded-expressions.md
+++ b/docs/plugin-minify-guarded-expressions.md
@@ -43,7 +43,7 @@ babel --plugins minify-guarded-expressions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-guarded-expressions"]
 });
 ```

--- a/docs/plugin-minify-infinity.md
+++ b/docs/plugin-minify-infinity.md
@@ -41,7 +41,7 @@ babel --plugins minify-infinity script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-infinity"]
 });
 ```

--- a/docs/plugin-minify-mangle-names.md
+++ b/docs/plugin-minify-mangle-names.md
@@ -65,7 +65,7 @@ babel --plugins minify-mangle-names script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-mangle-names"]
 });
 ```

--- a/docs/plugin-minify-numeric-literals.md
+++ b/docs/plugin-minify-numeric-literals.md
@@ -43,7 +43,7 @@ babel --plugins minify-numeric-literals script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-numeric-literals"]
 });
 ```

--- a/docs/plugin-minify-replace.md
+++ b/docs/plugin-minify-replace.md
@@ -85,7 +85,7 @@ babel --plugins minify-replace script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-replace"]
 });
 ```

--- a/docs/plugin-minify-simplify.md
+++ b/docs/plugin-minify-simplify.md
@@ -75,7 +75,7 @@ babel --plugins minify-simplify script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-simplify"]
 });
 ```

--- a/docs/plugin-minify-type-constructors.md
+++ b/docs/plugin-minify-type-constructors.md
@@ -53,7 +53,7 @@ babel --plugins minify-type-constructors script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["minify-type-constructors"]
 });
 ```

--- a/docs/plugin-proposal-async-generator-functions.md
+++ b/docs/plugin-proposal-async-generator-functions.md
@@ -97,7 +97,7 @@ babel --plugins @babel/plugin-proposal-async-generator-functions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-async-generator-functions"]
 });
 ```

--- a/docs/plugin-proposal-class-properties.md
+++ b/docs/plugin-proposal-class-properties.md
@@ -73,7 +73,7 @@ babel --plugins @babel/plugin-proposal-class-properties script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-class-properties"]
 });
 ```

--- a/docs/plugin-proposal-class-static-block.md
+++ b/docs/plugin-proposal-class-static-block.md
@@ -84,7 +84,7 @@ babel --plugins @babel/plugin-proposal-class-static-block script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-class-static-block"],
 });
 ```

--- a/docs/plugin-proposal-decorators.md
+++ b/docs/plugin-proposal-decorators.md
@@ -73,7 +73,7 @@ babel --plugins @babel/plugin-proposal-decorators script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-decorators"]
 });
 ```

--- a/docs/plugin-proposal-do-expressions.md
+++ b/docs/plugin-proposal-do-expressions.md
@@ -107,7 +107,7 @@ babel --plugins @babel/plugin-proposal-do-expressions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-do-expressions"]
 });
 ```

--- a/docs/plugin-proposal-export-default-from.md
+++ b/docs/plugin-proposal-export-default-from.md
@@ -35,7 +35,7 @@ babel --plugins @babel/plugin-proposal-export-default-from script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-export-default-from"]
 });
 ```

--- a/docs/plugin-proposal-export-namespace-from.md
+++ b/docs/plugin-proposal-export-namespace-from.md
@@ -35,7 +35,7 @@ babel --plugins @babel/plugin-proposal-export-namespace-from script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-export-namespace-from"]
 });
 ```

--- a/docs/plugin-proposal-function-bind.md
+++ b/docs/plugin-proposal-function-bind.md
@@ -110,7 +110,7 @@ babel --plugins @babel/plugin-proposal-function-bind script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-function-bind"]
 });
 ```

--- a/docs/plugin-proposal-function-sent.md
+++ b/docs/plugin-proposal-function-sent.md
@@ -56,7 +56,7 @@ babel --plugins @babel/plugin-proposal-function-sent script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-function-sent"]
 });
 ```

--- a/docs/plugin-proposal-json-strings.md
+++ b/docs/plugin-proposal-json-strings.md
@@ -45,7 +45,7 @@ babel --plugins @babel/plugin-proposal-json-strings script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-json-strings"]
 });
 ```

--- a/docs/plugin-proposal-logical-assignment-operators.md
+++ b/docs/plugin-proposal-logical-assignment-operators.md
@@ -53,7 +53,7 @@ babel --plugins @babel/plugin-proposal-logical-assignment-operators script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-logical-assignment-operators"]
 });
 ```

--- a/docs/plugin-proposal-nullish-coalescing-operator.md
+++ b/docs/plugin-proposal-nullish-coalescing-operator.md
@@ -48,7 +48,7 @@ babel --plugins @babel/plugin-proposal-nullish-coalescing-operator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-nullish-coalescing-operator"]
 });
 ```

--- a/docs/plugin-proposal-numeric-separator.md
+++ b/docs/plugin-proposal-numeric-separator.md
@@ -84,7 +84,7 @@ babel --plugins @babel/plugin-proposal-numeric-separator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-numeric-separator"],
 });
 ```

--- a/docs/plugin-proposal-object-rest-spread.md
+++ b/docs/plugin-proposal-object-rest-spread.md
@@ -47,7 +47,7 @@ babel --plugins @babel/plugin-proposal-object-rest-spread script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-object-rest-spread"]
 });
 ```

--- a/docs/plugin-proposal-optional-catch-binding.md
+++ b/docs/plugin-proposal-optional-catch-binding.md
@@ -51,7 +51,7 @@ babel --plugins @babel/plugin-proposal-optional-catch-binding script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-optional-catch-binding"]
 });
 ```

--- a/docs/plugin-proposal-optional-chaining.md
+++ b/docs/plugin-proposal-optional-chaining.md
@@ -125,7 +125,7 @@ babel --plugins @babel/plugin-proposal-optional-chaining script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-optional-chaining"]
 });
 ```

--- a/docs/plugin-proposal-partial-application.md
+++ b/docs/plugin-proposal-partial-application.md
@@ -69,7 +69,7 @@ babel --plugins @babel/plugin-proposal-partial-application script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-partial-application"]
 });
 ```

--- a/docs/plugin-proposal-pipeline-operator.md
+++ b/docs/plugin-proposal-pipeline-operator.md
@@ -37,7 +37,7 @@ $ babel --plugins @babel/plugin-proposal-pipeline-operator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: [
     [
       "@babel/plugin-proposal-pipeline-operator",

--- a/docs/plugin-proposal-private-methods.md
+++ b/docs/plugin-proposal-private-methods.md
@@ -66,7 +66,7 @@ $ babel --plugins @babel/plugin-proposal-private-methods script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-private-methods"],
 });
 ```

--- a/docs/plugin-proposal-private-property-in-object.md
+++ b/docs/plugin-proposal-private-property-in-object.md
@@ -63,7 +63,7 @@ babel --plugins @babel/plugin-proposal-private-property-in-object
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-private-property-in-object"]
 });
 ```

--- a/docs/plugin-proposal-throw-expressions.md
+++ b/docs/plugin-proposal-throw-expressions.md
@@ -37,7 +37,7 @@ babel --plugins @babel/plugin-proposal-throw-expressions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-proposal-throw-expressions"]
 });
 ```

--- a/docs/plugin-proposal-unicode-property-regex.md
+++ b/docs/plugin-proposal-unicode-property-regex.md
@@ -31,7 +31,7 @@ babel --plugins @babel/@babel/plugin-proposal-unicode-property-regex script.js
 ### Via Node.js API
 
 ```js
-require("@babel/core").transform(code, {
+require("@babel/core").transformSync(code, {
   "plugins": ["@babel/plugin-proposal-unicode-property-regex"]
 });
 ```
@@ -39,7 +39,7 @@ require("@babel/core").transform(code, {
 To transpile to ES6/ES2015:
 
 ```js
-require("@babel/core").transform(code, {
+require("@babel/core").transformSync(code, {
   "plugins": [
     ["@babel/plugin-proposal-unicode-property-regex", { "useUnicodeFlag": false }]
   ]

--- a/docs/plugin-syntax-async-generators.md
+++ b/docs/plugin-syntax-async-generators.md
@@ -51,7 +51,7 @@ babel --plugins @babel/plugin-syntax-async-generators script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-async-generators"]
 });
 ```

--- a/docs/plugin-syntax-bigint.md
+++ b/docs/plugin-syntax-bigint.md
@@ -30,7 +30,7 @@ babel --plugins @babel/plugin-syntax-bigint script.js
 ### Via Node API
 
 ```javascript
-require("babel-core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-bigint"]
 });
 ```

--- a/docs/plugin-syntax-class-properties.md
+++ b/docs/plugin-syntax-class-properties.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-class-properties script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-class-properties"]
 });
 ```

--- a/docs/plugin-syntax-class-static-block.md
+++ b/docs/plugin-syntax-class-static-block.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-class-static-block script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-class-static-block"],
 });
 ```

--- a/docs/plugin-syntax-decorators.md
+++ b/docs/plugin-syntax-decorators.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-decorators script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-decorators"]
 });
 ```

--- a/docs/plugin-syntax-do-expressions.md
+++ b/docs/plugin-syntax-do-expressions.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-do-expressions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-do-expressions"]
 });
 ```

--- a/docs/plugin-syntax-dynamic-import.md
+++ b/docs/plugin-syntax-dynamic-import.md
@@ -29,7 +29,7 @@ babel --plugins @babel/plugin-syntax-dynamic-import script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-dynamic-import"],
 });
 ```

--- a/docs/plugin-syntax-export-default-from.md
+++ b/docs/plugin-syntax-export-default-from.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-export-default-from script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-export-default-from"]
 });
 ```

--- a/docs/plugin-syntax-export-namespace-from.md
+++ b/docs/plugin-syntax-export-namespace-from.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-export-namespace-from script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-export-namespace-from"]
 });
 ```

--- a/docs/plugin-syntax-flow.md
+++ b/docs/plugin-syntax-flow.md
@@ -29,7 +29,7 @@ babel --plugins @babel/plugin-syntax-flow script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-flow"]
 });
 ```

--- a/docs/plugin-syntax-function-bind.md
+++ b/docs/plugin-syntax-function-bind.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-function-bind script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-function-bind"]
 });
 ```

--- a/docs/plugin-syntax-function-sent.md
+++ b/docs/plugin-syntax-function-sent.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-function-sent script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-function-sent"]
 });
 ```

--- a/docs/plugin-syntax-import-meta.md
+++ b/docs/plugin-syntax-import-meta.md
@@ -29,7 +29,7 @@ babel --plugins @babel/plugin-syntax-import-meta script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-import-meta"]
 });
 ```

--- a/docs/plugin-syntax-json-strings.md
+++ b/docs/plugin-syntax-json-strings.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-json-strings script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-json-strings"]
 });
 ```

--- a/docs/plugin-syntax-jsx.md
+++ b/docs/plugin-syntax-jsx.md
@@ -29,7 +29,7 @@ babel --plugins @babel/plugin-syntax-jsx script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-jsx"]
 });
 ```

--- a/docs/plugin-syntax-logical-assignment-operators.md
+++ b/docs/plugin-syntax-logical-assignment-operators.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-logical-assignment-operators script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-logical-assignment-operators"]
 });
 ```

--- a/docs/plugin-syntax-module-string-names.md
+++ b/docs/plugin-syntax-module-string-names.md
@@ -50,7 +50,7 @@ babel --plugins @babel/plugin-syntax-module-string-names script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-module-string-names"],
 });
 ```

--- a/docs/plugin-syntax-nullish-coalescing-operator.md
+++ b/docs/plugin-syntax-nullish-coalescing-operator.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-nullish-coalescing-operator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-nullish-coalescing-operator"]
 });
 ```

--- a/docs/plugin-syntax-numeric-separator.md
+++ b/docs/plugin-syntax-numeric-separator.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-numeric-separator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-numeric-separator"]
 });
 ```

--- a/docs/plugin-syntax-object-rest-spread.md
+++ b/docs/plugin-syntax-object-rest-spread.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-object-rest-spread script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-object-rest-spread"]
 });
 ```

--- a/docs/plugin-syntax-optional-catch-binding.md
+++ b/docs/plugin-syntax-optional-catch-binding.md
@@ -46,7 +46,7 @@ babel --plugins @babel/plugin-syntax-optional-catch-binding script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-optional-catch-binding"]
 });
 ```

--- a/docs/plugin-syntax-optional-chaining.md
+++ b/docs/plugin-syntax-optional-chaining.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-optional-chaining script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-optional-chaining"]
 });
 ```

--- a/docs/plugin-syntax-partial-application.md
+++ b/docs/plugin-syntax-partial-application.md
@@ -33,7 +33,7 @@ babel --plugins @babel/plugin-syntax-partial-application script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-partial-application"]
 });
 ```

--- a/docs/plugin-syntax-pipeline-operator.md
+++ b/docs/plugin-syntax-pipeline-operator.md
@@ -33,7 +33,7 @@ $ babel --plugins @babel/plugin-syntax-pipeline-operator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-pipeline-operator"]
 });
 ```

--- a/docs/plugin-syntax-throw-expressions.md
+++ b/docs/plugin-syntax-throw-expressions.md
@@ -40,7 +40,7 @@ babel --plugins @babel/plugin-syntax-throw-expressions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-throw-expressions"]
 });
 ```

--- a/docs/plugin-syntax-top-level-await.md
+++ b/docs/plugin-syntax-top-level-await.md
@@ -41,7 +41,7 @@ babel --plugins @babel/plugin-syntax-top-level-await script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform(code, {
+require("@babel/core").transformSync(code, {
   plugins: ["@babel/plugin-syntax-top-level-await"],
 });
 ```

--- a/docs/plugin-syntax-typescript.md
+++ b/docs/plugin-syntax-typescript.md
@@ -27,7 +27,7 @@ babel --plugins @babel/plugin-syntax-typescript script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-syntax-typescript"]
 });
 ```

--- a/docs/plugin-transform-arrow-functions.md
+++ b/docs/plugin-transform-arrow-functions.md
@@ -90,7 +90,7 @@ babel --plugins @babel/plugin-transform-arrow-functions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-arrow-functions"]
 });
 ```

--- a/docs/plugin-transform-async-to-generator.md
+++ b/docs/plugin-transform-async-to-generator.md
@@ -79,7 +79,7 @@ babel --plugins @babel/plugin-transform-async-to-generator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-async-to-generator"]
 });
 ```

--- a/docs/plugin-transform-block-scoped-functions.md
+++ b/docs/plugin-transform-block-scoped-functions.md
@@ -54,7 +54,7 @@ babel --plugins @babel/plugin-transform-block-scoped-functions script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-block-scoped-functions"]
 });
 ```

--- a/docs/plugin-transform-block-scoping.md
+++ b/docs/plugin-transform-block-scoping.md
@@ -70,7 +70,7 @@ babel --plugins @babel/plugin-transform-block-scoping script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-block-scoping"]
 });
 ```

--- a/docs/plugin-transform-classes.md
+++ b/docs/plugin-transform-classes.md
@@ -105,7 +105,7 @@ babel --plugins @babel/plugin-transform-classes script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-classes"]
 });
 ```

--- a/docs/plugin-transform-computed-properties.md
+++ b/docs/plugin-transform-computed-properties.md
@@ -86,7 +86,7 @@ babel --plugins @babel/plugin-transform-computed-properties script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-computed-properties"]
 });
 ```

--- a/docs/plugin-transform-destructuring.md
+++ b/docs/plugin-transform-destructuring.md
@@ -55,7 +55,7 @@ babel --plugins @babel/plugin-transform-destructuring script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-destructuring"]
 });
 ```

--- a/docs/plugin-transform-dotall-regex.md
+++ b/docs/plugin-transform-dotall-regex.md
@@ -59,7 +59,7 @@ $ babel --plugins @babel/plugin-transform-dotall-regex script.js
 ### Via Node.js API
 
 ```js
-require('@babel/core').transform(code, {
+require("@babel/core").transformSync(code, {
   'plugins': ['@babel/plugin-transform-dotall-regex']
 });
 ```

--- a/docs/plugin-transform-duplicate-keys.md
+++ b/docs/plugin-transform-duplicate-keys.md
@@ -55,7 +55,7 @@ babel --plugins @babel/plugin-transform-duplicate-keys script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-duplicate-keys"],
 });
 ```

--- a/docs/plugin-transform-exponentiation-operator.md
+++ b/docs/plugin-transform-exponentiation-operator.md
@@ -47,7 +47,7 @@ babel --plugins @babel/plugin-transform-exponentiation-operator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-exponentiation-operator"]
 });
 ```

--- a/docs/plugin-transform-flow-comments.md
+++ b/docs/plugin-transform-flow-comments.md
@@ -65,7 +65,7 @@ babel --plugins @babel/plugin-transform-flow-comments script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-flow-comments"]
 });
 ```

--- a/docs/plugin-transform-flow-strip-types.md
+++ b/docs/plugin-transform-flow-strip-types.md
@@ -43,7 +43,7 @@ babel --plugins @babel/plugin-transform-flow-strip-types script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-flow-strip-types"],
 });
 ```

--- a/docs/plugin-transform-for-of.md
+++ b/docs/plugin-transform-for-of.md
@@ -79,7 +79,7 @@ babel --plugins @babel/plugin-transform-for-of script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-for-of"]
 });
 ```

--- a/docs/plugin-transform-function-name.md
+++ b/docs/plugin-transform-function-name.md
@@ -45,7 +45,7 @@ babel --plugins @babel/plugin-transform-function-name script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-function-name"]
 });
 ```

--- a/docs/plugin-transform-inline-consecutive-adds.md
+++ b/docs/plugin-transform-inline-consecutive-adds.md
@@ -60,7 +60,7 @@ babel --plugins transform-inline-consecutive-adds script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-inline-consecutive-adds"]
 });
 ```

--- a/docs/plugin-transform-inline-environment-variables.md
+++ b/docs/plugin-transform-inline-environment-variables.md
@@ -56,7 +56,7 @@ babel --plugins transform-inline-environment-variables script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-inline-environment-variables"]
 });
 ```

--- a/docs/plugin-transform-instanceof.md
+++ b/docs/plugin-transform-instanceof.md
@@ -51,7 +51,7 @@ babel --plugins @babel/plugin-transform-instanceof script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-instanceof"]
 });
 ```

--- a/docs/plugin-transform-jscript.md
+++ b/docs/plugin-transform-jscript.md
@@ -51,7 +51,7 @@ babel --plugins @babel/plugin-transform-jscript script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-jscript"]
 });
 ```

--- a/docs/plugin-transform-literals.md
+++ b/docs/plugin-transform-literals.md
@@ -47,7 +47,7 @@ babel --plugins @babel/plugin-transform-literals script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-literals"]
 });
 ```

--- a/docs/plugin-transform-member-expression-literals.md
+++ b/docs/plugin-transform-member-expression-literals.md
@@ -49,7 +49,7 @@ babel --plugins @babel/plugin-transform-member-expression-literals script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-member-expression-literals"]
 });
 ```

--- a/docs/plugin-transform-merge-sibling-variables.md
+++ b/docs/plugin-transform-merge-sibling-variables.md
@@ -54,7 +54,7 @@ babel --plugins transform-merge-sibling-variables script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-merge-sibling-variables"]
 });
 ```

--- a/docs/plugin-transform-minify-booleans.md
+++ b/docs/plugin-transform-minify-booleans.md
@@ -45,7 +45,7 @@ babel --plugins transform-minify-booleans script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-minify-booleans"]
 });
 ```

--- a/docs/plugin-transform-modules-amd.md
+++ b/docs/plugin-transform-modules-amd.md
@@ -53,7 +53,7 @@ babel --plugins @babel/plugin-transform-modules-amd script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-modules-amd"]
 });
 ```

--- a/docs/plugin-transform-modules-commonjs.md
+++ b/docs/plugin-transform-modules-commonjs.md
@@ -59,7 +59,7 @@ babel --plugins @babel/plugin-transform-modules-commonjs script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-modules-commonjs"]
 });
 ```

--- a/docs/plugin-transform-modules-systemjs.md
+++ b/docs/plugin-transform-modules-systemjs.md
@@ -72,7 +72,7 @@ babel --plugins @babel/plugin-transform-modules-systemjs script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-modules-systemjs"],
 });
 ```

--- a/docs/plugin-transform-modules-umd.md
+++ b/docs/plugin-transform-modules-umd.md
@@ -212,7 +212,7 @@ babel --plugins @babel/plugin-transform-modules-umd script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-modules-umd"]
 });
 ```

--- a/docs/plugin-transform-named-capturing-groups-regex.md
+++ b/docs/plugin-transform-named-capturing-groups-regex.md
@@ -51,7 +51,7 @@ babel --plugins @babel/plugin-transform-named-capturing-groups-regex script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-named-capturing-groups-regex"]
 });
 ```

--- a/docs/plugin-transform-new-target.md
+++ b/docs/plugin-transform-new-target.md
@@ -98,7 +98,7 @@ babel --plugins @babel/plugin-transform-new-target script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-new-target"]
 });
 ```

--- a/docs/plugin-transform-node-env-inline.md
+++ b/docs/plugin-transform-node-env-inline.md
@@ -50,7 +50,7 @@ babel --plugins transform-node-env-inline script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-node-env-inline"]
 });
 ```

--- a/docs/plugin-transform-object-assign.md
+++ b/docs/plugin-transform-object-assign.md
@@ -54,7 +54,7 @@ babel --plugins @babel/plugin-transform-object-assign script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-object-assign"]
 });
 ```

--- a/docs/plugin-transform-object-set-prototype-of-to-assign.md
+++ b/docs/plugin-transform-object-set-prototype-of-to-assign.md
@@ -47,7 +47,7 @@ babel --plugins @babel/plugin-transform-object-set-prototype-of-to-assign script
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-object-set-prototype-of-to-assign"],
 });
 ```

--- a/docs/plugin-transform-object-super.md
+++ b/docs/plugin-transform-object-super.md
@@ -67,7 +67,7 @@ babel --plugins @babel/plugin-transform-object-super script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-object-super"]
 });
 ```

--- a/docs/plugin-transform-parameters.md
+++ b/docs/plugin-transform-parameters.md
@@ -75,7 +75,7 @@ babel --plugins @babel/plugin-transform-parameters script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-parameters"],
 });
 ```

--- a/docs/plugin-transform-property-literals.md
+++ b/docs/plugin-transform-property-literals.md
@@ -59,7 +59,7 @@ babel --plugins @babel/plugin-transform-property-literals script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-property-literals"]
 });
 ```

--- a/docs/plugin-transform-property-mutators.md
+++ b/docs/plugin-transform-property-mutators.md
@@ -61,7 +61,7 @@ babel --plugins @babel/plugin-transform-property-mutators script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-property-mutators"]
 });
 ```

--- a/docs/plugin-transform-proto-to-assign.md
+++ b/docs/plugin-transform-proto-to-assign.md
@@ -70,7 +70,7 @@ babel --plugins @babel/plugin-transform-proto-to-assign script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-proto-to-assign"]
 });
 ```

--- a/docs/plugin-transform-react-constant-elements.md
+++ b/docs/plugin-transform-react-constant-elements.md
@@ -97,7 +97,7 @@ babel --plugins @babel/plugin-transform-react-constant-elements script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-react-constant-elements"]
 });
 ```

--- a/docs/plugin-transform-react-display-name.md
+++ b/docs/plugin-transform-react-display-name.md
@@ -49,7 +49,7 @@ babel --plugins @babel/plugin-transform-react-display-name script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-react-display-name"]
 });
 ```

--- a/docs/plugin-transform-react-inline-elements.md
+++ b/docs/plugin-transform-react-inline-elements.md
@@ -72,7 +72,7 @@ babel --plugins @babel/plugin-transform-react-inline-elements script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-react-inline-elements"]
 });
 ```

--- a/docs/plugin-transform-react-jsx-compat.md
+++ b/docs/plugin-transform-react-jsx-compat.md
@@ -49,7 +49,7 @@ babel --plugins @babel/plugin-transform-react-jsx-compat script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-react-jsx-compat"]
 });
 ```

--- a/docs/plugin-transform-react-jsx-self.md
+++ b/docs/plugin-transform-react-jsx-self.md
@@ -43,7 +43,7 @@ babel --plugins @babel/plugin-transform-react-jsx-self script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-react-jsx-self"]
 });
 ```

--- a/docs/plugin-transform-react-jsx-source.md
+++ b/docs/plugin-transform-react-jsx-source.md
@@ -45,7 +45,7 @@ babel --plugins @babel/plugin-transform-react-jsx-source script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-react-jsx-source"]
 });
 ```

--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -268,7 +268,7 @@ babel --plugins @babel/plugin-transform-react-jsx script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-react-jsx"],
 });
 ```

--- a/docs/plugin-transform-regenerator.md
+++ b/docs/plugin-transform-regenerator.md
@@ -83,7 +83,7 @@ babel --plugins @babel/plugin-transform-regenerator script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-regenerator"]
 });
 ```

--- a/docs/plugin-transform-regexp-constructors.md
+++ b/docs/plugin-transform-regexp-constructors.md
@@ -45,7 +45,7 @@ babel --plugins transform-regexp-constructors script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-regexp-constructors"]
 });
 ```

--- a/docs/plugin-transform-remove-console.md
+++ b/docs/plugin-transform-remove-console.md
@@ -51,7 +51,7 @@ babel --plugins transform-remove-console script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-remove-console"]
 });
 ```

--- a/docs/plugin-transform-remove-debugger.md
+++ b/docs/plugin-transform-remove-debugger.md
@@ -42,7 +42,7 @@ babel --plugins transform-remove-debugger script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-remove-debugger"]
 });
 ```

--- a/docs/plugin-transform-remove-undefined.md
+++ b/docs/plugin-transform-remove-undefined.md
@@ -53,7 +53,7 @@ babel --plugins babel-plugin-transform-remove-undefined script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["babel-plugin-transform-remove-undefined"]
 });
 ```

--- a/docs/plugin-transform-reserved-words.md
+++ b/docs/plugin-transform-reserved-words.md
@@ -49,7 +49,7 @@ babel --plugins @babel/plugin-transform-reserved-words script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-reserved-words"]
 });
 ```

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -79,7 +79,7 @@ babel --plugins @babel/plugin-transform-runtime script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-runtime"],
 });
 ```

--- a/docs/plugin-transform-shorthand-properties.md
+++ b/docs/plugin-transform-shorthand-properties.md
@@ -63,7 +63,7 @@ babel --plugins @babel/plugin-transform-shorthand-properties script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-shorthand-properties"]
 });
 ```

--- a/docs/plugin-transform-simplify-comparison-operators.md
+++ b/docs/plugin-transform-simplify-comparison-operators.md
@@ -43,7 +43,7 @@ babel --plugins transform-simplify-comparison-operators script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-simplify-comparison-operators"]
 });
 ```

--- a/docs/plugin-transform-spread.md
+++ b/docs/plugin-transform-spread.md
@@ -65,7 +65,7 @@ babel --plugins @babel/plugin-transform-spread script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-spread"]
 });
 ```

--- a/docs/plugin-transform-sticky-regex.md
+++ b/docs/plugin-transform-sticky-regex.md
@@ -43,7 +43,7 @@ babel --plugins @babel/plugin-transform-sticky-regex script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-sticky-regex"]
 });
 ```

--- a/docs/plugin-transform-strict-mode.md
+++ b/docs/plugin-transform-strict-mode.md
@@ -51,7 +51,7 @@ babel --plugins @babel/plugin-transform-strict-mode script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-strict-mode"]
 });
 ```

--- a/docs/plugin-transform-template-literals.md
+++ b/docs/plugin-transform-template-literals.md
@@ -57,7 +57,7 @@ babel --plugins @babel/plugin-transform-template-literals script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-template-literals"]
 });
 ```

--- a/docs/plugin-transform-typeof-symbol.md
+++ b/docs/plugin-transform-typeof-symbol.md
@@ -47,7 +47,7 @@ babel --plugins @babel/plugin-transform-typeof-symbol script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-typeof-symbol"]
 });
 ```

--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -45,7 +45,7 @@ babel --plugins @babel/plugin-transform-typescript script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-typescript"]
 });
 ```

--- a/docs/plugin-transform-undefined-to-void.md
+++ b/docs/plugin-transform-undefined-to-void.md
@@ -45,7 +45,7 @@ babel --plugins transform-undefined-to-void script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["transform-undefined-to-void"]
 });
 ```

--- a/docs/plugin-transform-unicode-escapes.md
+++ b/docs/plugin-transform-unicode-escapes.md
@@ -51,7 +51,7 @@ babel --plugins @babel/plugin-transform-unicode-escapes
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-unicode-escapes"]
 });
 ```

--- a/docs/plugin-transform-unicode-regex.md
+++ b/docs/plugin-transform-unicode-regex.md
@@ -45,7 +45,7 @@ babel --plugins @babel/plugin-transform-unicode-regex script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-unicode-regex"]
 });
 ```

--- a/docs/preset-es2015.md
+++ b/docs/preset-es2015.md
@@ -32,7 +32,7 @@ babel script.js --presets @babel/preset-es2015
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-es2015"]
 });
 ```

--- a/docs/preset-es2016.md
+++ b/docs/preset-es2016.md
@@ -32,7 +32,7 @@ babel script.js --presets @babel/preset-es2016
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-es2016"]
 });
 ```

--- a/docs/preset-es2017.md
+++ b/docs/preset-es2017.md
@@ -32,7 +32,7 @@ babel script.js --presets @babel/preset-es2017
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-es2017"]
 });
 ```

--- a/docs/preset-flow.md
+++ b/docs/preset-flow.md
@@ -47,7 +47,7 @@ babel --presets @babel/preset-flow script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-flow"],
 });
 ```

--- a/docs/preset-minify.md
+++ b/docs/preset-minify.md
@@ -49,7 +49,7 @@ babel script.js --presets minify
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["minify"]
 });
 ```

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -69,7 +69,7 @@ babel --presets @babel/preset-react script.js
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-react"],
 });
 ```

--- a/docs/preset-stage-0.md
+++ b/docs/preset-stage-0.md
@@ -34,7 +34,7 @@ babel script.js --presets @babel/preset-stage-0
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-stage-0"]
 });
 ```

--- a/docs/preset-stage-1.md
+++ b/docs/preset-stage-1.md
@@ -44,7 +44,7 @@ babel script.js --presets @babel/preset-stage-1
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-stage-1"]
 });
 ```

--- a/docs/preset-stage-2.md
+++ b/docs/preset-stage-2.md
@@ -44,7 +44,7 @@ babel script.js --presets @babel/preset-stage-2
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-stage-2"]
 });
 ```

--- a/docs/preset-stage-3.md
+++ b/docs/preset-stage-3.md
@@ -44,7 +44,7 @@ babel script.js --presets @babel/preset-stage-3
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-stage-3"]
 });
 ```

--- a/docs/preset-typescript.md
+++ b/docs/preset-typescript.md
@@ -49,7 +49,7 @@ babel --presets @babel/preset-typescript script.ts
 ### Via Node API
 
 ```javascript
-require("@babel/core").transform("code", {
+require("@babel/core").transformSync("code", {
   presets: ["@babel/preset-typescript"],
 });
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,7 +93,7 @@ you can `require` it directly in your JavaScript program and use it like this:
 ```js
 const babel = require("@babel/core");
 
-babel.transform("code", optionsObject);
+babel.transformSync("code", optionsObject);
 ```
 
 As an end-user though, you'll probably want to install other tools that serve as an interface to `@babel/core` and integrate well with your development process. Even so, you might still want to check its documentation page to learn about the options, most of which can be set from the other tools as well.


### PR DESCRIPTION
Companion PR of https://github.com/babel/babel/pull/12695.

Since `babel.transformSync` and `babel.parseSync` is available in Babel 7. We should use them whenever the `callback` parameter is missing.