### PR TITLE
docs(plugin-transform-react-constant-elements): use inclusive language

### DIFF
--- a/docs/plugin-transform-react-constant-elements.md
+++ b/docs/plugin-transform-react-constant-elements.md
@@ -73,7 +73,7 @@ npm install --save-dev @babel/plugin-transform-react-constant-elements
 `Array<string>`, defaults to `[]`
 
 If you are using a particular library (like react-intl) that uses object properties, and you are sure
-that the element won't modify its own props, you can whitelist the element so that objects are allowed.
+that the element won't modify its own props, you can permit objects to be allowed for specific elements.
 
 This will skip the `Mutable Properties` deopt.
 


### PR DESCRIPTION
"whitelist" is considered non-inclusive by some - figured it's easy enough to reword so might as well 🙂 