### PR TITLE
docs: allowNamespaces now defaults to true

### DIFF
--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -71,7 +71,7 @@ class A {
 
 ### `allowNamespaces`
 
-`boolean`, defaults to `true` but will default to `true` in the [future](https://github.com/babel/notes/blob/master/2019/05/21.md#prs).
+`boolean`, defaults to `true`.
 
 <details>
   <summary>History</summary>


### PR DESCRIPTION
`allowNamespaces` now defaults to true