### PR TITLE
docs: allowNamespaces in typescript now defaults to true

### DIFF
--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -46,10 +46,9 @@ babel --plugins @babel/plugin-transform-typescript script.js
 
 ```javascript
 require("@babel/core").transformSync("code", {
-  plugins: ["@babel/plugin-transform-typescript"]
+  plugins: ["@babel/plugin-transform-typescript"],
 });
 ```
-
 
 ## Caveats
 
@@ -60,14 +59,16 @@ Because there are features of the TypeScript language which rely on the full typ
 1. This plugin does not support [`const enum`][const_enum]s because those require type information to compile.
 
    **Workarounds**:
-    - Use the plugin [babel-plugin-const-enum](https://www.npmjs.com/package/babel-plugin-const-enum).
-    - Remove the `const`, which makes it available at runtime.
+
+   - Use the plugin [babel-plugin-const-enum](https://www.npmjs.com/package/babel-plugin-const-enum).
+   - Remove the `const`, which makes it available at runtime.
 
 1. This plugin does not support [`export =`][exin] and [`import =`][exin], because those cannot be compiled to ES.next. These are a TypeScript only form of `import`/`export`.
 
    **Workarounds**:
-    - Use the plugin [babel-plugin-replace-ts-export-assignment](https://www.npmjs.com/package/babel-plugin-replace-ts-export-assignment) to transform `export =`.
-    - Convert to using `export default` and `export const`, and `import x, {y} from "z"`.
+
+   - Use the plugin [babel-plugin-replace-ts-export-assignment](https://www.npmjs.com/package/babel-plugin-replace-ts-export-assignment) to transform `export =`.
+   - Convert to using `export default` and `export const`, and `import x, {y} from "z"`.
 
 1. Changes to your `tsconfig.json` are not reflected in babel. The build process will always behave as though [`isolatedModules`][iso-mods] is turned on, there are Babel-native alternative ways to set a lot of the [`tsconfig.json` options](#typescript-compiler-options) however.
 
@@ -75,22 +76,17 @@ Because there are features of the TypeScript language which rely on the full typ
 
    **A**: The TypeScript compiler dynamically changes how these variables are used depending on whether or not the value is mutated. Ultimately, this depends on a type-model and is outside the scope of Babel. A best-effort implementation would transform context-dependent usages of the variable to always use the `Namespace.Value` version instead of `Value`, in case it was mutated outside of the current file. Allowing `var` or `let` from Babel (as the transform is not-yet-written) is therefore is more likely than not to present itself as a bug when used as-if it was not `const`.
 
-
 ### Impartial Namespace Support
 
 If you have existing code which uses the TypeScript-only [namespace][namespace] features. Babel supports a subset of TypeScript's namespace features. If you are considering writing new code which uses namespace, using the ES2015 `import`/`export` is recommended instead. It's [not going away][not-disappearing], but there are modern alternatives.
 
-* Type-only `namespace`s should be marked with `declare` and will subsequently be safely removed.
+- Type-only `namespace`s should be marked with `declare` and will subsequently be safely removed.
 
-* `namespaces`s not marked with `declare` are experimental and disabled by default. Not enabling will result in an error: *"Namespace not marked type-only declare. Non-declarative namespaces are only supported experimentally in Babel."*
-
-  **Workaround**: Enable the `allowNamespaces` option.
-
-* `export`ing a variable using `var` or `let` in a `namespace` will result in an error: *"Namespaces exporting non-const are not supported by Babel. Change to const or ..."*
+- `export`ing a variable using `var` or `let` in a `namespace` will result in an error: _"Namespaces exporting non-const are not supported by Babel. Change to const or ..."_
 
   **Workaround**: Use `const`. If some form of mutation is required, explicitly use an object with internal mutability.
 
-* `namespace`s will not share their scope. In TypeScript, it is valid to refer to contextual items that a `namespace` extends without qualifying them, and the compiler will add the qualifier. In Babel, there is no type-model, and it is impossible to dynamically change references to match the established type of the parent object.
+- `namespace`s will not share their scope. In TypeScript, it is valid to refer to contextual items that a `namespace` extends without qualifying them, and the compiler will add the qualifier. In Babel, there is no type-model, and it is impossible to dynamically change references to match the established type of the parent object.
 
   Consider this code:
 
@@ -107,10 +103,10 @@ If you have existing code which uses the TypeScript-only [namespace][namespace] 
 
   ```javascript
   var N = {};
-  (function (N) {
+  (function(N) {
     N.V = 1;
   })(N);
-  (function (N) {
+  (function(N) {
     N.W = N.V;
   })(N);
   ```
@@ -119,10 +115,10 @@ If you have existing code which uses the TypeScript-only [namespace][namespace] 
 
   ```javascript
   var N;
-  (function (_N) {
-    const V = _N = 1;
+  (function(_N) {
+    const V = (_N = 1);
   })(N || (N = {}));
-  (function (_N) {
+  (function(_N) {
     const W = V;
   })(N || (N = {}));
   ```
@@ -170,9 +166,15 @@ class A {
 
 ### `allowNamespaces`
 
-`boolean`, defaults to `false` but will default to `true` in the [future](https://github.com/babel/notes/blob/master/2019/05/21.md#prs).
+`boolean`, defaults to `true` but will default to `true` in the [future](https://github.com/babel/notes/blob/master/2019/05/21.md#prs).
 
-Added in: `v7.5.0`
+<details>
+  <summary>History</summary>
+| Version | Changes |
+| --- | --- |
+| `v7.5.0` | Added `allowNamespaces`, defaults: `false` |
+| `v7.13.0` | defaults to `true` |
+</details>
 
 Enables compilation of TypeScript namespaces.
 
@@ -235,9 +237,7 @@ equivalents in Babel can be enabled by some configuration options or plugins.
   This option enables support for the "legacy" decorator proposal. You can enable it in Babel using the `@babel/plugin-proposal-decorators` plugin, but please be aware, there are some minor differences.
   ```js
   module.exports = {
-    plugins: [
-      ["@babel/plugin-proposal-decorators", { legacy: true }]
-    ]
+    plugins: [["@babel/plugin-proposal-decorators", { legacy: true }]],
   };
   ```
 - `--importHelpers`
@@ -257,14 +257,14 @@ equivalents in Babel can be enabled by some configuration options or plugins.
   If you are using a bundler (Webpack or Rollup), this option is set automatically.
   If you are using `@babel/preset-env`, you can use the [`modules` option](https://babeljs.io/docs/en/babel-preset-env#modules); otherwise you can load the specific plugin.
 
-  | **`--module` value** | **`@babel/preset-env`'s `modules`** | **Single plugin** |
-  |:--------------------:|:-----------------------------------:|:-----------------:|
-  | `None` | `false` | / |
-  | `CommonJS` | `"commonjs"` or `"cjs"` | `@babel/plugin-transform-modules-commonjs` |
-  | `AMD` | `"amd"` | `@babel/plugin-transform-modules-amd` |
-  | `System` | `"systemjs"` | `@babel/plugin-transform-modules-systemjs` |
-  | `UMD` | `"umd"` | `@babel/plugin-transform-modules-umd` |
-  | `ES6` or `ES2015` | `false` | / |
+  | **`--module` value** | **`@babel/preset-env`'s `modules`** |             **Single plugin**              |
+  | :------------------: | :---------------------------------: | :----------------------------------------: |
+  |        `None`        |               `false`               |                     /                      |
+  |      `CommonJS`      |       `"commonjs"` or `"cjs"`       | `@babel/plugin-transform-modules-commonjs` |
+  |        `AMD`         |               `"amd"`               |   `@babel/plugin-transform-modules-amd`    |
+  |       `System`       |            `"systemjs"`             | `@babel/plugin-transform-modules-systemjs` |
+  |        `UMD`         |               `"umd"`               |   `@babel/plugin-transform-modules-umd`    |
+  |  `ES6` or `ES2015`   |               `false`               |                     /                      |
 
 - `--outDir`
   When using `@babel/cli`, you can set the [`--out-dir` option](https://babeljs.io/docs/en/babel-cli#compile-directories).

--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -77,7 +77,7 @@ class A {
   <summary>History</summary>
 | Version | Changes |
 | --- | --- |
-| `v7.5.0` | Added `allowNamespaces`, defaults: `false` |
+| `v7.5.0` | Added `allowNamespaces`, defaults to `false` |
 | `v7.13.0` | defaults to `true` |
 </details>
 


### PR DESCRIPTION
Companion PR of https://github.com/babel/babel/pull/12765.