### PR TITLE
fixup sidebar, modidy parts in plugins/presets

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -15,9 +15,6 @@ https://babel.netlify.com/* https://babeljs.io/:splat 301!
 /7/                                 https://old.babeljs.io/repl/build/7.0/
 /7.html                             https://old.babeljs.io/repl/build/7.0/
 
-/docs/en/plugins#pluginpreset-paths /docs/en/plugins#using-a-plugin
-/docs/en/presets#preset-paths /docs/en/presets#using-a-preset
-
 # after docusaurus rewrite
 /php/                               https://old.babeljs.io/php/
 /docs/usage/                        /docs/en/usage/

--- a/_redirects
+++ b/_redirects
@@ -15,6 +15,9 @@ https://babel.netlify.com/* https://babeljs.io/:splat 301!
 /7/                                 https://old.babeljs.io/repl/build/7.0/
 /7.html                             https://old.babeljs.io/repl/build/7.0/
 
+/docs/en/plugins#pluginpreset-paths /docs/en/plugins#using-a-plugin
+/docs/en/presets#preset-paths /docs/en/presets#using-a-preset
+
 # after docusaurus rewrite
 /php/                               https://old.babeljs.io/php/
 /docs/usage/                        /docs/en/usage/

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,6 @@
 ---
 id: babel-cli
 title: @babel/cli
-sidebar_label: cli
 ---
 
 Babel comes with a built-in CLI which can be used to compile files from the command line.
@@ -16,9 +15,9 @@ to install it **locally** project by project.
 There are two primary reasons for this.
 
 1. Different projects on the same machine can depend on different versions of
-     Babel allowing you to update them individually.
+   Babel allowing you to update them individually.
 2. Not having an implicit dependency on the environment you are working in
-     makes your project far more portable and easier to setup.
+   makes your project far more portable and easier to setup.
 
 We can install Babel CLI locally by running:
 
@@ -42,6 +41,7 @@ After that finishes installing, your `package.json` file should include:
 ## Usage
 
 > **Note:** Please install `@babel/cli` and `@babel/core` first before `npx babel`, otherwise `npx` will install out-of-dated `babel` 6.x. Other than [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b), you can also drop it inside of an [npm run script](https://docs.npmjs.com/cli/run-script) or you may instead execute with the relative path instead. `./node_modules/.bin/babel`
+
 ```sh
 npx babel script.js
 ```

--- a/docs/code-frame.md
+++ b/docs/code-frame.md
@@ -1,7 +1,6 @@
 ---
 id: babel-code-frame
 title: @babel/code-frame
-sidebar_label: code-frame
 ---
 
 ## Install
@@ -13,14 +12,16 @@ npm install --save-dev @babel/code-frame
 ## Usage
 
 ```js
-import { codeFrameColumns } from '@babel/code-frame';
+import { codeFrameColumns } from "@babel/code-frame";
 
 const rawLines = `class Foo {
   constructor()
 }`;
 const location = { start: { line: 2, column: 16 } };
 
-const result = codeFrameColumns(rawLines, location, { /* options */ });
+const result = codeFrameColumns(rawLines, location, {
+  /* options */
+});
 
 console.log(result);
 ```
@@ -37,16 +38,21 @@ If the column number is not known, you may omit it.
 You can also pass an `end` hash in `location`.
 
 ```js
-import { codeFrameColumns } from '@babel/code-frame';
+import { codeFrameColumns } from "@babel/code-frame";
 
 const rawLines = `class Foo {
   constructor() {
     console.log("hello");
   }
 }`;
-const location = { start: { line: 2, column: 17 }, end: { line: 4, column: 3 } };
+const location = {
+  start: { line: 2, column: 17 },
+  end: { line: 4, column: 3 },
+};
 
-const result = codeFrameColumns(rawLines, location, { /* options */ });
+const result = codeFrameColumns(rawLines, location, {
+  /* options */
+});
 
 console.log(result);
 ```
@@ -69,7 +75,6 @@ console.log(result);
 `boolean`, defaults to `false`.
 
 Toggles syntax highlighting the code as JavaScript for terminals.
-
 
 ### `linesAbove`
 
@@ -113,7 +118,7 @@ The new API takes a `location` object, similar to what is available in an AST.
 This is an example of the deprecated (but still available) API:
 
 ```js
-import codeFrame from '@babel/code-frame';
+import codeFrame from "@babel/code-frame";
 
 const rawLines = `class Foo {
   constructor()
@@ -121,7 +126,9 @@ const rawLines = `class Foo {
 const lineNumber = 2;
 const colNumber = 16;
 
-const result = codeFrame(rawLines, lineNumber, colNumber, { /* options */ });
+const result = codeFrame(rawLines, lineNumber, colNumber, {
+  /* options */
+});
 
 console.log(result);
 ```
@@ -129,7 +136,7 @@ console.log(result);
 To get the same highlighting using the new API:
 
 ```js
-import { codeFrameColumns } from '@babel/code-frame';
+import { codeFrameColumns } from "@babel/code-frame";
 
 const rawLines = `class Foo {
   constructor() {
@@ -138,8 +145,9 @@ const rawLines = `class Foo {
 }`;
 const location = { start: { line: 2, column: 16 } };
 
-const result = codeFrameColumns(rawLines, location, { /* options */ });
+const result = codeFrameColumns(rawLines, location, {
+  /* options */
+});
 
 console.log(result);
 ```
-

--- a/docs/core.md
+++ b/docs/core.md
@@ -1,7 +1,6 @@
 ---
 id: babel-core
 title: @babel/core
-sidebar_label: core
 ---
 
 ```javascript
@@ -11,7 +10,6 @@ import * as babel from "@babel/core";
 ```
 
 All transformations will use your local [configuration files](config-files.md).
-
 
 ## transform
 
@@ -48,7 +46,7 @@ Transforms the passed in `code`. Returning an object with the generated code,
 source map, and AST.
 
 ```js
-babel.transformSync(code, options) // => { code, map, ast }
+babel.transformSync(code, options); // => { code, map, ast }
 ```
 
 **Example**
@@ -68,7 +66,7 @@ Transforms the passed in `code`. Returning an promise for an object with the
 generated code, source map, and AST.
 
 ```js
-babel.transformAsync(code, options) // => Promise<{ code, map, ast }>
+babel.transformAsync(code, options); // => Promise<{ code, map, ast }>
 ```
 
 **Example**
@@ -81,7 +79,6 @@ babel.transformAsync("code();", options).then(result => {
 });
 ```
 
-
 ## transformFile
 
 > babel.transformFile(filename: string, [options?](#options): Object, callback: Function)
@@ -89,17 +86,16 @@ babel.transformAsync("code();", options).then(result => {
 Asynchronously transforms the entire contents of a file.
 
 ```js
-babel.transformFile(filename, options, callback)
+babel.transformFile(filename, options, callback);
 ```
 
 **Example**
 
 ```js
-babel.transformFile("filename.js", options, function (err, result) {
+babel.transformFile("filename.js", options, function(err, result) {
   result; // => { code, map, ast }
 });
 ```
-
 
 ## transformFileSync
 
@@ -109,7 +105,7 @@ Synchronous version of `babel.transformFile`. Returns the transformed contents o
 the `filename`.
 
 ```js
-babel.transformFileSync(filename, options) // => { code, map, ast }
+babel.transformFileSync(filename, options); // => { code, map, ast }
 ```
 
 **Example**
@@ -117,7 +113,6 @@ babel.transformFileSync(filename, options) // => { code, map, ast }
 ```js
 babel.transformFileSync("filename.js", options).code;
 ```
-
 
 ## transformFileAsync
 
@@ -127,7 +122,7 @@ Promise version of `babel.transformFile`. Returns a promise for the transformed
 contents of the `filename`.
 
 ```js
-babel.transformFileAsync(filename, options) // => Promise<{ code, map, ast }>
+babel.transformFileAsync(filename, options); // => Promise<{ code, map, ast }>
 ```
 
 **Example**
@@ -138,7 +133,6 @@ babel.transformFileAsync("filename.js", options).then(result => {
 });
 ```
 
-
 ## transformFromAst
 
 > babel.transformFromAst(ast: Object, code?: string, [options?](#options): Object, callback: Function): FileNode | null
@@ -147,7 +141,9 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-const parsedAst = babel.parseSync(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
+const parsedAst = babel.parseSync(sourceCode, {
+  parserOpts: { allowReturnOutsideFunction: true },
+});
 babel.transformFromAst(parsedAst, sourceCode, options, function(err, result) {
   const { code, map, ast } = result;
 });
@@ -157,7 +153,6 @@ babel.transformFromAst(parsedAst, sourceCode, options, function(err, result) {
 >
 > In Babel 6, this method was synchronous and `transformFromAstSync` did not exist. For backward-compatibility, this function will behave synchronously if no callback is given. If you're starting with Babel 7 and need synchronous behavior, please use `transformFromAstSync` since this backward-compatibility will be dropped in Babel 8.
 
-
 ## transformFromAstSync
 
 > babel.transformFromAstSync(ast: Object, code?: string, [options?](#options): Object)
@@ -166,8 +161,14 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-const parsedAst = babel.parseSync(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } });
-const { code, map, ast } = babel.transformFromAstSync(parsedAst, sourceCode, options);
+const parsedAst = babel.parseSync(sourceCode, {
+  parserOpts: { allowReturnOutsideFunction: true },
+});
+const { code, map, ast } = babel.transformFromAstSync(
+  parsedAst,
+  sourceCode,
+  options
+);
 ```
 
 ## transformFromAstAsync
@@ -178,7 +179,8 @@ Given an [AST](https://astexplorer.net/), transform it.
 
 ```js
 const sourceCode = "if (true) return;";
-babel.parseAsync(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } })
+babel
+  .parseAsync(sourceCode, { parserOpts: { allowReturnOutsideFunction: true } })
   .then(parsedAst => {
     return babel.transformFromAstAsync(parsedAst, sourceCode, options);
   })
@@ -201,7 +203,6 @@ enabled.
 > this function will behave synchronously if no callback is given. If you're starting with Babel 7 stable
 > and need synchronous behavior, please use `parseSync` since this backward-compatibility will be dropped in Babel 8.
 
-
 ## parseSync
 
 > babel.parseSync(code: string, [options?](#options): Object)
@@ -222,13 +223,11 @@ Given some code, parse it using Babel's standard behavior. Referenced presets an
 plugins will be loaded such that optional syntax plugins are automatically
 enabled.
 
-
 ## Advanced APIs
 
 Many systems that wrap Babel like to automatically inject plugins and presets,
 or override options. To accomplish this goal, Babel exposes several functions
 that aid in loading the configuration part-way without transforming.
-
 
 ### loadOptions
 
@@ -236,9 +235,9 @@ that aid in loading the configuration part-way without transforming.
 
 Resolve Babel's options fully, resulting in an options object where:
 
-* `opts.plugins` is a full list of `Plugin` instances.
-* `opts.presets` is empty and all presets are flattened into `opts`.
-* It can be safely passed back to Babel. Fields like [`"babelrc"`](options.md#babelrc) have been set to
+- `opts.plugins` is a full list of `Plugin` instances.
+- `opts.presets` is empty and all presets are flattened into `opts`.
+- It can be safely passed back to Babel. Fields like [`"babelrc"`](options.md#babelrc) have been set to
   `false` so that later calls to Babel will not make a second attempt to load
   config files.
 
@@ -246,7 +245,6 @@ Resolve Babel's options fully, resulting in an options object where:
 callers will serialize this `opts` to JSON to use it as a cache key representing
 the options Babel has received. Caching on this isn't 100% guaranteed to
 invalidate properly, but it is the best we have at the moment.
-
 
 ### loadPartialConfig
 
@@ -262,18 +260,18 @@ When set to true, `loadPartialConfig` always returns a result when a file is ign
 This is useful in order to allow the caller to access the list of files that influenced this outcome, e.g.
 for watch mode. The caller can determine whether a file was ignored based on the returned `fileHandling` property.
 
-* `babelrc: string | void` - The path of the [file-relative configuration](config-files.md#file-relative-configuration) file, if there was one.
-* `babelignore: string | void` - The path of the `.babelignore` file, if there was one.
-* `config: string | void` - The path of the [project-wide config file](config-files.md#project-wide-configuration) file, if there was one.
-* `options: ValidatedOptions` - The partially resolved options, which can be manipulated and passed back to Babel again.
-  * `plugins: Array<ConfigItem>` - See below.
-  * `presets: Array<ConfigItem>` - See below.
-  * It can be safely passed back to Babel. Options like [`"babelrc"`](options.md#babelrc) have been set
+- `babelrc: string | void` - The path of the [file-relative configuration](config-files.md#file-relative-configuration) file, if there was one.
+- `babelignore: string | void` - The path of the `.babelignore` file, if there was one.
+- `config: string | void` - The path of the [project-wide config file](config-files.md#project-wide-configuration) file, if there was one.
+- `options: ValidatedOptions` - The partially resolved options, which can be manipulated and passed back to Babel again.
+  - `plugins: Array<ConfigItem>` - See below.
+  - `presets: Array<ConfigItem>` - See below.
+  - It can be safely passed back to Babel. Options like [`"babelrc"`](options.md#babelrc) have been set
     to false so that later calls to Babel will not make a second attempt to
     load config files.
-* `hasFilesystemConfig(): boolean` - Check if the resolved config loaded any settings from the filesystem.
-* `fileHandling` - This is set to `"transpile"`, `"ignored"`, or `"unsupported"` to indicate to the caller what to do with this file.
-* `files` - A `Set` of file paths that were read to build the resulting config, including project wide config files, local config files,
+- `hasFilesystemConfig(): boolean` - Check if the resolved config loaded any settings from the filesystem.
+- `fileHandling` - This is set to `"transpile"`, `"ignored"`, or `"unsupported"` to indicate to the caller what to do with this file.
+- `files` - A `Set` of file paths that were read to build the resulting config, including project wide config files, local config files,
   extended config files, ignore files, etc. Useful for implementing watch mode or cache invalidation.
 
 [`ConfigItem`](#configitem-type) instances expose properties to introspect the values, but each
@@ -281,7 +279,6 @@ item should be treated as immutable. If changes are desired, the item should be
 removed from the list and replaced with either a normal Babel config value, or
 with a replacement item created by `babel.createConfigItem`. See that
 function for information about `ConfigItem` fields.
-
 
 ### createConfigItem
 
@@ -292,18 +289,17 @@ is called multiple times for a given plugin, Babel will call the plugin's functi
 multiple times. If you have a clear set of expected plugins and presets to
 inject, pre-constructing the config items would be recommended.
 
-
 ### `ConfigItem` type
 
 Each `ConfigItem` exposes all of the information Babel knows. The fields are:
 
-* `value: {} | Function` - The resolved value of the plugin.
-* `options: {} | void` - The options object passed to the plugin.
-* `dirname: string` - The path that the options are relative to.
-* `name: string | void` - The name that the user gave the plugin instance, e.g. `plugins: [ ['env', {}, 'my-env'] ]`
-* `file: Object | void` - Information about the plugin's file, if Babel knows it.
-  * `request: string` - The file that the user requested, e.g. `"@babel/env"`
-  * `resolved: string` - The full path of the resolved file, e.g. `"/tmp/node_modules/@babel/preset-env/lib/index.js"`
+- `value: {} | Function` - The resolved value of the plugin.
+- `options: {} | void` - The options object passed to the plugin.
+- `dirname: string` - The path that the options are relative to.
+- `name: string | void` - The name that the user gave the plugin instance, e.g. `plugins: [ ['env', {}, 'my-env'] ]`
+- `file: Object | void` - Information about the plugin's file, if Babel knows it.
+  - `request: string` - The file that the user requested, e.g. `"@babel/env"`
+  - `resolved: string` - The full path of the resolved file, e.g. `"/tmp/node_modules/@babel/preset-env/lib/index.js"`
 
 ## DEFAULT_EXTENSIONS
 

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -1,7 +1,6 @@
 ---
 id: babel-generator
 title: @babel/generator
-sidebar_label: generator
 ---
 
 > Turns an AST into code.
@@ -41,7 +40,7 @@ Options for formatting output:
 | comments               | boolean             | `true`          | Should comments be included in output                                                                                                                                                                                                                              |
 | compact                | boolean or `'auto'` | `opts.minified` | Set to `true` to avoid adding whitespace for formatting                                                                                                                                                                                                            |
 | concise                | boolean             | `false`         | Set to `true` to reduce whitespace (but not as much as `opts.compact`)                                                                                                                                                                                             |
-| decoratorsBeforeExport | boolean              |                 | Set to `true` to print decorators before `export` in output.                            |
+| decoratorsBeforeExport | boolean             |                 | Set to `true` to print decorators before `export` in output.                                                                                                                                                                                                       |
 | filename               | string              |                 | Used in warning messages                                                                                                                                                                                                                                           |
 | jsescOption            | object              |                 | Use `jsesc` to process literals. `jsesc` is applied to numbers only if `jsescOption.numbers` (added in `v7.9.0`) is present. You can customize `jsesc` by [passing options](https://github.com/mathiasbynens/jsesc#api) to it.                                     |
 | jsonCompatibleStrings  | boolean             | `false`         | Set to true to run `jsesc` with "json": true to print "\u00A9" vs. "©";                                                                                                                                                                                            |

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,7 +1,6 @@
 ---
 id: babel-helpers
 title: @babel/helpers
-sidebar_label: helpers
 ---
 
 ## Install
@@ -15,10 +14,10 @@ npm install --save-dev @babel/helpers
 Direct:
 
 ```js
-import * as helpers from '@babel/helpers';
-import * as t from '@babel/types';
+import * as helpers from "@babel/helpers";
+import * as t from "@babel/types";
 
-const typeofHelper = helpers.get('typeof');
+const typeofHelper = helpers.get("typeof");
 
 t.isExpressionStatement(typeofHelper);
 // true
@@ -43,9 +42,10 @@ export default {
 > **NOTE**: This package is only meant to be used by the packages included in this repository. There is currently no way for third-party plugins to define a helper.
 
 Helpers are defined in the `src/helpers.js` file, and they must be valid modules which follow these guidelines:
- - They must have a default export, which is their entry-point.
- - They can import other helpers, exclusively by using default imports.
- - They can't have named exports.
+
+- They must have a default export, which is their entry-point.
+- They can import other helpers, exclusively by using default imports.
+- They can't have named exports.
 
 ```js
 helpers.customHelper = defineHelper(`
@@ -58,4 +58,3 @@ helpers.customHelper = defineHelper(`
   }
 `);
 ```
-

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,6 +1,7 @@
 ---
 title: Options
 id: options
+sidebar_label: Config Options
 ---
 
 - [Primary options](#primary-options)
@@ -30,7 +31,6 @@ they are primarily for use by tools that wrap around Babel, or people calling
 `babel.transform` directly. Users of Babel's integrations, like `babel-loader`
 or [`@babel/register`](core.md#options) are unlikely to use these.
 
-
 ### `cwd`
 
 Type: `string`<br />
@@ -39,10 +39,10 @@ Default: `process.cwd()`<br />
 The working directory that all paths in the programmatic options will be resolved
 relative to.
 
-
 ### `caller`
 
 Type: An object with the shape of
+
 ```flow
 interface CallerData {
   name: string;
@@ -52,6 +52,7 @@ interface CallerData {
   supportsExportNamespaceFrom?: boolean;
 }
 ```
+
 <details>
   <summary>History</summary>
 | Version | Changes |
@@ -63,17 +64,18 @@ interface CallerData {
 
 Utilities may pass a `caller` object to identify themselves to Babel and pass
 capability-related flags for use by configs, presets and plugins. For example
+
 ```js
 babel.transformFileSync("example.js", {
   caller: {
     name: "my-custom-tool",
-    supportsStaticESM: true
+    supportsStaticESM: true,
   },
-})
+});
 ```
+
 would allow plugins and presets to decide that, since ES modules are supported,
 they will skip compilation of ES modules into CommonJS modules.
-
 
 ### `filename`
 
@@ -86,10 +88,9 @@ for their functionality.
 
 The three primary cases users could run into are:
 
-* The filename is exposed to plugins. Some plugins may require the presence of the filename.
-* Options like [`"test"`](#test), [`"exclude"`](#exclude), and [`"ignore"`](#ignore) require the filename for string/RegExp matching.
-* `.babelrc.json` or `.babelrc` files are loaded relative to the file being compiled. If this option is omitted, Babel will behave as if `babelrc: false` has been set.
-
+- The filename is exposed to plugins. Some plugins may require the presence of the filename.
+- Options like [`"test"`](#test), [`"exclude"`](#exclude), and [`"ignore"`](#ignore) require the filename for string/RegExp matching.
+- `.babelrc.json` or `.babelrc` files are loaded relative to the file being compiled. If this option is omitted, Babel will behave as if `babelrc: false` has been set.
 
 ### `filenameRelative`
 
@@ -98,7 +99,6 @@ Default: `path.relative(opts.cwd, opts.filename)` (if [`"filename"`](#filename) 
 
 Used as the default value for Babel's `sourceFileName` option, and used
 as part of generation of filenames for the AMD / UMD / SystemJS module transforms.
-
 
 ### `code`
 
@@ -109,7 +109,6 @@ Babel's default return value includes `code` and `map` properties with the
 resulting generated code. In some contexts where multiple calls to Babel
 are being made, it can be helpful to disable code generation and instead
 use `ast: true` to get the AST directly in order to avoid doing unnecessary work.
-
 
 ### `ast`
 
@@ -125,7 +124,11 @@ const filename = "example.js";
 const source = fs.readFileSync(filename, "utf8");
 
 // Load and compile file normally, but skip code generation.
-const { ast } = babel.transformSync(source, { filename, ast: true, code: false });
+const { ast } = babel.transformSync(source, {
+  filename,
+  ast: true,
+  code: false,
+});
 
 // Minify the file in a second pass and generate the output code here.
 const { code, map } = babel.transformFromAstSync(ast, source, {
@@ -156,7 +159,6 @@ Loading configuration can get a little complex as environments can have several
 types of configuration files, and those configuration files can have various
 nested configuration objects that apply depending on the configuration.
 
-
 ### `root`
 
 Type: `string`<br />
@@ -167,9 +169,8 @@ The initial path that will be processed based on the [`"rootMode"`](#rootmode)
 to determine the conceptual root folder for the current Babel project.
 This is used in two primary cases:
 
-* The base directory when checking for the default [`"configFile"`](#configfile) value
-* The default value for [`"babelrcRoots"`](#babelrcroots).
-
+- The base directory when checking for the default [`"configFile"`](#configfile) value
+- The default value for [`"babelrcRoots"`](#babelrcroots).
 
 ### `rootMode`
 
@@ -184,12 +185,12 @@ Babel can process the [`"root"`](#root) value to get the final project root.
 
 Note: `babel.config.json` is supported from Babel 7.8.0. In older Babel 7 versions, only `babel.config.js` is supported.
 
-* `"root"` - Passes the [`"root"`](#root) value through as unchanged.
-* `"upward"` - Walks upward from the [`"root"`](#root) directory, looking
+- `"root"` - Passes the [`"root"`](#root) value through as unchanged.
+- `"upward"` - Walks upward from the [`"root"`](#root) directory, looking
   for a directory containing a [`babel.config.json`](config-files.md#project-wide-configuration)
   file, and throws an error if a [`babel.config.json`](config-files.md#project-wide-configuration)
   is not found.
-* `"upward-optional"` - Walk upward from the [`"root"`](#root) directory,
+- `"upward-optional"` - Walk upward from the [`"root"`](#root) directory,
   looking for a directory containing a [`babel.config.json`](config-files.md#project-wide-configuration)
   file, and falls back to [`"root"`](#root) if a [`babel.config.json`](config-files.md#project-wide-configuration)
   is not found.
@@ -207,7 +208,6 @@ in the project root. Running Babel in a monorepo subdirectory without `"upward"`
 will cause Babel to skip loading any [`babel.config.json`](config-files.md#project-wide-configuration)
 files in the project root, which can lead to unexpected errors and compilation failure.
 
-
 ### `envName`
 
 Type: `string`<br />
@@ -218,7 +218,6 @@ The current active environment used during configuration loading. This value
 is used as the key when resolving [`"env"`](#env) configs, and is also
 available inside configuration functions, plugins, and presets, via the
 [`api.env()`](config-files.md#apienv) function.
-
 
 ### `configFile`
 
@@ -236,7 +235,6 @@ file-relative logic, you'll end up loading the same config file twice, merging i
 If you are linking a specific config file, it is recommended to stick with a
 naming scheme that is independent of the "babelrc" name.
 
-
 ### `babelrc`
 
 Type: `boolean`<br />
@@ -251,7 +249,6 @@ within a configuration file.
 
 Note: `.babelrc.json` files are only loaded if the current [`"filename"`](#filename) is inside of
 a package that matches one of the [`"babelrcRoots"`](#babelrcroots) packages.
-
 
 ### `babelrcRoots`
 
@@ -276,8 +273,8 @@ babelrcRoots: [
   ".",
 
   // Also consider monorepo packages "root" and load their .babelrc.json files.
-  "./packages/*"
-]
+  "./packages/*",
+];
 ```
 
 ## Plugin and Preset options
@@ -295,7 +292,6 @@ Note: The option also allows `Plugin` instances from Babel itself, but
 using these directly is not recommended. If you need to create a persistent
 representation of a plugin or preset, you should use [`babel.createConfigItem()`](core.md#createconfigitem).
 
-
 ### `presets`
 
 Type: `Array<PresetEntry>` ([`PresetEntry`](#plugin-preset-entries))<br />
@@ -309,12 +305,11 @@ Note: The format of presets is identical to plugins, except for the fact that
 name normalization expects "preset-" instead of "plugin-", and presets cannot
 be instances of `Plugin`.
 
-
 ### `passPerPreset`
 
 Type: `boolean`<br />
 Default: `false`<br />
-Status: *Deprecated*<br />
+Status: _Deprecated_<br />
 
 Instructs Babel to run each of the presets in the `presets` array as an
 independent pass. This option tends to introduce a lot of confusion around
@@ -444,7 +439,6 @@ Placement: Not allowed inside of presets<br />
 Configs may "extend" other configuration files. Config fields in the current
 config will be [merged](#merging) on top of the extended file's configuration.
 
-
 ### `env`
 
 Type: `{ [envKey: string]: Options }`<br />
@@ -456,7 +450,6 @@ if the `envKey` matches the `envName` option.
 Note: `env[envKey]` options will be [merged](#merging) on top of the options specified in
 the root object.
 
-
 ### `overrides`
 
 Type: `Array<Options>`<br />
@@ -465,15 +458,16 @@ Placement: May not be nested inside of another `overrides` object, or within an 
 Allows users to provide an array of options that will be [merged](#merging) into the current
 configuration one at a time. This feature is best used alongside the [`"test"`](#test)/[`"include"`](#include)/[`"exclude"`](#exclude)
 options to provide conditions for which an override should apply. For example:
+
 ```js
 overrides: [{
   test: "./vendor/large.min.js",
   compact: true,
 }],
 ```
+
 could be used to enable the `compact` option for one specific file that is known
 to be large and minified, and tell Babel not to bother trying to print the file nicely.
-
 
 ### `test`
 
@@ -487,13 +481,11 @@ Note: These toggles do not affect the programmatic and config-loading options
 in earlier sections, since they are taken into account long before the
 configuration that is prepared for merging.
 
-
 ### `include`
 
 Type: `MatchPattern | Array<MatchPattern>` ([`MatchPattern`](#matchpattern))<br />
 
 This option is a synonym for [`"test"`](#test).
-
 
 ### `exclude`
 
@@ -507,7 +499,6 @@ Note: These toggles do not affect the programmatic and config-loading options
 in earlier sections, since they are taken into account long before the
 configuration that is prepared for merging.
 
-
 ### `ignore`
 
 Type: `Array<MatchPattern>` ([`MatchPattern`](#matchpattern))<br />
@@ -517,16 +508,14 @@ If any of the patterns match, Babel will immediately stop all processing of
 the current build. For example, a user may want to do something like
 
 ```js
-ignore: [
-  "./lib",
-]
+ignore: ["./lib"];
 ```
+
 to explicitly disable Babel compilation of files inside the `lib` directory.
 
 Note: This option disables _all_ Babel processing of a file. While that has
 its uses, it is also worth considering the [`"exclude"`](#exclude) option as a less aggressive
 alternative.
-
 
 ### `only`
 
@@ -537,17 +526,15 @@ If all of the patterns fail to match, Babel will immediately stop all processing
 of the current build. For example, a user may want to do something like
 
 ```js
-only: [
-  "./src",
-]
+only: ["./src"];
 ```
+
 to explicitly enable Babel compilation of files inside the `src` directory
 while disabling everything else.
 
 Note: This option disables _all_ Babel processing of a file. While that has
 its uses, it is also worth considering the [`"test"`](#test)/[`"include"`](#include)
 options as a less aggressive alternative.
-
 
 ## Source Map options
 
@@ -562,30 +549,27 @@ map fails to load and parse, it will be silently discarded.
 
 If an object is provided, it will be treated as the source map object itself.
 
-
 ### `sourceMaps`
 
 Type: `boolean | "inline" | "both"`<br />
 Default: `false`<br />
 
-* `true` to generate a sourcemap for the code and include it in the result object.
-* `"inline"` to generate a sourcemap and append it as a data URL to the end of the code, but not include it in the result object.
-* `"both"` is the same as inline, but will include the map in the result object.
+- `true` to generate a sourcemap for the code and include it in the result object.
+- `"inline"` to generate a sourcemap and append it as a data URL to the end of the code, but not include it in the result object.
+- `"both"` is the same as inline, but will include the map in the result object.
 
 `@babel/cli` overloads some of these to also affect how maps are written to disk:
 
-* `true` will write the map to a `.map` file on disk
-* `"inline"` will write the file directly, so it will have a `data:` containing the map
-* `"both"` will write the file with a `data:` URL and _also_ a `.map`.
+- `true` will write the map to a `.map` file on disk
+- `"inline"` will write the file directly, so it will have a `data:` containing the map
+- `"both"` will write the file with a `data:` URL and _also_ a `.map`.
 
 Note: These options are bit weird, so it may make the most sense to just use
 `true` and handle the rest in your own code, depending on your use case.
 
-
 ### `sourceMap`
 
 This is an synonym for `sourceMaps`. Using `sourceMaps` is recommended.
-
 
 ### `sourceFileName`
 
@@ -594,13 +578,11 @@ Default: `path.basename(opts.filenameRelative)` when available, or `"unknown"`<b
 
 The name to use for the file inside the source map object.
 
-
 ### `sourceRoot`
 
 Type: `string`<br />
 
 The `sourceRoot` fields to set in the generated source map, if one is desired.
-
 
 ## Misc options
 
@@ -609,9 +591,9 @@ The `sourceRoot` fields to set in the generated source map, if one is desired.
 Type: `"script" | "module" | "unambiguous"`<br />
 Default: "module"<br />
 
-* `"script"` - Parse the file using the ECMAScript Script grammar. No `import`/`export` statements allowed, and files are not in strict mode.
-* `"module"` - Parse the file using the ECMAScript Module grammar. Files are automatically strict, and `import`/`export` statements are allowed.
-* `"unambiguous"` - Consider the file a "module" if `import`/`export` statements are present, or else consider it a "script".
+- `"script"` - Parse the file using the ECMAScript Script grammar. No `import`/`export` statements allowed, and files are not in strict mode.
+- `"module"` - Parse the file using the ECMAScript Module grammar. Files are automatically strict, and `import`/`export` statements are allowed.
+- `"unambiguous"` - Consider the file a "module" if `import`/`export` statements are present, or else consider it a "script".
 
 `unambiguous` can be quite useful in contexts where the type is unknown, but it can lead to
 false matches because it's perfectly valid to have a module file that does not use `import`/`export`
@@ -644,6 +626,7 @@ Default: `{}`<br />
 Placement: Allowed in programmatic options, config files and presets.<br />
 
 Set assumptions that Babel can make in order to produce smaller output:
+
 ```json
 {
   "assumptions": {
@@ -662,7 +645,6 @@ Default: `true`<br />
 
 Highlight tokens in code snippets in Babel's error messages to make them easier to read.
 
-
 ### `wrapPluginVisitorMethod`
 
 Type: `(key: string, nodeType: string, fn: Function) => Function`<br />
@@ -670,13 +652,12 @@ Type: `(key: string, nodeType: string, fn: Function) => Function`<br />
 Allows users to add a wrapper on each visitor in order to inspect the visitor
 process as Babel executes the plugins.
 
-* `key` is a simple opaque string that represents the plugin being executed.
-* `nodeType` is the type of AST node currently being visited.
-* `fn` is the visitor function itself.
+- `key` is a simple opaque string that represents the plugin being executed.
+- `nodeType` is the type of AST node currently being visited.
+- `fn` is the visitor function itself.
 
 Users can return a replacement function that should call the original function
 after performing whatever logging and analysis they wish to do.
-
 
 ### `parserOpts`
 
@@ -692,7 +673,6 @@ Type: `{}`<br />
 
 An opaque object containing options to pass through to the code generator being used. See [Code Generator Options](#code-generator-options) for most used options.
 
-
 ## Code Generator options
 
 ### `retainLines`
@@ -705,7 +685,6 @@ same line that they were on in the original file. This option exists so that
 users who cannot use source maps can get vaguely useful error line numbers,
 but it is only a best-effort, and is not guaranteed in all cases with all plugins.
 
-
 ### `compact`
 
 Type: `boolean | "auto"`<br />
@@ -716,7 +695,6 @@ Default: `"auto"`<br />
 All optional newlines and whitespace will be omitted when generating code in
 compact mode.
 
-
 ### `minified`
 
 Type: `boolean`<br />
@@ -724,7 +702,6 @@ Default: `false`<br />
 
 Includes `compact: true`, omits block-end semicolons, omits `()` from
 `new Foo()` when possible, and may output shorter versions of literals.
-
 
 ### `auxiliaryCommentBefore`
 
@@ -737,7 +714,6 @@ Note: The definition of what is and isn't present in the original file can
 get a little ugly, so usage of this option is _not recommended_. If you need to
 annotate code somehow, it is better to do so using a Babel plugin.
 
-
 ### `auxiliaryCommentAfter`
 
 Type: `string`<br />
@@ -749,7 +725,6 @@ Note: The definition of what is and isn't present in the original file can
 get a little ugly, so usage of this option is _not recommended_. If you need to
 annotate code somehow, it is better to do so using a Babel plugin.
 
-
 ### `comments`
 
 Type: `boolean`<br />
@@ -757,7 +732,6 @@ Default: `true`<br />
 
 Provides a default comment state for `shouldPrintComment` if no function
 is given. See the default value of that option for more info.
-
 
 ### `shouldPrintComment`
 
@@ -768,10 +742,9 @@ Default with `minified`: `() => opts.comments`<br />
 A function that can decide whether a given comment should be included in the
 output code from Babel.
 
-
 ### Advanced Usage
-For more code generator options, see [Generator Options](generator.md#options).
 
+For more code generator options, see [Generator Options](generator.md#options).
 
 ## AMD / UMD / SystemJS module options
 
@@ -782,13 +755,11 @@ Default: `!!opts.moduleId`<br />
 
 Enables module ID generation.
 
-
 ### `moduleId`
 
 Type: `string`<br />
 
 A hard-coded ID to use for the module. Cannot be used alongside `getModuleId`.
-
 
 ### `getModuleId`
 
@@ -796,7 +767,6 @@ Type: `(name: string) => string`<br />
 
 Given the babel-generated module name, return the name to use. Returning
 a falsy value will use the original `name`.
-
 
 ### `moduleRoot`
 
@@ -813,33 +783,33 @@ Type: `string | RegExp | (filename: string | void, context: { caller: { name: st
 Several Babel options perform tests against file paths. In general, these
 options support a common pattern approach where each pattern can be
 
-* `string` - A file path with simple support for `*` and `**` as full slug matches. Any file or
+- `string` - A file path with simple support for `*` and `**` as full slug matches. Any file or
   parent folder matching the pattern counts as a match. The path follow's Node's normal path logic,
   so on POSIX is must be `/`-separated, but on Windows both `/` and `\` are supported.
-* `RegExp` - A regular expression to match against the normalized filename. On POSIX the path
+- `RegExp` - A regular expression to match against the normalized filename. On POSIX the path
   RegExp will run against a `/`-separated path, and on Windows it will be on a `\`-separated path.
 
 Importantly, if either of these are used, Babel requires that the `filename` option be present,
 and will consider it an error otherwise.
 
-* `(filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string }) => boolean` is a general callback that should
+- `(filename: string | void, context: { caller: { name: string } | void, envName: string, dirname: string }) => boolean` is a general callback that should
   return a boolean to indicate whether it is a match or not. The function is passed the filename
   or `undefined` if one was not given to Babel. It is also passed the current `envName` and `caller`
   options that were specified by the top-level call to Babel and `dirname` that is either a directory of the configuration file or the current working directory (if the transformation was called programmatically).
-
 
 ### Merging
 
 Babel's configuration merging is relatively straightforward. Options will overwrite existing options
 when they are present, and their value is not `undefined`, with a few special cases:
 
-* `parserOpts` objects are merged, rather than replaced, using the same logic as top-level options.
-* `generatorOpts` objects are merged, rather than replaced, using the same logic as top-level options.
-* `plugins` and `presets` are replaced based on the identity of the plugin/preset object/function itself combined with the name of the entry.
+- `parserOpts` objects are merged, rather than replaced, using the same logic as top-level options.
+- `generatorOpts` objects are merged, rather than replaced, using the same logic as top-level options.
+- `plugins` and `presets` are replaced based on the identity of the plugin/preset object/function itself combined with the name of the entry.
 
 #### Plugin/Preset merging
 
 As an example, consider a config with:
+
 ```js
 plugins: [
   './other',
@@ -851,6 +821,7 @@ overrides: [{
   ]
 }]
 ```
+
 The `overrides` item will be merged on top of the top-level plugins. Importantly, the `plugins`
 array as a whole doesn't just replace the top-level one. The merging logic will see that `"./plug"`
 is the same plugin in both cases, and `{ thing: false, field2: true }` will replace the original
@@ -865,20 +836,17 @@ plugins: [
 
 Since merging is based on identity + name, it is considered an error to use the same plugin with
 the same name twice in the same `plugins`/`presets` array. For example
+
 ```js
-plugins: [
-  './plug',
-  './plug',
-]
+plugins: ["./plug", "./plug"];
 ```
+
 is considered an error, because it's identical to `plugins: ['./plug']`. Additionally, even
 
 ```js
-plugins: [
-  ['./plug', {one: true}],
-  ['./plug', {two: true}]
-]
+plugins: [["./plug", { one: true }], ["./plug", { two: true }]];
 ```
+
 is considered an error, because the second one would just always replace the first one.
 
 If you actually _do_ want to instantiate two separate instances of a plugin, you must assign each one
@@ -886,12 +854,12 @@ a name to disambiguate them. For example:
 
 ```js
 plugins: [
-  ['./plug', {one: true}, "first-instance-name"],
-  ['./plug', {two: true}, "second-instance-name"]
-]
+  ["./plug", { one: true }, "first-instance-name"],
+  ["./plug", { two: true }, "second-instance-name"],
+];
 ```
-because each instance has been given a unique name and this a unique identity.
 
+because each instance has been given a unique name and this a unique identity.
 
 ### Plugin/Preset entries
 
@@ -899,10 +867,10 @@ because each instance has been given a unique name and this a unique identity.
 
 Individual plugin/preset items can have several different structures:
 
-* `EntryTarget` - Individual plugin
-* `[EntryTarget, EntryOptions]` - Individual plugin w/ options
-* `[EntryTarget, EntryOptions, string]` - Individual plugin with options and name (see [merging](#merging) for more info on names)
-* `ConfigItem` - A plugin configuration item created by `babel.createConfigItem()`.
+- `EntryTarget` - Individual plugin
+- `[EntryTarget, EntryOptions]` - Individual plugin w/ options
+- `[EntryTarget, EntryOptions, string]` - Individual plugin with options and name (see [merging](#merging) for more info on names)
+- `ConfigItem` - A plugin configuration item created by `babel.createConfigItem()`.
 
 The same `EntryTarget` may be used multiple times unless each one is given a different
 name, and doing so will result in a duplicate-plugin/preset error.
@@ -931,9 +899,8 @@ Type: `string | {} | Function`<br />
 
 A plugin/preset target can come from a few different sources:
 
-* `string` - A `require`-style path or plugin/preset identifier. Identifiers will be passed through [name normalization](#name-normalization).
-* `{} | Function` - An actual plugin/preset object or function after it has been `require()`ed.
-
+- `string` - A `require`-style path or plugin/preset identifier. Identifiers will be passed through [name normalization](#name-normalization).
+- `{} | Function` - An actual plugin/preset object or function after it has been `require()`ed.
 
 #### `EntryOptions`
 
@@ -958,8 +925,8 @@ overrides: [{
   ]
 }]
 ```
-would enable the `two` plugin for files in `src`, but `two` would still execute between `one` and `three`.
 
+would enable the `two` plugin for files in `src`, but `two` would still execute between `one` and `three`.
 
 ### Name Normalization
 
@@ -967,31 +934,31 @@ By default, Babel expects plugins to have a `babel-plugin-` or `babel-preset-` p
 To avoid repetition, Babel has a name normalization phase will automatically add these prefixes
 when loading items. This boils down to a few primary rules:
 
-* Absolute paths pass through untouched.
-* Relative paths starting with `./` pass through untouched.
-* References to files _within_ a package are untouched.
-* Any identifier prefixed with `module:` will have the prefix removed but otherwise be untouched.
-* `plugin-`/`preset-` will be injected at the start of any `@babel`-scoped package that doesn't have it as a prefix.
-* `babel-plugin-`/`babel-preset-` will be injected as a prefix any unscoped package that doesn't have it as a prefix.
-* `babel-plugin-`/`babel-preset-` will be injected as a prefix any `@`-scoped package that doesn't have it _anywhere_ in their name.
-* `babel-plugin`/`babel-preset` will be injected as the package name if only the `@`-scope name is given.
+- Absolute paths pass through untouched.
+- Relative paths starting with `./` pass through untouched.
+- References to files _within_ a package are untouched.
+- Any identifier prefixed with `module:` will have the prefix removed but otherwise be untouched.
+- `plugin-`/`preset-` will be injected at the start of any `@babel`-scoped package that doesn't have it as a prefix.
+- `babel-plugin-`/`babel-preset-` will be injected as a prefix any unscoped package that doesn't have it as a prefix.
+- `babel-plugin-`/`babel-preset-` will be injected as a prefix any `@`-scoped package that doesn't have it _anywhere_ in their name.
+- `babel-plugin`/`babel-preset` will be injected as the package name if only the `@`-scope name is given.
 
 Here are some examples, when applied in a plugin context:
 
-| Input | Normalized |
-| -------- | --- |
-| `"/dir/plugin.js"` | `"/dir/plugin.js"`
-| `"./dir/plugin.js"` | `"./dir/plugin.js"`
-| `"mod"` | `"babel-plugin-mod"` |
-| `"mod/plugin"` | `"mod/plugin"`
-| `"babel-plugin-mod"` | `"babel-plugin-mod"` |
-| `"@babel/mod"` | `"@babel/plugin-mod"` |
-| `"@babel/plugin-mod"` | `"@babel/plugin-mod"` |
-| `"@babel/mod/plugin"` | `"@babel/mod/plugin"`
-| `"@scope"` | `"@scope/babel-plugin"` |
-| `"@scope/babel-plugin"` | `"@scope/babel-plugin"` |
-| `"@scope/mod"` | `"@scope/babel-plugin-mod"` |
-| `"@scope/babel-plugin-mod"` | `"@scope/babel-plugin-mod"` |
+| Input                              | Normalized                         |
+| ---------------------------------- | ---------------------------------- |
+| `"/dir/plugin.js"`                 | `"/dir/plugin.js"`                 |
+| `"./dir/plugin.js"`                | `"./dir/plugin.js"`                |
+| `"mod"`                            | `"babel-plugin-mod"`               |
+| `"mod/plugin"`                     | `"mod/plugin"`                     |
+| `"babel-plugin-mod"`               | `"babel-plugin-mod"`               |
+| `"@babel/mod"`                     | `"@babel/plugin-mod"`              |
+| `"@babel/plugin-mod"`              | `"@babel/plugin-mod"`              |
+| `"@babel/mod/plugin"`              | `"@babel/mod/plugin"`              |
+| `"@scope"`                         | `"@scope/babel-plugin"`            |
+| `"@scope/babel-plugin"`            | `"@scope/babel-plugin"`            |
+| `"@scope/mod"`                     | `"@scope/babel-plugin-mod"`        |
+| `"@scope/babel-plugin-mod"`        | `"@scope/babel-plugin-mod"`        |
 | `"@scope/prefix-babel-plugin-mod"` | `"@scope/prefix-babel-plugin-mod"` |
-| `"@scope/mod/plugin"` | `"@scope/mod/plugin"`
-| `"module:foo"` | `"foo"` |
+| `"@scope/mod/plugin"`              | `"@scope/mod/plugin"`              |
+| `"module:foo"`                     | `"foo"`                            |

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,17 +1,16 @@
 ---
 id: babel-parser
 title: @babel/parser
-sidebar_label: parser
 ---
 
 <p align="left">
   The Babel parser (previously Babylon) is a JavaScript parser used in <a href="https://github.com/babel/babel">Babel</a>.
 </p>
 
- - The latest ECMAScript version enabled by default (ES2020).
- - Comment attachment.
- - Support for JSX, Flow, Typescript.
- - Support for experimental language proposals (accepting PRs for anything at least [stage-0](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md)).
+- The latest ECMAScript version enabled by default (ES2020).
+- Comment attachment.
+- Support for JSX, Flow, Typescript.
+- Support for experimental language proposals (accepting PRs for anything at least [stage-0](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md)).
 
 ## Credits
 
@@ -78,7 +77,7 @@ mind. When in doubt, use `.parse()`.
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   one of `"script"`, `"module"`, or `"unambiguous"`. Defaults to `"script"`. `"unambiguous"` will make @babel/parser attempt to _guess_, based on the presence of ES6 `import` or `export` statements. Files with ES6 `import`s and `export`s are considered `"module"` and are otherwise `"script"`.
 
-- **sourceFilename**: Correlate output AST nodes with their source filename.  Useful when generating code and source maps from the ASTs of multiple input files.
+- **sourceFilename**: Correlate output AST nodes with their source filename. Useful when generating code and source maps from the ASTs of multiple input files.
 
 - **startLine**: By default, the first line of code parsed is treated as line 1. You can provide a line number to alternatively start with. Useful for integration with other source tools.
 
@@ -107,35 +106,32 @@ It is based on [ESTree spec][] with the following deviations:
 
 AST for JSX code is based on [Facebook JSX AST][].
 
-[Babel AST format]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md
-[ESTree spec]: https://github.com/estree/estree
-
-[Literal]: https://github.com/estree/estree/blob/master/es5.md#literal
-[Property]: https://github.com/estree/estree/blob/master/es5.md#property
-[MethodDefinition]: https://github.com/estree/estree/blob/master/es2015.md#methoddefinition
-[ChainExpression]: https://github.com/estree/estree/blob/master/es2020.md#chainexpression
-[ImportExpression]: https://github.com/estree/estree/blob/master/es2020.md#importexpression
-
-[StringLiteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#stringliteral
-[NumericLiteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#numericliteral
-[BigIntLiteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#bigintliteral
-[BooleanLiteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#booleanliteral
-[NullLiteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#nullliteral
-[RegExpLiteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#regexpliteral
-[ObjectProperty]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#objectproperty
-[ObjectMethod]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#objectmethod
-[ClassMethod]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#classmethod
-[Program]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#programs
-[BlockStatement]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#blockstatement
-[Directive]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#directive
-[DirectiveLiteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#directiveliteral
-[FunctionExpression]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#functionexpression
-[OptionalMemberExpression]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#optionalmemberexpression
-[OptionalCallExpression]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#optionalcallexpression
-[CallExpression]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#callexpression
-[Import]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#import
-
-[Facebook JSX AST]: https://github.com/facebook/jsx/blob/master/AST.md
+[babel ast format]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md
+[estree spec]: https://github.com/estree/estree
+[literal]: https://github.com/estree/estree/blob/master/es5.md#literal
+[property]: https://github.com/estree/estree/blob/master/es5.md#property
+[methoddefinition]: https://github.com/estree/estree/blob/master/es2015.md#methoddefinition
+[chainexpression]: https://github.com/estree/estree/blob/master/es2020.md#chainexpression
+[importexpression]: https://github.com/estree/estree/blob/master/es2020.md#importexpression
+[stringliteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#stringliteral
+[numericliteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#numericliteral
+[bigintliteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#bigintliteral
+[booleanliteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#booleanliteral
+[nullliteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#nullliteral
+[regexpliteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#regexpliteral
+[objectproperty]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#objectproperty
+[objectmethod]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#objectmethod
+[classmethod]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#classmethod
+[program]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#programs
+[blockstatement]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#blockstatement
+[directive]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#directive
+[directiveliteral]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#directiveliteral
+[functionexpression]: https://github.com/babel/babel/tree/main/packages/babel-parser/ast/spec.md#functionexpression
+[optionalmemberexpression]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#optionalmemberexpression
+[optionalcallexpression]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#optionalcallexpression
+[callexpression]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#callexpression
+[import]: https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#import
+[facebook jsx ast]: https://github.com/facebook/jsx/blob/master/AST.md
 
 ### Semver
 
@@ -153,8 +149,8 @@ require("@babel/parser").parse("code", {
   plugins: [
     // enable jsx and flow syntax
     "jsx",
-    "flow"
-  ]
+    "flow",
+  ],
 });
 ```
 
@@ -162,9 +158,9 @@ require("@babel/parser").parse("code", {
 
 #### Miscellaneous
 
-| Name | Code Example |
-|------|--------------|
-| `estree` ([repo](https://github.com/estree/estree)) | n/a |
+| Name                                                | Code Example |
+| --------------------------------------------------- | ------------ |
+| `estree` ([repo](https://github.com/estree/estree)) | n/a          |
 
 #### Language extensions
 
@@ -198,52 +194,54 @@ require("@babel/parser").parse("code", {
 | `v7.2.0` | Added `classPrivateMethods` |
 </details>
 
-| Name | Code Example |
-|------|--------------|
-| `classProperties` ([proposal](https://github.com/tc39/proposal-class-public-fields)) | `class A { b = 1; }` |
-| `classPrivateProperties` ([proposal](https://github.com/tc39/proposal-private-fields)) | `class A { #b = 1; }` |
-| `classPrivateMethods` ([proposal](https://github.com/tc39/proposal-private-methods)) | `class A { #c() {} }` |
-| `classStaticBlock` ([proposal](https://github.com/tc39/proposal-class-static-block)) | `class A { static {} }` |
-| `decimal` ([proposal](https://github.com/tc39/proposal-decimal)) | `0.3m` |
-| `decorators` ([proposal](https://github.com/tc39/proposal-decorators)) <br> `decorators-legacy` | `@a class A {}` |
-| `doExpressions` ([proposal](https://github.com/tc39/proposal-do-expressions)) | `var a = do { if (true) { 'hi'; } };` |
-| `exportDefaultFrom` ([proposal](https://github.com/tc39/ecmascript-export-default-from)) | `export v from "mod"` |
-| `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind)) | `a::b`, `::console.log` |
-| `importAssertions` ([proposal](https://github.com/tc39/proposal-import-assertions)) | `import json from "./foo.json" assert { type: "json" };` |
-| `moduleBlocks` ([proposal](https://github.com/tc39/proposal-js-module-blocks)) | `let m = module { export let y = 1; };` |
-| `moduleStringNames` ([proposal](https://github.com/tc39/ecma262/pull/2154)) | `import { "😄" as smile } from "emoji";` |
-| `partialApplication` ([proposal](https://github.com/babel/proposals/issues/32)) | `f(?, a)` |
-| `pipelineOperator` ([proposal](https://github.com/babel/proposals/issues/29)) | <code>a &#124;> b</code> |
-| `privateIn` ([proposal](https://github.com/tc39/proposal-private-fields-in-in)) | `#p in obj` |
-| `recordAndTuple` ([proposal](https://github.com/tc39/proposal-record-tuple)) | `#{x: 1}`, `#[1, 2]` |
-| `throwExpressions` ([proposal](https://github.com/babel/proposals/issues/23)) | `() => throw new Error("")` |
-| `topLevelAwait` ([proposal](https://github.com/tc39/proposal-top-level-await/)) | `await promise` in modules |
+| Name                                                                                            | Code Example                                             |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `classProperties` ([proposal](https://github.com/tc39/proposal-class-public-fields))            | `class A { b = 1; }`                                     |
+| `classPrivateProperties` ([proposal](https://github.com/tc39/proposal-private-fields))          | `class A { #b = 1; }`                                    |
+| `classPrivateMethods` ([proposal](https://github.com/tc39/proposal-private-methods))            | `class A { #c() {} }`                                    |
+| `classStaticBlock` ([proposal](https://github.com/tc39/proposal-class-static-block))            | `class A { static {} }`                                  |
+| `decimal` ([proposal](https://github.com/tc39/proposal-decimal))                                | `0.3m`                                                   |
+| `decorators` ([proposal](https://github.com/tc39/proposal-decorators)) <br> `decorators-legacy` | `@a class A {}`                                          |
+| `doExpressions` ([proposal](https://github.com/tc39/proposal-do-expressions))                   | `var a = do { if (true) { 'hi'; } };`                    |
+| `exportDefaultFrom` ([proposal](https://github.com/tc39/ecmascript-export-default-from))        | `export v from "mod"`                                    |
+| `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind))                     | `a::b`, `::console.log`                                  |
+| `importAssertions` ([proposal](https://github.com/tc39/proposal-import-assertions))             | `import json from "./foo.json" assert { type: "json" };` |
+| `moduleBlocks` ([proposal](https://github.com/tc39/proposal-js-module-blocks))                  | `let m = module { export let y = 1; };`                  |
+| `moduleStringNames` ([proposal](https://github.com/tc39/ecma262/pull/2154))                     | `import { "😄" as smile } from "emoji";`                 |
+| `partialApplication` ([proposal](https://github.com/babel/proposals/issues/32))                 | `f(?, a)`                                                |
+| `pipelineOperator` ([proposal](https://github.com/babel/proposals/issues/29))                   | <code>a &#124;> b</code>                                 |
+| `privateIn` ([proposal](https://github.com/tc39/proposal-private-fields-in-in))                 | `#p in obj`                                              |
+| `recordAndTuple` ([proposal](https://github.com/tc39/proposal-record-tuple))                    | `#{x: 1}`, `#[1, 2]`                                     |
+| `throwExpressions` ([proposal](https://github.com/babel/proposals/issues/23))                   | `() => throw new Error("")`                              |
+| `topLevelAwait` ([proposal](https://github.com/tc39/proposal-top-level-await/))                 | `await promise` in modules                               |
 
 #### Latest ECMAScript features
 
 The following features are already enabled on the latest version of `@babel/parser`, and cannot be disabled because they are part of the language.
 You should enable these features only if you are using an older version.
 
-| Name | Code Example |
-|------|--------------|
-| `asyncGenerators` ([proposal](https://github.com/tc39/proposal-async-iteration)) | `async function*() {}`, `for await (let a of b) {}` |
-| `bigInt` ([proposal](https://github.com/tc39/proposal-bigint)) | `100n` |
-| `dynamicImport` ([proposal](https://github.com/tc39/proposal-dynamic-import)) | `import('./guy').then(a)` |
-| `exportNamespaceFrom` ([proposal](https://github.com/leebyron/ecmascript-export-ns-from)) | `export * as ns from "mod"` |
-| `functionSent` ([proposal](https://github.com/tc39/proposal-function.sent)) | `function.sent` |
-| `logicalAssignment` ([proposal](https://github.com/tc39/proposal-logical-assignment)) | `a &&= b` |
-| `nullishCoalescingOperator` ([proposal](https://github.com/babel/proposals/issues/14)) | `a ?? b` |
-| `numericSeparator` ([proposal](https://github.com/samuelgoto/proposal-numeric-separator)) | `1_000_000` |
-| `objectRestSpread` ([proposal](https://github.com/tc39/proposal-object-rest-spread)) | `var a = { b, ...c };` |
-| `optionalCatchBinding` ([proposal](https://github.com/babel/proposals/issues/7)) | `try {throw 0;} catch{do();}` |
-| `optionalChaining` ([proposal](https://github.com/tc39/proposal-optional-chaining)) | `a?.b` |
+| Name                                                                                      | Code Example                                        |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `asyncGenerators` ([proposal](https://github.com/tc39/proposal-async-iteration))          | `async function*() {}`, `for await (let a of b) {}` |
+| `bigInt` ([proposal](https://github.com/tc39/proposal-bigint))                            | `100n`                                              |
+| `dynamicImport` ([proposal](https://github.com/tc39/proposal-dynamic-import))             | `import('./guy').then(a)`                           |
+| `exportNamespaceFrom` ([proposal](https://github.com/leebyron/ecmascript-export-ns-from)) | `export * as ns from "mod"`                         |
+| `functionSent` ([proposal](https://github.com/tc39/proposal-function.sent))               | `function.sent`                                     |
+| `logicalAssignment` ([proposal](https://github.com/tc39/proposal-logical-assignment))     | `a &&= b`                                           |
+| `nullishCoalescingOperator` ([proposal](https://github.com/babel/proposals/issues/14))    | `a ?? b`                                            |
+| `numericSeparator` ([proposal](https://github.com/samuelgoto/proposal-numeric-separator)) | `1_000_000`                                         |
+| `objectRestSpread` ([proposal](https://github.com/tc39/proposal-object-rest-spread))      | `var a = { b, ...c };`                              |
+| `optionalCatchBinding` ([proposal](https://github.com/babel/proposals/issues/7))          | `try {throw 0;} catch{do();}`                       |
+| `optionalChaining` ([proposal](https://github.com/tc39/proposal-optional-chaining))       | `a?.b`                                              |
 
 #### Plugins options
 
 > NOTE: When a plugin is specified multiple times, only the first options are considered.
 
 - `decorators`:
+
   - `decoratorsBeforeExport` (`boolean`)
+
     ```js
     // decoratorsBeforeExport: true
     @dec
@@ -252,13 +250,16 @@ You should enable these features only if you are using an older version.
     // decoratorsBeforeExport: false
     export @dec class C {}
     ```
+
 - `pipelineOperator`:
+
   - `proposal` (required, accepted values: `minimal`, `smart`, `fsharp`)
     There are different proposals for the pipeline operator. This option
     allows to choose which one to use.
     See [What's Happening With the Pipeline (|>) Proposal?](https://babeljs.io/blog/2018/07/19/whats-happening-with-the-pipeline-proposal) for more information.
 
 - `recordAndtuple`:
+
   - `syntaxType` (required, accepted values: `hash`, `bar`)
     There are two syntax variants for `recordAndTuple`. They share exactly same runtime semantics.
     | SyntaxType | Record Example | Tuple Example |
@@ -288,10 +289,12 @@ To consume your custom parser, you can add a plugin to your [options](options.md
 const parse = require("custom-fork-of-babel-parser-on-npm-here");
 
 module.exports = {
-  plugins: [{
-    parserOverride(code, opts) {
-      return parse(code, opts);
+  plugins: [
+    {
+      parserOverride(code, opts) {
+        return parse(code, opts);
+      },
     },
-  }]
-}
+  ],
+};
 ```

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -1,7 +1,6 @@
 ---
 id: babel-plugin-transform-runtime
 title: @babel/plugin-transform-runtime
-sidebar_label: transform-runtime
 ---
 
 A plugin that enables the re-use of Babel's injected helper code to save on codesize.
@@ -190,6 +189,7 @@ By default transform-runtime assumes that `@babel/runtime@7.0.0` is installed. I
 `@babel/runtime` (or their corejs counterparts e.g. `@babel/runtime-corejs3`) installed or listed as a dependency, transform-runtime can use more advanced features.
 
 For example if you depend on `@babel/runtime-corejs2@7.7.4` you can transpile your code with
+
 ```json
 {
   "plugins": [
@@ -204,6 +204,7 @@ For example if you depend on `@babel/runtime-corejs2@7.7.4` you can transpile yo
   ]
 }
 ```
+
 which results in a smaller bundle size.
 
 ## Technical details

--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -10,13 +10,13 @@ This plugin adds support for the syntax used by the [TypeScript programming lang
 
 **In**
 
-```javascript
+```typescript
 const x: number = 0;
 ```
 
 **Out**
 
-```javascript
+```typescript
 const x = 0;
 ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -154,19 +154,6 @@ Your `.babelrc`:
 }
 ```
 
-### Plugin Shorthand
-
-If the name of the package is prefixed with `babel-plugin-`, you can use a shorthand:
-
-```js
-{
-  "plugins": [
-    "@org/name", // equivalent to "@org/babel-plugin-name"
-    "myPlugin", // equivalent to "babel-plugin-myPlugin"
-  ]
-}
-```
-
 ## Plugin Ordering
 
 > Ordering matters for each visitor in the plugin.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,11 +3,27 @@ id: plugins
 title: Plugins
 ---
 
-Babel is a compiler (source code => output code). Like many other compilers it runs in 3 stages: parsing, transforming, and printing.
+Babel's code transformations are enabled by applying plugins (or [presets](presets.md)) to your [configuration file](config-files.md).
 
-Now, out of the box Babel doesn't do anything. It basically acts like `const babel = code => code;` by parsing the code and then generating the same code back out again. You will need to add plugins for Babel to do anything.
+## Using a Plugin
 
-Instead of individual plugins, you can also enable a set of plugins in a [preset](presets.md).
+If the plugin is on [npm](https://www.npmjs.com/search?q=babel-plugin), you can pass in the name of the plugin and Babel will check that it's installed in `node_modules`. This is added to the [plugins](options.md#presets) config option, which takes an array.
+
+```json
+{
+  "plugins": ["babel-plugin-myPlugin", "@babel/plugin-transform-runtime"]
+}
+```
+
+You can also specify an relative/absolute path to your plugin.
+
+```json
+{
+  "plugins": ["./node_modules/asdf/plugin"]
+}
+```
+
+See [name normalization](options.md#name-normalization) for more specifics on configuring the path of a plugin or preset.
 
 ## Transform Plugins
 
@@ -97,37 +113,6 @@ These plugins apply transformations to your code.
 - [throw-expressions](plugin-proposal-throw-expressions.md)
 - [private-property-in-object](plugin-proposal-private-property-in-object.md)
 
-### Minification
-
-Check out our [minifier based on Babel](https://github.com/babel/minify)!
-
-These plugins are in the minify repo.
-
-- [inline-consecutive-adds](plugin-transform-inline-consecutive-adds.md)
-- [inline-environment-variables](plugin-transform-inline-environment-variables.md)
-- [member-expression-literals](plugin-transform-member-expression-literals.md)
-- [merge-sibling-variables](plugin-transform-merge-sibling-variables.md)
-- [minify-booleans](plugin-transform-minify-booleans.md)
-- [minify-builtins](plugin-minify-builtins.md)
-- [minify-constant-folding](plugin-minify-constant-folding.md)
-- [minify-dead-code-elimination](plugin-minify-dead-code-elimination.md)
-- [minify-flip-comparisons](plugin-minify-flip-comparisons.md)
-- [minify-guarded-expressions](plugin-minify-guarded-expressions.md)
-- [minify-infinity](plugin-minify-infinity.md)
-- [minify-mangle-names](plugin-minify-mangle-names.md)
-- [minify-numeric-literals](plugin-minify-numeric-literals.md)
-- [minify-replace](plugin-minify-replace.md)
-- [minify-simplify](plugin-minify-simplify.md)
-- [minify-type-constructors](plugin-minify-type-constructors.md)
-- [node-env-inline](plugin-transform-node-env-inline.md)
-- [property-literals](plugin-transform-property-literals.md)
-- [regexp-constructors](plugin-transform-regexp-constructors.md)
-- [remove-console](plugin-transform-remove-console.md)
-- [remove-debugger](plugin-transform-remove-debugger.md)
-- [remove-undefined](plugin-transform-remove-undefined.md)
-- [simplify-comparison-operators](plugin-transform-simplify-comparison-operators.md)
-- [undefined-to-void](plugin-transform-undefined-to-void.md)
-
 ### React
 
 - [react-constant-elements](plugin-transform-react-constant-elements.md)
@@ -153,9 +138,9 @@ These plugins are in the minify repo.
 
 ## Syntax Plugins
 
-These plugins only allow Babel to **parse** specific types of syntax (not transform).
+Most syntax is transformable by Babel. In rarer cases (if the transform isn't implemented yet, or there isn't a default way to do so), you can use plugins such as `@babel/plugin-syntax-bigint` to only allow Babel to **parse** specific types of syntax. Or you want to preserve the source code because you only want Babel to do code analysis or codemods.
 
-> NOTE: transform plugins automatically enable the syntax plugins. So you don't need to specify the syntax plugin if the corresponding transform plugin is used already.
+> NOTE: You don't need to specify the syntax plugin if the corresponding transform plugin is used already, since it enables it automatically.
 
 Alternatively, you can also provide any [`plugins` option](parser.md#plugins) from the Babel parser:
 
@@ -169,24 +154,6 @@ Your `.babelrc`:
 }
 ```
 
-## Plugin/Preset Paths
-
-If the plugin is on npm, you can pass in the name of the plugin and babel will check that it's installed in `node_modules`
-
-```json
-{
-  "plugins": ["babel-plugin-myPlugin"]
-}
-```
-
-You can also specify an relative/absolute path to your plugin.
-
-```json
-{
-  "plugins": ["./node_modules/asdf/plugin"]
-}
-```
-
 ### Plugin Shorthand
 
 If the name of the package is prefixed with `babel-plugin-`, you can use a shorthand:
@@ -194,19 +161,8 @@ If the name of the package is prefixed with `babel-plugin-`, you can use a short
 ```js
 {
   "plugins": [
-    "myPlugin",
-    "babel-plugin-myPlugin" // equivalent
-  ]
-}
-```
-
-This also works with scoped packages:
-
-```js
-{
-  "plugins": [
-    "@org/babel-plugin-name",
-    "@org/name" // equivalent
+    "@org/name", // equivalent to "@org/babel-plugin-name"
+    "myPlugin", // equivalent to "babel-plugin-myPlugin"
   ]
 }
 ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,6 +5,8 @@ title: Plugins
 
 Babel's code transformations are enabled by applying plugins (or [presets](presets.md)) to your [configuration file](config-files.md).
 
+<div id="pluginpreset-paths"></div>
+
 ## Using a Plugin
 
 If the plugin is on [npm](https://www.npmjs.com/search?q=babel-plugin), you can pass in the name of the plugin and Babel will check that it's installed in `node_modules`. This is added to the [plugins](options.md#presets) config option, which takes an array.

--- a/docs/polyfill.md
+++ b/docs/polyfill.md
@@ -1,10 +1,10 @@
 ---
 id: babel-polyfill
 title: @babel/polyfill
-sidebar_label: polyfill
 ---
 
 > 🚨 As of Babel 7.4.0, this package has been deprecated in favor of directly including `core-js/stable` (to polyfill ECMAScript features) and `regenerator-runtime/runtime` (needed to use transpiled generator functions):
+>
 > ```js
 > import "core-js/stable";
 > import "regenerator-runtime/runtime";
@@ -85,4 +85,3 @@ before it.
 > ##### If you are looking for something that won't modify globals to be used in a tool/library, checkout the [`transform-runtime`](plugin-transform-runtime.md) plugin. This means you won't be able to use the instance methods mentioned above like `Array.prototype.includes`.
 
 Note: Depending on what ES2015 methods you actually use, you may not need to use `@babel/polyfill` or the runtime plugin. You may want to only [load the specific polyfills you are using](https://github.com/zloirock/core-js#commonjs) (like `Object.assign`) or just document that the environment the library is being loaded in should include certain polyfills.
-

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -1,7 +1,6 @@
 ---
 id: babel-preset-env
 title: @babel/preset-env
-sidebar_label: env
 ---
 
 `@babel/preset-env` is a smart preset that allows you to use the latest JavaScript without needing to micromanage which syntax transforms (and optionally, browser polyfills) are needed by your target environment(s). This both makes your life easier and JavaScript bundles smaller!
@@ -184,7 +183,7 @@ Added in: `v7.9.0`
 
 By default, `@babel/preset-env` (and Babel plugins in general) grouped ECMAScript syntax features into collections of closely related smaller features. These groups can be large and include a lot of edge cases, for example "function arguments" includes destructured, default and rest parameters. From this grouping information, Babel enables or disables each group based on the browser support target you specify to `@babel/preset-env`’s `targets` option.
 
-When this option is enabled, `@babel/preset-env` tries to compile the broken syntax to the closest *non-broken modern syntax* supported by your target browsers. Depending on your `targets` and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [`@babel/preset-modules`](https://github.com/babel/preset-modules) without having to use another preset.
+When this option is enabled, `@babel/preset-env` tries to compile the broken syntax to the closest _non-broken modern syntax_ supported by your target browsers. Depending on your `targets` and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [`@babel/preset-modules`](https://github.com/babel/preset-modules) without having to use another preset.
 
 ### `spec`
 
@@ -207,6 +206,7 @@ Enable transformation of ES module syntax to another module type. Note that `cjs
 Setting this to `false` will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default `modules: "auto"` is always preferred.
 
 #### `modules: "auto"`
+
 By default `@babel/preset-env` uses [`caller`](options.md#caller) data to determine whether ES modules and module features (e.g. `import()`) should be transformed. Generally `caller` data will be specified in the bundler plugins (e.g. `babel-loader`, `@rollup/plugin-babel`) and thus it is not recommended to pass `caller` data yourself -- The passed `caller` may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.
 
 ### `debug`
@@ -503,4 +503,5 @@ The following are currently supported:
 ## Caveats
 
 ### Ineffective browserslist queries
+
 While `op_mini all` is a valid browserslist query, preset-env currently ignores it due to [lack of support data](https://github.com/kangax/compat-table/issues/1057) for Opera Mini.

--- a/docs/preset-flow.md
+++ b/docs/preset-flow.md
@@ -1,7 +1,6 @@
 ---
 id: babel-preset-flow
 title: @babel/preset-flow
-sidebar_label: flow
 ---
 
 This preset is recommended if you use [Flow](https://flow.org/en/docs/getting-started/), a static type checker for JavaScript code. It includes the following plugins:

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -1,7 +1,6 @@
 ---
 id: babel-preset-react
 title: @babel/preset-react
-sidebar_label: react
 ---
 
 This preset always includes the following plugins:

--- a/docs/preset-typescript.md
+++ b/docs/preset-typescript.md
@@ -1,7 +1,6 @@
 ---
 id: babel-preset-typescript
 title: @babel/preset-typescript
-sidebar_label: typescript
 ---
 
 This preset is recommended if you use [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html), a typed superset of JavaScript. It includes the following plugins:
@@ -14,13 +13,13 @@ This preset is recommended if you use [TypeScript](https://www.typescriptlang.or
 
 **In**
 
-```javascript
+```typescript
 const x: number = 0;
 ```
 
 **Out**
 
-```javascript
+```typescript
 const x = 0;
 ```
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -91,19 +91,6 @@ module.exports = () => ({
 
 For more info, check out the [babel handbook](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/user-handbook.md#making-your-own-preset) section on presets.
 
-### Preset Shorthand
-
-If the name of the package is prefixed with `babel-preset-`, you can use a shorthand:
-
-```js
-{
-  "presets": [
-  	"@org/name", // equivalent to "@org/babel-preset-name"
-    "myPreset", // equivalent to "babel-preset-myPreset"
-  ]
-}
-```
-
 ## Preset Ordering
 
 Preset ordering is reversed (last to first).

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -3,29 +3,53 @@ id: presets
 title: Presets
 ---
 
-Don't want to assemble your own set of plugins? No problem! Presets can act as an array of Babel plugins or even a sharable [`options`](options.md) config.
+Babel presets can act as sharable set of Babel plugins and/or config [`options`](options.md).
 
 ## Official Presets
 
-We've assembled some for common environments:
+We've assembled a few presets for common environments:
 
-- [@babel/preset-env](preset-env.md)
-- [@babel/preset-flow](preset-flow.md)
-- [@babel/preset-react](preset-react.md)
-- [@babel/preset-typescript](preset-typescript.md)
+- [@babel/preset-env](preset-env.md) for compiling ES2015+ syntax
+- [@babel/preset-typescript](preset-typescript.md) for [TypeScript](https://www.typescriptlang.org)
+- [@babel/preset-react](preset-react.md) for [React](https://reactjs.org/)
+- [@babel/preset-flow](preset-flow.md) for [Flow](https://flow.org/)
 
-> Many other community maintained presets are available [on npm](https://www.npmjs.com/search?q=babel-preset)!
+## Other Integrations
+
+If you aren't using Babel directly, the framework you are using may have it's own configuration for you to use or extend. Many other community maintained presets are available [on npm](https://www.npmjs.com/search?q=babel-preset)!
+
+[Next.js](https://nextjs.org/docs/advanced-features/customizing-babel-config) | [Nuxt.js](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-build#babel) | [Parcel](https://en.parceljs.org/javascript.html#babel) | [Jest](https://jestjs.io/docs/getting-started#using-babel) | [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/babel)
+
+## Using a Preset
+
+Within a Babel config, if the preset is on [npm](https://www.npmjs.com/search?q=babel-preset), you can pass in the name of the preset and Babel will check that it's installed in `node_modules` already. This is added to the [presets](options.md#presets) config option, which takes an array.
+
+```json
+{
+  "presets": ["babel-preset-myPreset", "@babel/preset-env"]
+}
+```
+
+Otherwise, can also specify an relative/absolute path to your presets.
+
+```json
+{
+  "presets": ["./myProject/myPreset"]
+}
+```
+
+See [name normalization](options.md#name-normalization) for more specifics on configuring the path of a plugin or preset.
 
 ## Stage-X (Experimental Presets)
 
-Any transforms in stage-x presets are changes to the language that haven't been approved to be part of a release of JavaScript (such as ES6/ES2015).
-
 <blockquote class="babel-callout babel-callout-danger">
-  <h4>Subject to change</h4>
+  <h4>Deprecated</h4>
   <p>
-    These proposals are subject to change so <strong><em>use with extreme caution</em></strong>, especially for anything pre stage-3. We plan to update stage-x presets when proposals change after each TC39 meeting when possible.
+    As of Babel 7, we've decided to deprecate the Stage-X presets and stop publishing them. Because these proposals are inherently subject to change, it seems better to ask users to specify individual proposals as plugins vs. a catch all preset that you would need to check up on anyway. Check out our <a href="https://babeljs.io/blog/2018/07/27/removing-babels-stage-presets">blog</a> for more context.
   </p>
 </blockquote>
+
+Any transforms in stage-x presets are changes to the language that haven't been approved to be part of a release of JavaScript (such as ES6/ES2015).
 
 The [TC39](https://github.com/tc39) categorizes proposals into the following stages:
 
@@ -39,32 +63,25 @@ For more information, be sure to check out the [current TC39 proposals](https://
 
 The TC39 stage process is also explained in detail across a few posts by Yehuda Katz (@wycatz) over at [thefeedbackloop.xyz](https://thefeedbackloop.xyz): [Stage 0 and 1](https://thefeedbackloop.xyz/tc39-a-process-sketch-stages-0-and-1/), [Stage 2](https://thefeedbackloop.xyz/tc39-process-sketch-stage-2/), [Stage 3](https://thefeedbackloop.xyz/tc39-process-sketch-stage-3/)
 
-
 ## Creating a Preset
 
-To make your own preset, you just need to export a config.
+To make your own preset (either for local usage or to npm), you need to export a config object.
 
 > It could just return an array of plugins..
 
 ```js
 module.exports = function() {
   return {
-    plugins: [
-      "pluginA",
-      "pluginB",
-      "pluginC",
-    ]
+    plugins: ["pluginA", "pluginB", "pluginC"],
   };
-}
+};
 ```
 
 > Presets can contain other presets, and plugins with options.
 
 ```js
 module.exports = () => ({
-  presets: [
-    require("@babel/preset-env"),
-  ],
+  presets: [require("@babel/preset-env")],
   plugins: [
     [require("@babel/plugin-proposal-class-properties"), { loose: true }],
     require("@babel/plugin-proposal-object-rest-spread"),
@@ -74,24 +91,6 @@ module.exports = () => ({
 
 For more info, check out the [babel handbook](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/user-handbook.md#making-your-own-preset) section on presets.
 
-## Preset Paths
-
-If the preset is on npm, you can pass in the name of the preset and babel will check that it's installed in `node_modules`
-
-```json
-{
-  "presets": ["babel-preset-myPreset"]
-}
-```
-
-You can also specify an relative/absolute path to your presets.
-
-```json
-{
-  "presets": ["./myProject/myPreset"]
-}
-```
-
 ### Preset Shorthand
 
 If the name of the package is prefixed with `babel-preset-`, you can use a shorthand:
@@ -99,19 +98,8 @@ If the name of the package is prefixed with `babel-preset-`, you can use a short
 ```js
 {
   "presets": [
-    "myPreset",
-    "babel-preset-myPreset" // equivalent
-  ]
-}
-```
-
-This also works with scoped packages:
-
-```js
-{
-  "presets": [
-  	"@org/babel-preset-name",
-  	"@org/name" // equivalent
+  	"@org/name", // equivalent to "@org/babel-preset-name"
+    "myPreset", // equivalent to "babel-preset-myPreset"
   ]
 }
 ```
@@ -122,11 +110,7 @@ Preset ordering is reversed (last to first).
 
 ```json
 {
-  "presets": [
-    "a",
-    "b",
-    "c"
-  ]
+  "presets": ["a", "b", "c"]
 }
 ```
 
@@ -143,9 +127,9 @@ For specifying no options, these are all equivalent:
 ```json
 {
   "presets": [
-    "presetA",
-    ["presetA"],
-    ["presetA", {}],
+    "presetA", // bare string
+    ["presetA"], // wrapped in array
+    ["presetA", {}] // 2nd argument is an empty options object
   ]
 }
 ```
@@ -155,10 +139,13 @@ To specify an option, pass an object with the keys as the option names.
 ```json
 {
   "presets": [
-    ["@babel/preset-env", {
-      "loose": true,
-      "modules": false
-    }]
+    [
+      "@babel/preset-env",
+      {
+        "loose": true,
+        "modules": false
+      }
+    ]
   ]
 }
 ```

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -20,6 +20,8 @@ If you aren't using Babel directly, the framework you are using may have it's ow
 
 [Next.js](https://nextjs.org/docs/advanced-features/customizing-babel-config) | [Nuxt.js](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-build#babel) | [Parcel](https://en.parceljs.org/javascript.html#babel) | [Jest](https://jestjs.io/docs/getting-started#using-babel) | [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/babel)
 
+<div id="preset-paths"></div>
+
 ## Using a Preset
 
 Within a Babel config, if the preset is on [npm](https://www.npmjs.com/search?q=babel-preset), you can pass in the name of the preset and Babel will check that it's installed in `node_modules` already. This is added to the [presets](options.md#presets) config option, which takes an array.

--- a/docs/register.md
+++ b/docs/register.md
@@ -1,7 +1,6 @@
 ---
 id: babel-register
 title: @babel/register
-sidebar_label: register
 ---
 
 One of the ways you can use Babel is through the require hook. The require hook

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,7 +1,6 @@
 ---
 id: babel-runtime
 title: @babel/runtime
-sidebar_label: runtime
 ---
 
 `@babel/runtime` is a library that contains Babel modular runtime helpers and a version of `regenerator-runtime`.

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,13 +1,11 @@
 ---
 id: babel-standalone
 title: @babel/standalone
-sidebar_label: standalone
 ---
 
 @babel/standalone provides a standalone build of Babel for use in browsers and other non-Node.js environments.
 
-When (not) to use @babel/standalone
-===================================
+# When (not) to use @babel/standalone
 
 If you're using Babel in production, you should normally not use @babel/standalone. Instead, you should use a build system running on Node.js, such as Webpack, Rollup, or Parcel, to transpile your JS ahead of time.
 
@@ -19,16 +17,14 @@ However, there are some valid use cases for @babel/standalone:
 - Apps that want to use JavaScript as a scripting language for extending the app itself, including all the goodies that ES2015 provides.
 - Other non-Node.js environments ([ReactJS.NET](http://reactjs.net/), [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler), [php-babel-transpiler](https://github.com/talyssonoc/php-babel-transpiler), etc).
 
-Installation
-============
+# Installation
 
 There are several ways to get a copy of @babel/standalone. Pick whichever one you like:
 
 - Use it via UNPKG: https://unpkg.com/@babel/standalone/babel.min.js. This is a simple way to embed it on a webpage without having to do any other setup.
 - Install via NPM: `npm install --save @babel/standalone`
 
-Script Tags
-===========
+# Script Tags
 
 When loaded in a browser, @babel/standalone will automatically compile and execute all script tags with type `text/babel` or `text/jsx`:
 
@@ -38,8 +34,8 @@ When loaded in a browser, @babel/standalone will automatically compile and execu
 <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 <!-- Your custom script here -->
 <script type="text/babel">
-const getMessage = () => "Hello World";
-document.getElementById('output').innerHTML = getMessage();
+  const getMessage = () => "Hello World";
+  document.getElementById("output").innerHTML = getMessage();
 </script>
 ```
 
@@ -48,6 +44,7 @@ If you want to use your browser's native support for ES Modules, you'd normally 
 Added in: `v7.10.0`
 
 With @babel/standalone, set a `data-type="module"` attribute instead, like this:
+
 ```html
 <script type="text/babel" data-type="module">
 ```
@@ -70,20 +67,18 @@ You can also set the `async` attribute for external scripts.
 <script type="text/babel" src="foo.js" async></script>
 ```
 
-API
-===
+# API
 
 Load `babel.js` or `babel.min.js` in your environment. This will expose [Babel's API](http://babeljs.io/docs/usage/api/) in a `Babel` object:
 
 ```js
 var input = 'const getMessage = () => "Hello World";';
-var output = Babel.transform(input, { presets: ['env'] }).code;
+var output = Babel.transform(input, { presets: ["env"] }).code;
 ```
 
 Note that [config files](config-files.md) don't work in @babel/standalone, as no file system access is available. The presets and/or plugins to use **must** be specified in the options passed to `Babel.transform`.
 
-Customization
-=============
+# Customization
 
 ### custom plugins
 
@@ -95,12 +90,12 @@ function lolizer() {
   return {
     visitor: {
       Identifier(path) {
-        path.node.name = 'LOL';
-      }
-    }
-  }
+        path.node.name = "LOL";
+      },
+    },
+  };
 }
-Babel.registerPlugin('lolizer', lolizer);
+Babel.registerPlugin("lolizer", lolizer);
 ```
 
 Once registered, you can either use the custom plugin in an inline script:
@@ -112,26 +107,25 @@ Once registered, you can either use the custom plugin in an inline script:
 Or you can use the plugin with `Babel.transform`:
 
 ```js
-var output = Babel.transform(
-  'function helloWorld() { alert(hello); }',
-  {plugins: ['lolizer']}
-);
+var output = Babel.transform("function helloWorld() { alert(hello); }", {
+  plugins: ["lolizer"],
+});
 // Returns "function LOL() { LOL(LOL); }"
 ```
 
 ### custom presets: passing options to built-in presets/plugins
 
 If you want to pass options to builtin plugins and presets, you can create a new preset and pass these options inside the preset.
+
 ```js
 // Define a preset
 Babel.registerPreset("env-plus", {
-  presets: [
-    [Babel.availablePresets["env"], { "loose": true }]
-  ],
+  presets: [[Babel.availablePresets["env"], { loose: true }]],
   plugins: [
     [
-      Babel.availablePlugins["proposal-decorators"], { decoratorsBeforeExport: true }
-    ]
+      Babel.availablePlugins["proposal-decorators"],
+      { decoratorsBeforeExport: true },
+    ],
   ],
 });
 ```

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,7 +1,6 @@
 ---
 id: babel-template
 title: @babel/template
-sidebar_label: template
 ---
 
 In computer science, this is known as an implementation of quasiquotes.

--- a/docs/traverse.md
+++ b/docs/traverse.md
@@ -1,7 +1,6 @@
 ---
 id: babel-traverse
 title: @babel/traverse
-sidebar_label: traverse
 ---
 
 ## Install
@@ -29,7 +28,7 @@ traverse(ast, {
     if (path.isIdentifier({ name: "n" })) {
       path.node.name = "x";
     }
-  }
+  },
 });
 ```
 
@@ -37,11 +36,10 @@ Also, we can target particular [**node types**](https://babeljs.io/docs/en/babel
 
 ```js
 traverse(ast, {
-    FunctionDeclaration: function(path) {
-             path.node.id.name = "x";
-    }
-})
+  FunctionDeclaration: function(path) {
+    path.node.id.name = "x";
+  },
+});
 ```
 
 [📖 **Read the full docs here**](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-traverse)
-

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,7 +1,6 @@
 ---
 id: babel-types
 title: @babel/types
-sidebar_label: types
 ---
 
 ## Install
@@ -11,34 +10,37 @@ npm install --save-dev @babel/types
 ```
 
 ## API
+
 ### anyTypeAnnotation
+
 ```javascript
-t.anyTypeAnnotation()
+t.anyTypeAnnotation();
 ```
 
 See also `t.isAnyTypeAnnotation(node, opts)` and `t.assertAnyTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### arrayExpression
+
 ```javascript
-t.arrayExpression(elements)
+t.arrayExpression(elements);
 ```
 
 See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `elements`: `Array<null | Expression | SpreadElement>` (default: `[]`)
+- `elements`: `Array<null | Expression | SpreadElement>` (default: `[]`)
 
 ---
 
 ### argumentPlaceholder
+
 ```javascript
-t.argumentPlaceholder()
+t.argumentPlaceholder();
 ```
 
 See also `t.isArgumentPlaceholder(node, opts)` and `t.assertArgumentPlaceholder(node, opts)`.
@@ -50,345 +52,367 @@ Aliases: none
 ---
 
 ### arrayPattern
+
 ```javascript
-t.arrayPattern(elements)
+t.arrayPattern(elements);
 ```
 
 See also `t.isArrayPattern(node, opts)` and `t.assertArrayPattern(node, opts)`.
 
 Aliases: `Pattern`, `PatternLike`, `LVal`
 
- - `elements`: `Array<PatternLike>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `elements`: `Array<PatternLike>` (required)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### arrayTypeAnnotation
+
 ```javascript
-t.arrayTypeAnnotation(elementType)
+t.arrayTypeAnnotation(elementType);
 ```
 
 See also `t.isArrayTypeAnnotation(node, opts)` and `t.assertArrayTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `elementType`: `FlowType` (required)
+- `elementType`: `FlowType` (required)
 
 ---
 
 ### arrowFunctionExpression
+
 ```javascript
-t.arrowFunctionExpression(params, body, async)
+t.arrowFunctionExpression(params, body, async);
 ```
 
 See also `t.isArrowFunctionExpression(node, opts)` and `t.assertArrowFunctionExpression(node, opts)`.
 
 Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
 
- - `params`: `Array<LVal>` (required)
- - `body`: `BlockStatement | Expression` (required)
- - `async`: `boolean` (default: `false`)
- - `expression`: `boolean` (default: `null`)
- - `generator`: `boolean` (default: `false`)
- - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
+- `params`: `Array<LVal>` (required)
+- `body`: `BlockStatement | Expression` (required)
+- `async`: `boolean` (default: `false`)
+- `expression`: `boolean` (default: `null`)
+- `generator`: `boolean` (default: `false`)
+- `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
 ### assignmentExpression
+
 ```javascript
-t.assignmentExpression(operator, left, right)
+t.assignmentExpression(operator, left, right);
 ```
 
 See also `t.isAssignmentExpression(node, opts)` and `t.assertAssignmentExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `operator`: `string` (required)
- - `left`: `LVal` (required)
- - `right`: `Expression` (required)
+- `operator`: `string` (required)
+- `left`: `LVal` (required)
+- `right`: `Expression` (required)
 
 ---
 
 ### assignmentPattern
+
 ```javascript
-t.assignmentPattern(left, right)
+t.assignmentPattern(left, right);
 ```
 
 See also `t.isAssignmentPattern(node, opts)` and `t.assertAssignmentPattern(node, opts)`.
 
 Aliases: `Pattern`, `PatternLike`, `LVal`
 
- - `left`: `Identifier | ObjectPattern | ArrayPattern` (required)
- - `right`: `Expression` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `left`: `Identifier | ObjectPattern | ArrayPattern` (required)
+- `right`: `Expression` (required)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### awaitExpression
+
 ```javascript
-t.awaitExpression(argument)
+t.awaitExpression(argument);
 ```
 
 See also `t.isAwaitExpression(node, opts)` and `t.assertAwaitExpression(node, opts)`.
 
 Aliases: `Expression`, `Terminatorless`
 
- - `argument`: `Expression` (required)
+- `argument`: `Expression` (required)
 
 ---
 
 ### bigIntLiteral
+
 ```javascript
-t.bigIntLiteral(value)
+t.bigIntLiteral(value);
 ```
 
 See also `t.isBigIntLiteral(node, opts)` and `t.assertBigIntLiteral(node, opts)`.
 
 Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
- - `value`: `string` (required)
+- `value`: `string` (required)
 
 ---
 
 ### binaryExpression
+
 ```javascript
-t.binaryExpression(operator, left, right)
+t.binaryExpression(operator, left, right);
 ```
 
 See also `t.isBinaryExpression(node, opts)` and `t.assertBinaryExpression(node, opts)`.
 
 Aliases: `Binary`, `Expression`
 
- - `operator`: `"+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<="` (required)
- - `left`: `Expression` (required)
- - `right`: `Expression` (required)
+- `operator`: `"+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<="` (required)
+- `left`: `Expression` (required)
+- `right`: `Expression` (required)
 
 ---
 
 ### bindExpression
+
 ```javascript
-t.bindExpression(object, callee)
+t.bindExpression(object, callee);
 ```
 
 See also `t.isBindExpression(node, opts)` and `t.assertBindExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `object` (required)
- - `callee` (required)
+- `object` (required)
+- `callee` (required)
 
 ---
 
 ### blockStatement
+
 ```javascript
-t.blockStatement(body, directives)
+t.blockStatement(body, directives);
 ```
 
 See also `t.isBlockStatement(node, opts)` and `t.assertBlockStatement(node, opts)`.
 
 Aliases: `Scopable`, `BlockParent`, `Block`, `Statement`
 
- - `body`: `Array<Statement>` (required)
- - `directives`: `Array<Directive>` (default: `[]`)
+- `body`: `Array<Statement>` (required)
+- `directives`: `Array<Directive>` (default: `[]`)
 
 ---
 
 ### booleanLiteral
+
 ```javascript
-t.booleanLiteral(value)
+t.booleanLiteral(value);
 ```
 
 See also `t.isBooleanLiteral(node, opts)` and `t.assertBooleanLiteral(node, opts)`.
 
 Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
- - `value`: `boolean` (required)
+- `value`: `boolean` (required)
 
 ---
 
 ### booleanLiteralTypeAnnotation
+
 ```javascript
-t.booleanLiteralTypeAnnotation(value)
+t.booleanLiteralTypeAnnotation(value);
 ```
 
 See also `t.isBooleanLiteralTypeAnnotation(node, opts)` and `t.assertBooleanLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `value`: `boolean` (required)
+- `value`: `boolean` (required)
 
 ---
 
 ### booleanTypeAnnotation
+
 ```javascript
-t.booleanTypeAnnotation()
+t.booleanTypeAnnotation();
 ```
 
 See also `t.isBooleanTypeAnnotation(node, opts)` and `t.assertBooleanTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### breakStatement
+
 ```javascript
-t.breakStatement(label)
+t.breakStatement(label);
 ```
 
 See also `t.isBreakStatement(node, opts)` and `t.assertBreakStatement(node, opts)`.
 
 Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
- - `label`: `Identifier` (default: `null`)
+- `label`: `Identifier` (default: `null`)
 
 ---
 
 ### callExpression
+
 ```javascript
-t.callExpression(callee, arguments)
+t.callExpression(callee, arguments);
 ```
 
 See also `t.isCallExpression(node, opts)` and `t.assertCallExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
- - `optional`: `true | false` (default: `null`)
- - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+- `callee`: `Expression` (required)
+- `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+- `optional`: `true | false` (default: `null`)
+- `typeArguments`: `TypeParameterInstantiation` (default: `null`)
+- `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### catchClause
+
 ```javascript
-t.catchClause(param, body)
+t.catchClause(param, body);
 ```
 
 See also `t.isCatchClause(node, opts)` and `t.assertCatchClause(node, opts)`.
 
 Aliases: `Scopable`, `BlockParent`
 
- - `param`: `Identifier` (default: `null`)
- - `body`: `BlockStatement` (required)
+- `param`: `Identifier` (default: `null`)
+- `body`: `BlockStatement` (required)
 
 ---
 
 ### classBody
+
 ```javascript
-t.classBody(body)
+t.classBody(body);
 ```
 
 See also `t.isClassBody(node, opts)` and `t.assertClassBody(node, opts)`.
 
- - `body`: `Array<ClassMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
+- `body`: `Array<ClassMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
 
 ---
 
 ### classDeclaration
+
 ```javascript
-t.classDeclaration(id, superClass, body, decorators)
+t.classDeclaration(id, superClass, body, decorators);
 ```
 
 See also `t.isClassDeclaration(node, opts)` and `t.assertClassDeclaration(node, opts)`.
 
 Aliases: `Scopable`, `Class`, `Statement`, `Declaration`, `Pureish`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
- - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
- - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
+- `id`: `Identifier` (default: `null`)
+- `superClass`: `Expression` (default: `null`)
+- `body`: `ClassBody` (required)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `abstract`: `boolean` (default: `null`)
+- `declare`: `boolean` (default: `null`)
+- `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
+- `mixins` (default: `null`)
+- `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
+- `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
 ### classExpression
+
 ```javascript
-t.classExpression(id, superClass, body, decorators)
+t.classExpression(id, superClass, body, decorators);
 ```
 
 See also `t.isClassExpression(node, opts)` and `t.assertClassExpression(node, opts)`.
 
 Aliases: `Scopable`, `Class`, `Expression`, `Pureish`
 
- - `id`: `Identifier` (default: `null`)
- - `superClass`: `Expression` (default: `null`)
- - `body`: `ClassBody` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
- - `mixins` (default: `null`)
- - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
+- `id`: `Identifier` (default: `null`)
+- `superClass`: `Expression` (default: `null`)
+- `body`: `ClassBody` (required)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `implements`: `Array<TSExpressionWithTypeArguments | ClassImplements>` (default: `null`)
+- `mixins` (default: `null`)
+- `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`)
+- `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
 ### classImplements
+
 ```javascript
-t.classImplements(id, typeParameters)
+t.classImplements(id, typeParameters);
 ```
 
 See also `t.isClassImplements(node, opts)` and `t.assertClassImplements(node, opts)`.
 
 Aliases: `Flow`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### classMethod
+
 ```javascript
-t.classMethod(kind, key, params, body, computed, static)
+t.classMethod(kind, key, params, body, computed, static);
 ```
 
 See also `t.isClassMethod(node, opts)` and `t.assertClassMethod(node, opts)`.
 
 Aliases: `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`
 
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
- - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
- - `body`: `BlockStatement` (required)
- - `computed`: `boolean` (default: `false`)
- - `static`: `boolean` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `access`: `"public" | "private" | "protected"` (default: `null`)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `generator`: `boolean` (default: `false`)
- - `optional`: `boolean` (default: `null`)
- - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
+- `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+- `key`: if computed then `Expression` else `Identifier | Literal` (required)
+- `params`: `Array<LVal>` (required)
+- `body`: `BlockStatement` (required)
+- `computed`: `boolean` (default: `false`)
+- `static`: `boolean` (default: `null`)
+- `abstract`: `boolean` (default: `null`)
+- `access`: `"public" | "private" | "protected"` (default: `null`)
+- `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+- `async`: `boolean` (default: `false`)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `generator`: `boolean` (default: `false`)
+- `optional`: `boolean` (default: `null`)
+- `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
 ### classPrivateProperty
+
 ```javascript
-t.classPrivateProperty(key, value)
+t.classPrivateProperty(key, value);
 ```
 
 See also `t.isClassPrivateProperty(node, opts)` and `t.assertClassPrivateProperty(node, opts)`.
 
 Aliases: `Property`, `Private`
 
- - `key`: `PrivateName` (required)
- - `value`: `Expression` (default: `null`)
+- `key`: `PrivateName` (required)
+- `value`: `Expression` (default: `null`)
 
 ---
 
 ### classProperty
+
 ```javascript
-t.classProperty(key, value, typeAnnotation, decorators, computed, static)
+t.classProperty(key, value, typeAnnotation, decorators, computed, static);
 ```
 
 <details>
@@ -402,61 +426,64 @@ See also `t.isClassProperty(node, opts)` and `t.assertClassProperty(node, opts)`
 
 Aliases: `Property`
 
- - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
- - `value`: `Expression` (default: `null`)
- - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `computed`: `boolean` (default: `false`)
- - `abstract`: `boolean` (default: `null`)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `definite`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+- `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
+- `value`: `Expression` (default: `null`)
+- `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `computed`: `boolean` (default: `false`)
+- `abstract`: `boolean` (default: `null`)
+- `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+- `definite`: `boolean` (default: `null`)
+- `optional`: `boolean` (default: `null`)
+- `readonly`: `boolean` (default: `null`)
+- `static`: `boolean` (default: `null`)
 
 ---
 
 ### conditionalExpression
+
 ```javascript
-t.conditionalExpression(test, consequent, alternate)
+t.conditionalExpression(test, consequent, alternate);
 ```
 
 See also `t.isConditionalExpression(node, opts)` and `t.assertConditionalExpression(node, opts)`.
 
 Aliases: `Expression`, `Conditional`
 
- - `test`: `Expression` (required)
- - `consequent`: `Expression` (required)
- - `alternate`: `Expression` (required)
+- `test`: `Expression` (required)
+- `consequent`: `Expression` (required)
+- `alternate`: `Expression` (required)
 
 ---
 
 ### continueStatement
+
 ```javascript
-t.continueStatement(label)
+t.continueStatement(label);
 ```
 
 See also `t.isContinueStatement(node, opts)` and `t.assertContinueStatement(node, opts)`.
 
 Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
- - `label`: `Identifier` (default: `null`)
+- `label`: `Identifier` (default: `null`)
 
 ---
 
 ### debuggerStatement
+
 ```javascript
-t.debuggerStatement()
+t.debuggerStatement();
 ```
 
 See also `t.isDebuggerStatement(node, opts)` and `t.assertDebuggerStatement(node, opts)`.
 
 Aliases: `Statement`
 
-
 ---
 
 ### declareClass
+
 ```javascript
 t.declareClass(id, typeParameters, extends, body)
 ```
@@ -465,60 +492,64 @@ See also `t.isDeclareClass(node, opts)` and `t.assertDeclareClass(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+- `extends`: `Array<InterfaceExtends>` (default: `null`)
+- `body`: `ObjectTypeAnnotation` (required)
+- `implements`: `Array<ClassImplements>` (default: `null`)
+- `mixins`: `Array<InterfaceExtends>` (default: `null`)
 
 ---
 
 ### declareExportAllDeclaration
+
 ```javascript
-t.declareExportAllDeclaration(source)
+t.declareExportAllDeclaration(source);
 ```
 
 See also `t.isDeclareExportAllDeclaration(node, opts)` and `t.assertDeclareExportAllDeclaration(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `source`: `StringLiteral` (required)
- - `exportKind`: `["type","value"]` (default: `null`)
+- `source`: `StringLiteral` (required)
+- `exportKind`: `["type","value"]` (default: `null`)
 
 ---
 
 ### declareExportDeclaration
+
 ```javascript
-t.declareExportDeclaration(declaration, specifiers, source)
+t.declareExportDeclaration(declaration, specifiers, source);
 ```
 
 See also `t.isDeclareExportDeclaration(node, opts)` and `t.assertDeclareExportDeclaration(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `declaration`: `Flow` (default: `null`)
- - `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `null`)
- - `source`: `StringLiteral` (default: `null`)
- - `default`: `boolean` (default: `null`)
+- `declaration`: `Flow` (default: `null`)
+- `specifiers`: `Array<ExportSpecifier | ExportNamespaceSpecifier>` (default: `null`)
+- `source`: `StringLiteral` (default: `null`)
+- `default`: `boolean` (default: `null`)
 
 ---
 
 ### declareFunction
+
 ```javascript
-t.declareFunction(id)
+t.declareFunction(id);
 ```
 
 See also `t.isDeclareFunction(node, opts)` and `t.assertDeclareFunction(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `predicate`: `DeclaredPredicate` (default: `null`)
+- `id`: `Identifier` (required)
+- `predicate`: `DeclaredPredicate` (default: `null`)
 
 ---
 
 ### declareInterface
+
 ```javascript
 t.declareInterface(id, typeParameters, extends, body)
 ```
@@ -527,544 +558,578 @@ See also `t.isDeclareInterface(node, opts)` and `t.assertDeclareInterface(node, 
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+- `extends`: `Array<InterfaceExtends>` (default: `null`)
+- `body`: `ObjectTypeAnnotation` (required)
+- `implements`: `Array<ClassImplements>` (default: `null`)
+- `mixins`: `Array<InterfaceExtends>` (default: `null`)
 
 ---
 
 ### declareModule
+
 ```javascript
-t.declareModule(id, body, kind)
+t.declareModule(id, body, kind);
 ```
 
 See also `t.isDeclareModule(node, opts)` and `t.assertDeclareModule(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `BlockStatement` (required)
- - `kind`: `"CommonJS" | "ES"` (default: `null`)
+- `id`: `Identifier | StringLiteral` (required)
+- `body`: `BlockStatement` (required)
+- `kind`: `"CommonJS" | "ES"` (default: `null`)
 
 ---
 
 ### declareModuleExports
+
 ```javascript
-t.declareModuleExports(typeAnnotation)
+t.declareModuleExports(typeAnnotation);
 ```
 
 See also `t.isDeclareModuleExports(node, opts)` and `t.assertDeclareModuleExports(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `typeAnnotation`: `TypeAnnotation` (required)
+- `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
 ### declareOpaqueType
+
 ```javascript
-t.declareOpaqueType(id, typeParameters, supertype)
+t.declareOpaqueType(id, typeParameters, supertype);
 ```
 
 See also `t.isDeclareOpaqueType(node, opts)` and `t.assertDeclareOpaqueType(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+- `supertype`: `FlowType` (default: `null`)
 
 ---
 
 ### declareTypeAlias
+
 ```javascript
-t.declareTypeAlias(id, typeParameters, right)
+t.declareTypeAlias(id, typeParameters, right);
 ```
 
 See also `t.isDeclareTypeAlias(node, opts)` and `t.assertDeclareTypeAlias(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `FlowType` (required)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+- `right`: `FlowType` (required)
 
 ---
 
 ### declareVariable
+
 ```javascript
-t.declareVariable(id)
+t.declareVariable(id);
 ```
 
 See also `t.isDeclareVariable(node, opts)` and `t.assertDeclareVariable(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
+- `id`: `Identifier` (required)
 
 ---
 
 ### declaredPredicate
+
 ```javascript
-t.declaredPredicate(value)
+t.declaredPredicate(value);
 ```
 
 See also `t.isDeclaredPredicate(node, opts)` and `t.assertDeclaredPredicate(node, opts)`.
 
 Aliases: `Flow`, `FlowPredicate`
 
- - `value`: `Flow` (required)
+- `value`: `Flow` (required)
 
 ---
 
 ### decorator
+
 ```javascript
-t.decorator(expression)
+t.decorator(expression);
 ```
 
 See also `t.isDecorator(node, opts)` and `t.assertDecorator(node, opts)`.
 
- - `expression`: `Expression` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### directive
+
 ```javascript
-t.directive(value)
+t.directive(value);
 ```
 
 See also `t.isDirective(node, opts)` and `t.assertDirective(node, opts)`.
 
- - `value`: `DirectiveLiteral` (required)
+- `value`: `DirectiveLiteral` (required)
 
 ---
 
 ### directiveLiteral
+
 ```javascript
-t.directiveLiteral(value)
+t.directiveLiteral(value);
 ```
 
 See also `t.isDirectiveLiteral(node, opts)` and `t.assertDirectiveLiteral(node, opts)`.
 
- - `value`: `string` (required)
+- `value`: `string` (required)
 
 ---
 
 ### doExpression
+
 ```javascript
-t.doExpression(body)
+t.doExpression(body);
 ```
 
 See also `t.isDoExpression(node, opts)` and `t.assertDoExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `body`: `BlockStatement` (required)
+- `body`: `BlockStatement` (required)
 
 ---
 
 ### doWhileStatement
+
 ```javascript
-t.doWhileStatement(test, body)
+t.doWhileStatement(test, body);
 ```
 
 See also `t.isDoWhileStatement(node, opts)` and `t.assertDoWhileStatement(node, opts)`.
 
 Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
 
- - `test`: `Expression` (required)
- - `body`: `Statement` (required)
+- `test`: `Expression` (required)
+- `body`: `Statement` (required)
 
 ---
 
 ### emptyStatement
+
 ```javascript
-t.emptyStatement()
+t.emptyStatement();
 ```
 
 See also `t.isEmptyStatement(node, opts)` and `t.assertEmptyStatement(node, opts)`.
 
 Aliases: `Statement`
 
-
 ---
 
 ### emptyTypeAnnotation
+
 ```javascript
-t.emptyTypeAnnotation()
+t.emptyTypeAnnotation();
 ```
 
 See also `t.isEmptyTypeAnnotation(node, opts)` and `t.assertEmptyTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### existsTypeAnnotation
+
 ```javascript
-t.existsTypeAnnotation()
+t.existsTypeAnnotation();
 ```
 
 See also `t.isExistsTypeAnnotation(node, opts)` and `t.assertExistsTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
-
 ---
 
 ### exportAllDeclaration
+
 ```javascript
-t.exportAllDeclaration(source)
+t.exportAllDeclaration(source);
 ```
 
 See also `t.isExportAllDeclaration(node, opts)` and `t.assertExportAllDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
 
- - `source`: `StringLiteral` (required)
+- `source`: `StringLiteral` (required)
 
 ---
 
 ### exportDefaultDeclaration
+
 ```javascript
-t.exportDefaultDeclaration(declaration)
+t.exportDefaultDeclaration(declaration);
 ```
 
 See also `t.isExportDefaultDeclaration(node, opts)` and `t.assertExportDefaultDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
 
- - `declaration`: `FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression` (required)
+- `declaration`: `FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression` (required)
 
 ---
 
 ### exportDefaultSpecifier
+
 ```javascript
-t.exportDefaultSpecifier(exported)
+t.exportDefaultSpecifier(exported);
 ```
 
 See also `t.isExportDefaultSpecifier(node, opts)` and `t.assertExportDefaultSpecifier(node, opts)`.
 
 Aliases: `ModuleSpecifier`
 
- - `exported`: `Identifier` (required)
+- `exported`: `Identifier` (required)
 
 ---
 
 ### exportNamedDeclaration
+
 ```javascript
-t.exportNamedDeclaration(declaration, specifiers, source)
+t.exportNamedDeclaration(declaration, specifiers, source);
 ```
 
 See also `t.isExportNamedDeclaration(node, opts)` and `t.assertExportNamedDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`, `ModuleDeclaration`, `ExportDeclaration`
 
- - `declaration`: `Declaration` (default: `null`)
- - `specifiers`: `Array<ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier>` (required)
- - `source`: `StringLiteral` (default: `null`)
+- `declaration`: `Declaration` (default: `null`)
+- `specifiers`: `Array<ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier>` (required)
+- `source`: `StringLiteral` (default: `null`)
 
 ---
 
 ### exportNamespaceSpecifier
+
 ```javascript
-t.exportNamespaceSpecifier(exported)
+t.exportNamespaceSpecifier(exported);
 ```
 
 See also `t.isExportNamespaceSpecifier(node, opts)` and `t.assertExportNamespaceSpecifier(node, opts)`.
 
 Aliases: `ModuleSpecifier`
 
- - `exported`: `Identifier` (required)
+- `exported`: `Identifier` (required)
 
 ---
 
 ### exportSpecifier
+
 ```javascript
-t.exportSpecifier(local, exported)
+t.exportSpecifier(local, exported);
 ```
 
 See also `t.isExportSpecifier(node, opts)` and `t.assertExportSpecifier(node, opts)`.
 
 Aliases: `ModuleSpecifier`
 
- - `local`: `Identifier` (required)
- - `exported`: `Identifier` (required)
+- `local`: `Identifier` (required)
+- `exported`: `Identifier` (required)
 
 ---
 
 ### expressionStatement
+
 ```javascript
-t.expressionStatement(expression)
+t.expressionStatement(expression);
 ```
 
 See also `t.isExpressionStatement(node, opts)` and `t.assertExpressionStatement(node, opts)`.
 
 Aliases: `Statement`, `ExpressionWrapper`
 
- - `expression`: `Expression` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### file
+
 ```javascript
-t.file(program, comments, tokens)
+t.file(program, comments, tokens);
 ```
 
 See also `t.isFile(node, opts)` and `t.assertFile(node, opts)`.
 
- - `program`: `Program` (required)
- - `comments` (required)
- - `tokens` (required)
+- `program`: `Program` (required)
+- `comments` (required)
+- `tokens` (required)
 
 ---
 
 ### forInStatement
+
 ```javascript
-t.forInStatement(left, right, body)
+t.forInStatement(left, right, body);
 ```
 
 See also `t.isForInStatement(node, opts)` and `t.assertForInStatement(node, opts)`.
 
 Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
 
- - `left`: `VariableDeclaration | LVal` (required)
- - `right`: `Expression` (required)
- - `body`: `Statement` (required)
+- `left`: `VariableDeclaration | LVal` (required)
+- `right`: `Expression` (required)
+- `body`: `Statement` (required)
 
 ---
 
 ### forOfStatement
+
 ```javascript
-t.forOfStatement(left, right, body)
+t.forOfStatement(left, right, body);
 ```
 
 See also `t.isForOfStatement(node, opts)` and `t.assertForOfStatement(node, opts)`.
 
 Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`, `ForXStatement`
 
- - `left`: `VariableDeclaration | LVal` (required)
- - `right`: `Expression` (required)
- - `body`: `Statement` (required)
- - `await`: `boolean` (default: `false`)
+- `left`: `VariableDeclaration | LVal` (required)
+- `right`: `Expression` (required)
+- `body`: `Statement` (required)
+- `await`: `boolean` (default: `false`)
 
 ---
 
 ### forStatement
+
 ```javascript
-t.forStatement(init, test, update, body)
+t.forStatement(init, test, update, body);
 ```
 
 See also `t.isForStatement(node, opts)` and `t.assertForStatement(node, opts)`.
 
 Aliases: `Scopable`, `Statement`, `For`, `BlockParent`, `Loop`
 
- - `init`: `VariableDeclaration | Expression` (default: `null`)
- - `test`: `Expression` (default: `null`)
- - `update`: `Expression` (default: `null`)
- - `body`: `Statement` (required)
+- `init`: `VariableDeclaration | Expression` (default: `null`)
+- `test`: `Expression` (default: `null`)
+- `update`: `Expression` (default: `null`)
+- `body`: `Statement` (required)
 
 ---
 
 ### functionDeclaration
+
 ```javascript
-t.functionDeclaration(id, params, body, generator, async)
+t.functionDeclaration(id, params, body, generator, async);
 ```
 
 See also `t.isFunctionDeclaration(node, opts)` and `t.assertFunctionDeclaration(node, opts)`.
 
 Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Statement`, `Pureish`, `Declaration`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `body`: `BlockStatement` (required)
- - `generator`: `boolean` (default: `false`)
- - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
- - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
+- `id`: `Identifier` (default: `null`)
+- `params`: `Array<LVal>` (required)
+- `body`: `BlockStatement` (required)
+- `generator`: `boolean` (default: `false`)
+- `async`: `boolean` (default: `false`)
+- `declare`: `boolean` (default: `null`)
+- `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
 ### functionExpression
+
 ```javascript
-t.functionExpression(id, params, body, generator, async)
+t.functionExpression(id, params, body, generator, async);
 ```
 
 See also `t.isFunctionExpression(node, opts)` and `t.assertFunctionExpression(node, opts)`.
 
 Aliases: `Scopable`, `Function`, `BlockParent`, `FunctionParent`, `Expression`, `Pureish`
 
- - `id`: `Identifier` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `body`: `BlockStatement` (required)
- - `generator`: `boolean` (default: `false`)
- - `async`: `boolean` (default: `false`)
- - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
+- `id`: `Identifier` (default: `null`)
+- `params`: `Array<LVal>` (required)
+- `body`: `BlockStatement` (required)
+- `generator`: `boolean` (default: `false`)
+- `async`: `boolean` (default: `false`)
+- `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
 ### functionTypeAnnotation
+
 ```javascript
-t.functionTypeAnnotation(typeParameters, params, rest, returnType)
+t.functionTypeAnnotation(typeParameters, params, rest, returnType);
 ```
 
 See also `t.isFunctionTypeAnnotation(node, opts)` and `t.assertFunctionTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `params`: `Array<FunctionTypeParam>` (required)
- - `rest`: `FunctionTypeParam` (default: `null`)
- - `returnType`: `FlowType` (required)
+- `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+- `params`: `Array<FunctionTypeParam>` (required)
+- `rest`: `FunctionTypeParam` (default: `null`)
+- `returnType`: `FlowType` (required)
 
 ---
 
 ### functionTypeParam
+
 ```javascript
-t.functionTypeParam(name, typeAnnotation)
+t.functionTypeParam(name, typeAnnotation);
 ```
 
 See also `t.isFunctionTypeParam(node, opts)` and `t.assertFunctionTypeParam(node, opts)`.
 
 Aliases: `Flow`
 
- - `name`: `Identifier` (default: `null`)
- - `typeAnnotation`: `FlowType` (required)
- - `optional`: `boolean` (default: `null`)
+- `name`: `Identifier` (default: `null`)
+- `typeAnnotation`: `FlowType` (required)
+- `optional`: `boolean` (default: `null`)
 
 ---
 
 ### genericTypeAnnotation
+
 ```javascript
-t.genericTypeAnnotation(id, typeParameters)
+t.genericTypeAnnotation(id, typeParameters);
 ```
 
 See also `t.isGenericTypeAnnotation(node, opts)` and `t.assertGenericTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### identifier
+
 ```javascript
-t.identifier(name)
+t.identifier(name);
 ```
 
 See also `t.isIdentifier(node, opts)` and `t.assertIdentifier(node, opts)`.
 
 Aliases: `Expression`, `PatternLike`, `LVal`, `TSEntityName`
 
- - `name`: `string` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `name`: `string` (required)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `optional`: `boolean` (default: `null`)
+- `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### ifStatement
+
 ```javascript
-t.ifStatement(test, consequent, alternate)
+t.ifStatement(test, consequent, alternate);
 ```
 
 See also `t.isIfStatement(node, opts)` and `t.assertIfStatement(node, opts)`.
 
 Aliases: `Statement`, `Conditional`
 
- - `test`: `Expression` (required)
- - `consequent`: `Statement` (required)
- - `alternate`: `Statement` (default: `null`)
+- `test`: `Expression` (required)
+- `consequent`: `Statement` (required)
+- `alternate`: `Statement` (default: `null`)
 
 ---
 
 ### import
+
 ```javascript
-t.import()
+t.import();
 ```
 
 See also `t.isImport(node, opts)` and `t.assertImport(node, opts)`.
 
 Aliases: `Expression`
 
-
 ---
 
 ### importDeclaration
+
 ```javascript
-t.importDeclaration(specifiers, source)
+t.importDeclaration(specifiers, source);
 ```
 
 See also `t.isImportDeclaration(node, opts)` and `t.assertImportDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`, `ModuleDeclaration`
 
- - `specifiers`: `Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>` (required)
- - `source`: `StringLiteral` (required)
+- `specifiers`: `Array<ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier>` (required)
+- `source`: `StringLiteral` (required)
 
 ---
 
 ### importDefaultSpecifier
+
 ```javascript
-t.importDefaultSpecifier(local)
+t.importDefaultSpecifier(local);
 ```
 
 See also `t.isImportDefaultSpecifier(node, opts)` and `t.assertImportDefaultSpecifier(node, opts)`.
 
 Aliases: `ModuleSpecifier`
 
- - `local`: `Identifier` (required)
+- `local`: `Identifier` (required)
 
 ---
 
 ### importNamespaceSpecifier
+
 ```javascript
-t.importNamespaceSpecifier(local)
+t.importNamespaceSpecifier(local);
 ```
 
 See also `t.isImportNamespaceSpecifier(node, opts)` and `t.assertImportNamespaceSpecifier(node, opts)`.
 
 Aliases: `ModuleSpecifier`
 
- - `local`: `Identifier` (required)
+- `local`: `Identifier` (required)
 
 ---
 
 ### importSpecifier
+
 ```javascript
-t.importSpecifier(local, imported)
+t.importSpecifier(local, imported);
 ```
 
 See also `t.isImportSpecifier(node, opts)` and `t.assertImportSpecifier(node, opts)`.
 
 Aliases: `ModuleSpecifier`
 
- - `local`: `Identifier` (required)
- - `imported`: `Identifier` (required)
- - `importKind`: `null | "type" | "typeof"` (default: `null`)
+- `local`: `Identifier` (required)
+- `imported`: `Identifier` (required)
+- `importKind`: `null | "type" | "typeof"` (default: `null`)
 
 ---
 
 ### inferredPredicate
+
 ```javascript
-t.inferredPredicate()
+t.inferredPredicate();
 ```
 
 See also `t.isInferredPredicate(node, opts)` and `t.assertInferredPredicate(node, opts)`.
 
 Aliases: `Flow`, `FlowPredicate`
 
-
 ---
 
 ### interfaceDeclaration
+
 ```javascript
 t.interfaceDeclaration(id, typeParameters, extends, body)
 ```
@@ -1073,30 +1138,32 @@ See also `t.isInterfaceDeclaration(node, opts)` and `t.assertInterfaceDeclaratio
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
- - `implements`: `Array<ClassImplements>` (default: `null`)
- - `mixins`: `Array<InterfaceExtends>` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+- `extends`: `Array<InterfaceExtends>` (default: `null`)
+- `body`: `ObjectTypeAnnotation` (required)
+- `implements`: `Array<ClassImplements>` (default: `null`)
+- `mixins`: `Array<InterfaceExtends>` (default: `null`)
 
 ---
 
 ### interfaceExtends
+
 ```javascript
-t.interfaceExtends(id, typeParameters)
+t.interfaceExtends(id, typeParameters);
 ```
 
 See also `t.isInterfaceExtends(node, opts)` and `t.assertInterfaceExtends(node, opts)`.
 
 Aliases: `Flow`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterInstantiation` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### interfaceTypeAnnotation
+
 ```javascript
 t.interfaceTypeAnnotation(extends, body)
 ```
@@ -1105,1130 +1172,1204 @@ See also `t.isInterfaceTypeAnnotation(node, opts)` and `t.assertInterfaceTypeAnn
 
 Aliases: `Flow`, `FlowType`
 
- - `extends`: `Array<InterfaceExtends>` (default: `null`)
- - `body`: `ObjectTypeAnnotation` (required)
+- `extends`: `Array<InterfaceExtends>` (default: `null`)
+- `body`: `ObjectTypeAnnotation` (required)
 
 ---
 
 ### interpreterDirective
+
 ```javascript
-t.interpreterDirective(value)
+t.interpreterDirective(value);
 ```
 
 See also `t.isInterpreterDirective(node, opts)` and `t.assertInterpreterDirective(node, opts)`.
 
- - `value`: `string` (required)
+- `value`: `string` (required)
 
 ---
 
 ### intersectionTypeAnnotation
+
 ```javascript
-t.intersectionTypeAnnotation(types)
+t.intersectionTypeAnnotation(types);
 ```
 
 See also `t.isIntersectionTypeAnnotation(node, opts)` and `t.assertIntersectionTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `types`: `Array<FlowType>` (required)
+- `types`: `Array<FlowType>` (required)
 
 ---
 
 ### jSXAttribute
+
 ```javascript
-t.jsxAttribute(name, value)
+t.jsxAttribute(name, value);
 ```
 
 See also `t.isJSXAttribute(node, opts)` and `t.assertJSXAttribute(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
- - `name`: `JSXIdentifier | JSXNamespacedName` (required)
- - `value`: `JSXElement | JSXFragment | StringLiteral | JSXExpressionContainer` (default: `null`)
+- `name`: `JSXIdentifier | JSXNamespacedName` (required)
+- `value`: `JSXElement | JSXFragment | StringLiteral | JSXExpressionContainer` (default: `null`)
 
 ---
 
 ### jSXClosingElement
+
 ```javascript
-t.jsxClosingElement(name)
+t.jsxClosingElement(name);
 ```
 
 See also `t.isJSXClosingElement(node, opts)` and `t.assertJSXClosingElement(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
- - `name`: `JSXIdentifier | JSXMemberExpression` (required)
+- `name`: `JSXIdentifier | JSXMemberExpression` (required)
 
 ---
 
 ### jSXClosingFragment
+
 ```javascript
-t.jsxClosingFragment()
+t.jsxClosingFragment();
 ```
 
 See also `t.isJSXClosingFragment(node, opts)` and `t.assertJSXClosingFragment(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
-
 ---
 
 ### jSXElement
+
 ```javascript
-t.jsxElement(openingElement, closingElement, children, selfClosing)
+t.jsxElement(openingElement, closingElement, children, selfClosing);
 ```
 
 See also `t.isJSXElement(node, opts)` and `t.assertJSXElement(node, opts)`.
 
 Aliases: `JSX`, `Immutable`, `Expression`
 
- - `openingElement`: `JSXOpeningElement` (required)
- - `closingElement`: `JSXClosingElement` (default: `null`)
- - `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
- - `selfClosing` (required)
+- `openingElement`: `JSXOpeningElement` (required)
+- `closingElement`: `JSXClosingElement` (default: `null`)
+- `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
+- `selfClosing` (required)
 
 ---
 
 ### jSXEmptyExpression
+
 ```javascript
-t.jsxEmptyExpression()
+t.jsxEmptyExpression();
 ```
 
 See also `t.isJSXEmptyExpression(node, opts)` and `t.assertJSXEmptyExpression(node, opts)`.
 
 Aliases: `JSX`
 
-
 ---
 
 ### jSXExpressionContainer
+
 ```javascript
-t.jsxExpressionContainer(expression)
+t.jsxExpressionContainer(expression);
 ```
 
 See also `t.isJSXExpressionContainer(node, opts)` and `t.assertJSXExpressionContainer(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
- - `expression`: `Expression` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### jSXFragment
+
 ```javascript
-t.jsxFragment(openingFragment, closingFragment, children)
+t.jsxFragment(openingFragment, closingFragment, children);
 ```
 
 See also `t.isJSXFragment(node, opts)` and `t.assertJSXFragment(node, opts)`.
 
 Aliases: `JSX`, `Immutable`, `Expression`
 
- - `openingFragment`: `JSXOpeningFragment` (required)
- - `closingFragment`: `JSXClosingFragment` (required)
- - `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
+- `openingFragment`: `JSXOpeningFragment` (required)
+- `closingFragment`: `JSXClosingFragment` (required)
+- `children`: `Array<JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment>` (required)
 
 ---
 
 ### jSXIdentifier
+
 ```javascript
-t.jsxIdentifier(name)
+t.jsxIdentifier(name);
 ```
 
 See also `t.isJSXIdentifier(node, opts)` and `t.assertJSXIdentifier(node, opts)`.
 
 Aliases: `JSX`
 
- - `name`: `string` (required)
+- `name`: `string` (required)
 
 ---
 
 ### jSXMemberExpression
+
 ```javascript
-t.jsxMemberExpression(object, property)
+t.jsxMemberExpression(object, property);
 ```
 
 See also `t.isJSXMemberExpression(node, opts)` and `t.assertJSXMemberExpression(node, opts)`.
 
 Aliases: `JSX`
 
- - `object`: `JSXMemberExpression | JSXIdentifier` (required)
- - `property`: `JSXIdentifier` (required)
+- `object`: `JSXMemberExpression | JSXIdentifier` (required)
+- `property`: `JSXIdentifier` (required)
 
 ---
 
 ### jSXNamespacedName
+
 ```javascript
-t.jsxNamespacedName(namespace, name)
+t.jsxNamespacedName(namespace, name);
 ```
 
 See also `t.isJSXNamespacedName(node, opts)` and `t.assertJSXNamespacedName(node, opts)`.
 
 Aliases: `JSX`
 
- - `namespace`: `JSXIdentifier` (required)
- - `name`: `JSXIdentifier` (required)
+- `namespace`: `JSXIdentifier` (required)
+- `name`: `JSXIdentifier` (required)
 
 ---
 
 ### jSXOpeningElement
+
 ```javascript
-t.jsxOpeningElement(name, attributes, selfClosing)
+t.jsxOpeningElement(name, attributes, selfClosing);
 ```
 
 See also `t.isJSXOpeningElement(node, opts)` and `t.assertJSXOpeningElement(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
- - `name`: `JSXIdentifier | JSXMemberExpression` (required)
- - `attributes`: `Array<JSXAttribute | JSXSpreadAttribute>` (required)
- - `selfClosing`: `boolean` (default: `false`)
+- `name`: `JSXIdentifier | JSXMemberExpression` (required)
+- `attributes`: `Array<JSXAttribute | JSXSpreadAttribute>` (required)
+- `selfClosing`: `boolean` (default: `false`)
 
 ---
 
 ### jSXOpeningFragment
+
 ```javascript
-t.jsxOpeningFragment()
+t.jsxOpeningFragment();
 ```
 
 See also `t.isJSXOpeningFragment(node, opts)` and `t.assertJSXOpeningFragment(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
-
 ---
 
 ### jSXSpreadAttribute
+
 ```javascript
-t.jsxSpreadAttribute(argument)
+t.jsxSpreadAttribute(argument);
 ```
 
 See also `t.isJSXSpreadAttribute(node, opts)` and `t.assertJSXSpreadAttribute(node, opts)`.
 
 Aliases: `JSX`
 
- - `argument`: `Expression` (required)
+- `argument`: `Expression` (required)
 
 ---
 
 ### jSXSpreadChild
+
 ```javascript
-t.jsxSpreadChild(expression)
+t.jsxSpreadChild(expression);
 ```
 
 See also `t.isJSXSpreadChild(node, opts)` and `t.assertJSXSpreadChild(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
- - `expression`: `Expression` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### jSXText
+
 ```javascript
-t.jsxText(value)
+t.jsxText(value);
 ```
 
 See also `t.isJSXText(node, opts)` and `t.assertJSXText(node, opts)`.
 
 Aliases: `JSX`, `Immutable`
 
- - `value`: `string` (required)
+- `value`: `string` (required)
 
 ---
 
 ### labeledStatement
+
 ```javascript
-t.labeledStatement(label, body)
+t.labeledStatement(label, body);
 ```
 
 See also `t.isLabeledStatement(node, opts)` and `t.assertLabeledStatement(node, opts)`.
 
 Aliases: `Statement`
 
- - `label`: `Identifier` (required)
- - `body`: `Statement` (required)
+- `label`: `Identifier` (required)
+- `body`: `Statement` (required)
 
 ---
 
 ### logicalExpression
+
 ```javascript
-t.logicalExpression(operator, left, right)
+t.logicalExpression(operator, left, right);
 ```
 
 See also `t.isLogicalExpression(node, opts)` and `t.assertLogicalExpression(node, opts)`.
 
 Aliases: `Binary`, `Expression`
 
- - `operator`: `"||" | "&&" | "??"` (required)
- - `left`: `Expression` (required)
- - `right`: `Expression` (required)
+- `operator`: `"||" | "&&" | "??"` (required)
+- `left`: `Expression` (required)
+- `right`: `Expression` (required)
 
 ---
 
 ### memberExpression
+
 ```javascript
-t.memberExpression(object, property, computed, optional)
+t.memberExpression(object, property, computed, optional);
 ```
 
 See also `t.isMemberExpression(node, opts)` and `t.assertMemberExpression(node, opts)`.
 
 Aliases: `Expression`, `LVal`
 
- - `object`: `Expression` (required)
- - `property`: if computed then `Expression` else `Identifier` (required)
- - `computed`: `boolean` (default: `false`)
- - `optional`: `true | false` (default: `null`)
+- `object`: `Expression` (required)
+- `property`: if computed then `Expression` else `Identifier` (required)
+- `computed`: `boolean` (default: `false`)
+- `optional`: `true | false` (default: `null`)
 
 ---
 
 ### metaProperty
+
 ```javascript
-t.metaProperty(meta, property)
+t.metaProperty(meta, property);
 ```
 
 See also `t.isMetaProperty(node, opts)` and `t.assertMetaProperty(node, opts)`.
 
 Aliases: `Expression`
 
- - `meta`: `Identifier` (required)
- - `property`: `Identifier` (required)
+- `meta`: `Identifier` (required)
+- `property`: `Identifier` (required)
 
 ---
 
 ### mixedTypeAnnotation
+
 ```javascript
-t.mixedTypeAnnotation()
+t.mixedTypeAnnotation();
 ```
 
 See also `t.isMixedTypeAnnotation(node, opts)` and `t.assertMixedTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### newExpression
+
 ```javascript
-t.newExpression(callee, arguments)
+t.newExpression(callee, arguments);
 ```
 
 See also `t.isNewExpression(node, opts)` and `t.assertNewExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
- - `optional`: `true | false` (default: `null`)
- - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+- `callee`: `Expression` (required)
+- `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+- `optional`: `true | false` (default: `null`)
+- `typeArguments`: `TypeParameterInstantiation` (default: `null`)
+- `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### noop
+
 ```javascript
-t.noop()
+t.noop();
 ```
 
 See also `t.isNoop(node, opts)` and `t.assertNoop(node, opts)`.
 
-
 ---
 
 ### nullLiteral
+
 ```javascript
-t.nullLiteral()
+t.nullLiteral();
 ```
 
 See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
 
 Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
-
 ---
 
 ### nullLiteralTypeAnnotation
+
 ```javascript
-t.nullLiteralTypeAnnotation()
+t.nullLiteralTypeAnnotation();
 ```
 
 See also `t.isNullLiteralTypeAnnotation(node, opts)` and `t.assertNullLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### nullableTypeAnnotation
+
 ```javascript
-t.nullableTypeAnnotation(typeAnnotation)
+t.nullableTypeAnnotation(typeAnnotation);
 ```
 
 See also `t.isNullableTypeAnnotation(node, opts)` and `t.assertNullableTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `typeAnnotation`: `FlowType` (required)
+- `typeAnnotation`: `FlowType` (required)
 
 ---
 
 ### numberLiteralTypeAnnotation
+
 ```javascript
-t.numberLiteralTypeAnnotation(value)
+t.numberLiteralTypeAnnotation(value);
 ```
 
 See also `t.isNumberLiteralTypeAnnotation(node, opts)` and `t.assertNumberLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `value`: `number` (required)
+- `value`: `number` (required)
 
 ---
 
 ### numberTypeAnnotation
+
 ```javascript
-t.numberTypeAnnotation()
+t.numberTypeAnnotation();
 ```
 
 See also `t.isNumberTypeAnnotation(node, opts)` and `t.assertNumberTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### numericLiteral
+
 ```javascript
-t.numericLiteral(value)
+t.numericLiteral(value);
 ```
 
 See also `t.isNumericLiteral(node, opts)` and `t.assertNumericLiteral(node, opts)`.
 
 Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
- - `value`: `number` (required)
+- `value`: `number` (required)
 
 ---
 
 ### objectExpression
+
 ```javascript
-t.objectExpression(properties)
+t.objectExpression(properties);
 ```
 
 See also `t.isObjectExpression(node, opts)` and `t.assertObjectExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `properties`: `Array<ObjectMethod | ObjectProperty | SpreadElement>` (required)
+- `properties`: `Array<ObjectMethod | ObjectProperty | SpreadElement>` (required)
 
 ---
 
 ### objectMethod
+
 ```javascript
-t.objectMethod(kind, key, params, body, computed)
+t.objectMethod(kind, key, params, body, computed);
 ```
 
 See also `t.isObjectMethod(node, opts)` and `t.assertObjectMethod(node, opts)`.
 
 Aliases: `UserWhitespacable`, `Function`, `Scopable`, `BlockParent`, `FunctionParent`, `Method`, `ObjectMember`
 
- - `kind`: `"method" | "get" | "set"` (default: `'method'`)
- - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `params`: `Array<LVal>` (required)
- - `body`: `BlockStatement` (required)
- - `computed`: `boolean` (default: `false`)
- - `async`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `generator`: `boolean` (default: `false`)
- - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
- - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
+- `kind`: `"method" | "get" | "set"` (default: `'method'`)
+- `key`: if computed then `Expression` else `Identifier | Literal` (required)
+- `params`: `Array<LVal>` (required)
+- `body`: `BlockStatement` (required)
+- `computed`: `boolean` (default: `false`)
+- `async`: `boolean` (default: `false`)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `generator`: `boolean` (default: `false`)
+- `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`)
 
 ---
 
 ### objectPattern
+
 ```javascript
-t.objectPattern(properties)
+t.objectPattern(properties);
 ```
 
 See also `t.isObjectPattern(node, opts)` and `t.assertObjectPattern(node, opts)`.
 
 Aliases: `Pattern`, `PatternLike`, `LVal`
 
- - `properties`: `Array<RestElement | ObjectProperty>` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `properties`: `Array<RestElement | ObjectProperty>` (required)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### objectProperty
+
 ```javascript
-t.objectProperty(key, value, computed, shorthand, decorators)
+t.objectProperty(key, value, computed, shorthand, decorators);
 ```
 
 See also `t.isObjectProperty(node, opts)` and `t.assertObjectProperty(node, opts)`.
 
 Aliases: `UserWhitespacable`, `Property`, `ObjectMember`
 
- - `key`: if computed then `Expression` else `Identifier | Literal` (required)
- - `value`: `Expression | PatternLike` (required)
- - `computed`: `boolean` (default: `false`)
- - `shorthand`: `boolean` (default: `false`)
- - `decorators`: `Array<Decorator>` (default: `null`)
+- `key`: if computed then `Expression` else `Identifier | Literal` (required)
+- `value`: `Expression | PatternLike` (required)
+- `computed`: `boolean` (default: `false`)
+- `shorthand`: `boolean` (default: `false`)
+- `decorators`: `Array<Decorator>` (default: `null`)
 
 ---
 
 ### objectTypeAnnotation
+
 ```javascript
-t.objectTypeAnnotation(properties, indexers, callProperties, internalSlots, exact)
+t.objectTypeAnnotation(
+  properties,
+  indexers,
+  callProperties,
+  internalSlots,
+  exact
+);
 ```
 
 See also `t.isObjectTypeAnnotation(node, opts)` and `t.assertObjectTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
- - `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
- - `callProperties`: `Array<ObjectTypeCallProperty>` (default: `null`)
- - `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `null`)
- - `exact`: `boolean` (default: `false`)
+- `properties`: `Array<ObjectTypeProperty | ObjectTypeSpreadProperty>` (required)
+- `indexers`: `Array<ObjectTypeIndexer>` (default: `null`)
+- `callProperties`: `Array<ObjectTypeCallProperty>` (default: `null`)
+- `internalSlots`: `Array<ObjectTypeInternalSlot>` (default: `null`)
+- `exact`: `boolean` (default: `false`)
 
 ---
 
 ### objectTypeCallProperty
+
 ```javascript
-t.objectTypeCallProperty(value)
+t.objectTypeCallProperty(value);
 ```
 
 See also `t.isObjectTypeCallProperty(node, opts)` and `t.assertObjectTypeCallProperty(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `value`: `FlowType` (required)
- - `static`: `boolean` (default: `null`)
+- `value`: `FlowType` (required)
+- `static`: `boolean` (default: `null`)
 
 ---
 
 ### objectTypeIndexer
+
 ```javascript
-t.objectTypeIndexer(id, key, value, variance)
+t.objectTypeIndexer(id, key, value, variance);
 ```
 
 See also `t.isObjectTypeIndexer(node, opts)` and `t.assertObjectTypeIndexer(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `id`: `Identifier` (default: `null`)
- - `key`: `FlowType` (required)
- - `value`: `FlowType` (required)
- - `variance`: `Variance` (default: `null`)
- - `static`: `boolean` (default: `null`)
+- `id`: `Identifier` (default: `null`)
+- `key`: `FlowType` (required)
+- `value`: `FlowType` (required)
+- `variance`: `Variance` (default: `null`)
+- `static`: `boolean` (default: `null`)
 
 ---
 
 ### objectTypeInternalSlot
+
 ```javascript
-t.objectTypeInternalSlot(id, value, optional, static, method)
+t.objectTypeInternalSlot(id, value, optional, static, method);
 ```
 
 See also `t.isObjectTypeInternalSlot(node, opts)` and `t.assertObjectTypeInternalSlot(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `id`: `Identifier` (required)
- - `value`: `FlowType` (required)
- - `optional`: `boolean` (required)
- - `static`: `boolean` (required)
- - `method`: `boolean` (required)
+- `id`: `Identifier` (required)
+- `value`: `FlowType` (required)
+- `optional`: `boolean` (required)
+- `static`: `boolean` (required)
+- `method`: `boolean` (required)
 
 ---
 
 ### objectTypeProperty
+
 ```javascript
-t.objectTypeProperty(key, value, variance)
+t.objectTypeProperty(key, value, variance);
 ```
 
 See also `t.isObjectTypeProperty(node, opts)` and `t.assertObjectTypeProperty(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `key`: `Identifier | StringLiteral` (required)
- - `value`: `FlowType` (required)
- - `variance`: `Variance` (default: `null`)
- - `kind`: `"init" | "get" | "set"` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `proto`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+- `key`: `Identifier | StringLiteral` (required)
+- `value`: `FlowType` (required)
+- `variance`: `Variance` (default: `null`)
+- `kind`: `"init" | "get" | "set"` (default: `null`)
+- `optional`: `boolean` (default: `null`)
+- `proto`: `boolean` (default: `null`)
+- `static`: `boolean` (default: `null`)
 
 ---
 
 ### objectTypeSpreadProperty
+
 ```javascript
-t.objectTypeSpreadProperty(argument)
+t.objectTypeSpreadProperty(argument);
 ```
 
 See also `t.isObjectTypeSpreadProperty(node, opts)` and `t.assertObjectTypeSpreadProperty(node, opts)`.
 
 Aliases: `Flow`, `UserWhitespacable`
 
- - `argument`: `FlowType` (required)
+- `argument`: `FlowType` (required)
 
 ---
 
 ### opaqueType
+
 ```javascript
-t.opaqueType(id, typeParameters, supertype, impltype)
+t.opaqueType(id, typeParameters, supertype, impltype);
 ```
 
 See also `t.isOpaqueType(node, opts)` and `t.assertOpaqueType(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `supertype`: `FlowType` (default: `null`)
- - `impltype`: `FlowType` (required)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+- `supertype`: `FlowType` (default: `null`)
+- `impltype`: `FlowType` (required)
 
 ---
 
 ### optionalCallExpression
+
 ```javascript
-t.optionalCallExpression(callee, arguments, optional)
+t.optionalCallExpression(callee, arguments, optional);
 ```
 
 See also `t.isOptionalCallExpression(node, opts)` and `t.assertOptionalCallExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `callee`: `Expression` (required)
- - `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
- - `optional`: `boolean` (required)
- - `typeArguments`: `TypeParameterInstantiation` (default: `null`)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+- `callee`: `Expression` (required)
+- `arguments`: `Array<Expression | SpreadElement | JSXNamespacedName>` (required)
+- `optional`: `boolean` (required)
+- `typeArguments`: `TypeParameterInstantiation` (default: `null`)
+- `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### optionalMemberExpression
+
 ```javascript
-t.optionalMemberExpression(object, property, computed, optional)
+t.optionalMemberExpression(object, property, computed, optional);
 ```
 
 See also `t.isOptionalMemberExpression(node, opts)` and `t.assertOptionalMemberExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `object`: `Expression` (required)
- - `property`: `any` (required)
- - `computed`: `boolean` (default: `false`)
- - `optional`: `boolean` (required)
+- `object`: `Expression` (required)
+- `property`: `any` (required)
+- `computed`: `boolean` (default: `false`)
+- `optional`: `boolean` (required)
 
 ---
 
 ### parenthesizedExpression
+
 ```javascript
-t.parenthesizedExpression(expression)
+t.parenthesizedExpression(expression);
 ```
 
 See also `t.isParenthesizedExpression(node, opts)` and `t.assertParenthesizedExpression(node, opts)`.
 
 Aliases: `Expression`, `ExpressionWrapper`
 
- - `expression`: `Expression` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### privateName
+
 ```javascript
-t.privateName(id)
+t.privateName(id);
 ```
 
 See also `t.isPrivateName(node, opts)` and `t.assertPrivateName(node, opts)`.
 
 Aliases: `Private`
 
- - `id`: `Identifier` (required)
+- `id`: `Identifier` (required)
 
 ---
 
 ### program
+
 ```javascript
-t.program(body, directives, sourceType, interpreter)
+t.program(body, directives, sourceType, interpreter);
 ```
 
 See also `t.isProgram(node, opts)` and `t.assertProgram(node, opts)`.
 
 Aliases: `Scopable`, `BlockParent`, `Block`
 
- - `body`: `Array<Statement>` (required)
- - `directives`: `Array<Directive>` (default: `[]`)
- - `sourceType`: `"script" | "module"` (default: `'script'`)
- - `interpreter`: `InterpreterDirective` (default: `null`)
- - `sourceFile`: `string` (default: `null`)
+- `body`: `Array<Statement>` (required)
+- `directives`: `Array<Directive>` (default: `[]`)
+- `sourceType`: `"script" | "module"` (default: `'script'`)
+- `interpreter`: `InterpreterDirective` (default: `null`)
+- `sourceFile`: `string` (default: `null`)
 
 ---
 
 ### qualifiedTypeIdentifier
+
 ```javascript
-t.qualifiedTypeIdentifier(id, qualification)
+t.qualifiedTypeIdentifier(id, qualification);
 ```
 
 See also `t.isQualifiedTypeIdentifier(node, opts)` and `t.assertQualifiedTypeIdentifier(node, opts)`.
 
 Aliases: `Flow`
 
- - `id`: `Identifier` (required)
- - `qualification`: `Identifier | QualifiedTypeIdentifier` (required)
+- `id`: `Identifier` (required)
+- `qualification`: `Identifier | QualifiedTypeIdentifier` (required)
 
 ---
 
 ### regExpLiteral
+
 ```javascript
-t.regExpLiteral(pattern, flags)
+t.regExpLiteral(pattern, flags);
 ```
 
 See also `t.isRegExpLiteral(node, opts)` and `t.assertRegExpLiteral(node, opts)`.
 
 Aliases: `Expression`, `Literal`
 
- - `pattern`: `string` (required)
- - `flags`: `string` (default: `''`)
+- `pattern`: `string` (required)
+- `flags`: `string` (default: `''`)
 
 ---
 
 ### restElement
+
 ```javascript
-t.restElement(argument)
+t.restElement(argument);
 ```
 
 See also `t.isRestElement(node, opts)` and `t.assertRestElement(node, opts)`.
 
 Aliases: `LVal`, `PatternLike`
 
- - `argument`: `LVal` (required)
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
+- `argument`: `LVal` (required)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`)
 
 ---
 
 ### returnStatement
+
 ```javascript
-t.returnStatement(argument)
+t.returnStatement(argument);
 ```
 
 See also `t.isReturnStatement(node, opts)` and `t.assertReturnStatement(node, opts)`.
 
 Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
- - `argument`: `Expression` (default: `null`)
+- `argument`: `Expression` (default: `null`)
 
 ---
 
 ### sequenceExpression
+
 ```javascript
-t.sequenceExpression(expressions)
+t.sequenceExpression(expressions);
 ```
 
 See also `t.isSequenceExpression(node, opts)` and `t.assertSequenceExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `expressions`: `Array<Expression>` (required)
+- `expressions`: `Array<Expression>` (required)
 
 ---
 
 ### spreadElement
+
 ```javascript
-t.spreadElement(argument)
+t.spreadElement(argument);
 ```
 
 See also `t.isSpreadElement(node, opts)` and `t.assertSpreadElement(node, opts)`.
 
 Aliases: `UnaryLike`
 
- - `argument`: `Expression` (required)
+- `argument`: `Expression` (required)
 
 ---
 
 ### stringLiteral
+
 ```javascript
-t.stringLiteral(value)
+t.stringLiteral(value);
 ```
 
 See also `t.isStringLiteral(node, opts)` and `t.assertStringLiteral(node, opts)`.
 
 Aliases: `Expression`, `Pureish`, `Literal`, `Immutable`
 
- - `value`: `string` (required)
+- `value`: `string` (required)
 
 ---
 
 ### stringLiteralTypeAnnotation
+
 ```javascript
-t.stringLiteralTypeAnnotation(value)
+t.stringLiteralTypeAnnotation(value);
 ```
 
 See also `t.isStringLiteralTypeAnnotation(node, opts)` and `t.assertStringLiteralTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `value`: `string` (required)
+- `value`: `string` (required)
 
 ---
 
 ### stringTypeAnnotation
+
 ```javascript
-t.stringTypeAnnotation()
+t.stringTypeAnnotation();
 ```
 
 See also `t.isStringTypeAnnotation(node, opts)` and `t.assertStringTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### super
+
 ```javascript
-t.super()
+t.super();
 ```
 
 See also `t.isSuper(node, opts)` and `t.assertSuper(node, opts)`.
 
 Aliases: `Expression`
 
-
 ---
 
 ### switchCase
+
 ```javascript
-t.switchCase(test, consequent)
+t.switchCase(test, consequent);
 ```
 
 See also `t.isSwitchCase(node, opts)` and `t.assertSwitchCase(node, opts)`.
 
- - `test`: `Expression` (default: `null`)
- - `consequent`: `Array<Statement>` (required)
+- `test`: `Expression` (default: `null`)
+- `consequent`: `Array<Statement>` (required)
 
 ---
 
 ### switchStatement
+
 ```javascript
-t.switchStatement(discriminant, cases)
+t.switchStatement(discriminant, cases);
 ```
 
 See also `t.isSwitchStatement(node, opts)` and `t.assertSwitchStatement(node, opts)`.
 
 Aliases: `Statement`, `BlockParent`, `Scopable`
 
- - `discriminant`: `Expression` (required)
- - `cases`: `Array<SwitchCase>` (required)
+- `discriminant`: `Expression` (required)
+- `cases`: `Array<SwitchCase>` (required)
 
 ---
 
 ### tSAnyKeyword
+
 ```javascript
-t.tsAnyKeyword()
+t.tsAnyKeyword();
 ```
 
 See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSArrayType
+
 ```javascript
-t.tsArrayType(elementType)
+t.tsArrayType(elementType);
 ```
 
 See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
 
 Aliases: `TSType`
 
- - `elementType`: `TSType` (required)
+- `elementType`: `TSType` (required)
 
 ---
 
 ### tSAsExpression
+
 ```javascript
-t.tsAsExpression(expression, typeAnnotation)
+t.tsAsExpression(expression, typeAnnotation);
 ```
 
 See also `t.isTSAsExpression(node, opts)` and `t.assertTSAsExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `expression`: `Expression` (required)
- - `typeAnnotation`: `TSType` (required)
+- `expression`: `Expression` (required)
+- `typeAnnotation`: `TSType` (required)
 
 ---
 
 ### tSBooleanKeyword
+
 ```javascript
-t.tsBooleanKeyword()
+t.tsBooleanKeyword();
 ```
 
 See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSCallSignatureDeclaration
+
 ```javascript
-t.tsCallSignatureDeclaration(typeParameters, parameters, typeAnnotation)
+t.tsCallSignatureDeclaration(typeParameters, parameters, typeAnnotation);
 ```
 
 See also `t.isTSCallSignatureDeclaration(node, opts)` and `t.assertTSCallSignatureDeclaration(node, opts)`.
 
 Aliases: `TSTypeElement`
 
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+- `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
+- `parameters`: `Array<Identifier | RestElement>` (default: `null`)
+- `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 
 ---
 
 ### tSConditionalType
+
 ```javascript
-t.tsConditionalType(checkType, extendsType, trueType, falseType)
+t.tsConditionalType(checkType, extendsType, trueType, falseType);
 ```
 
 See also `t.isTSConditionalType(node, opts)` and `t.assertTSConditionalType(node, opts)`.
 
 Aliases: `TSType`
 
- - `checkType`: `TSType` (required)
- - `extendsType`: `TSType` (required)
- - `trueType`: `TSType` (required)
- - `falseType`: `TSType` (required)
+- `checkType`: `TSType` (required)
+- `extendsType`: `TSType` (required)
+- `trueType`: `TSType` (required)
+- `falseType`: `TSType` (required)
 
 ---
 
 ### tSConstructSignatureDeclaration
+
 ```javascript
-t.tsConstructSignatureDeclaration(typeParameters, parameters, typeAnnotation)
+t.tsConstructSignatureDeclaration(typeParameters, parameters, typeAnnotation);
 ```
 
 See also `t.isTSConstructSignatureDeclaration(node, opts)` and `t.assertTSConstructSignatureDeclaration(node, opts)`.
 
 Aliases: `TSTypeElement`
 
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+- `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
+- `parameters`: `Array<Identifier | RestElement>` (default: `null`)
+- `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 
 ---
 
 ### tSConstructorType
+
 ```javascript
-t.tsConstructorType(typeParameters, typeAnnotation)
+t.tsConstructorType(typeParameters, typeAnnotation);
 ```
 
 See also `t.isTSConstructorType(node, opts)` and `t.assertTSConstructorType(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
+- `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
+- `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+- `parameters`: `Array<Identifier | RestElement>` (default: `null`)
 
 ---
 
 ### tSDeclareFunction
+
 ```javascript
-t.tsDeclareFunction(id, typeParameters, params, returnType)
+t.tsDeclareFunction(id, typeParameters, params, returnType);
 ```
 
 See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node, opts)`.
 
 Aliases: `Statement`, `Declaration`
 
- - `id`: `Identifier` (default: `null`)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `declare`: `boolean` (default: `null`)
- - `generator`: `boolean` (default: `false`)
+- `id`: `Identifier` (default: `null`)
+- `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
+- `params`: `Array<LVal>` (required)
+- `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+- `async`: `boolean` (default: `false`)
+- `declare`: `boolean` (default: `null`)
+- `generator`: `boolean` (default: `false`)
 
 ---
 
 ### tSDeclareMethod
+
 ```javascript
-t.tsDeclareMethod(decorators, key, typeParameters, params, returnType)
+t.tsDeclareMethod(decorators, key, typeParameters, params, returnType);
 ```
 
 See also `t.isTSDeclareMethod(node, opts)` and `t.assertTSDeclareMethod(node, opts)`.
 
- - `decorators`: `Array<Decorator>` (default: `null`)
- - `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
- - `params`: `Array<LVal>` (required)
- - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
- - `abstract`: `boolean` (default: `null`)
- - `access`: `"public" | "private" | "protected"` (default: `null`)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `async`: `boolean` (default: `false`)
- - `computed`: `boolean` (default: `false`)
- - `generator`: `boolean` (default: `false`)
- - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
- - `optional`: `boolean` (default: `null`)
- - `static`: `boolean` (default: `null`)
+- `decorators`: `Array<Decorator>` (default: `null`)
+- `key`: `Identifier | StringLiteral | NumericLiteral | Expression` (required)
+- `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
+- `params`: `Array<LVal>` (required)
+- `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
+- `abstract`: `boolean` (default: `null`)
+- `access`: `"public" | "private" | "protected"` (default: `null`)
+- `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+- `async`: `boolean` (default: `false`)
+- `computed`: `boolean` (default: `false`)
+- `generator`: `boolean` (default: `false`)
+- `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`)
+- `optional`: `boolean` (default: `null`)
+- `static`: `boolean` (default: `null`)
 
 ---
 
 ### tSEnumDeclaration
+
 ```javascript
-t.tsEnumDeclaration(id, members)
+t.tsEnumDeclaration(id, members);
 ```
 
 See also `t.isTSEnumDeclaration(node, opts)` and `t.assertTSEnumDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `members`: `Array<TSEnumMember>` (required)
- - `const`: `boolean` (default: `null`)
- - `declare`: `boolean` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
+- `id`: `Identifier` (required)
+- `members`: `Array<TSEnumMember>` (required)
+- `const`: `boolean` (default: `null`)
+- `declare`: `boolean` (default: `null`)
+- `initializer`: `Expression` (default: `null`)
 
 ---
 
 ### tSEnumMember
+
 ```javascript
-t.tsEnumMember(id, initializer)
+t.tsEnumMember(id, initializer);
 ```
 
 See also `t.isTSEnumMember(node, opts)` and `t.assertTSEnumMember(node, opts)`.
 
- - `id`: `Identifier | StringLiteral` (required)
- - `initializer`: `Expression` (default: `null`)
+- `id`: `Identifier | StringLiteral` (required)
+- `initializer`: `Expression` (default: `null`)
 
 ---
 
 ### tSExportAssignment
+
 ```javascript
-t.tsExportAssignment(expression)
+t.tsExportAssignment(expression);
 ```
 
 See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(node, opts)`.
 
 Aliases: `Statement`
 
- - `expression`: `Expression` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### tSExpressionWithTypeArguments
+
 ```javascript
-t.tsExpressionWithTypeArguments(expression, typeParameters)
+t.tsExpressionWithTypeArguments(expression, typeParameters);
 ```
 
 See also `t.isTSExpressionWithTypeArguments(node, opts)` and `t.assertTSExpressionWithTypeArguments(node, opts)`.
 
 Aliases: `TSType`
 
- - `expression`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+- `expression`: `TSEntityName` (required)
+- `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### tSExternalModuleReference
+
 ```javascript
-t.tsExternalModuleReference(expression)
+t.tsExternalModuleReference(expression);
 ```
 
 See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModuleReference(node, opts)`.
 
- - `expression`: `StringLiteral` (required)
+- `expression`: `StringLiteral` (required)
 
 ---
 
 ### tSFunctionType
+
 ```javascript
-t.tsFunctionType(typeParameters, typeAnnotation)
+t.tsFunctionType(typeParameters, typeAnnotation);
 ```
 
 See also `t.isTSFunctionType(node, opts)` and `t.assertTSFunctionType(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
+- `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
+- `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+- `parameters`: `Array<Identifier | RestElement>` (default: `null`)
 
 ---
 
 ### tSImportEqualsDeclaration
+
 ```javascript
-t.tsImportEqualsDeclaration(id, moduleReference)
+t.tsImportEqualsDeclaration(id, moduleReference);
 ```
 
 See also `t.isTSImportEqualsDeclaration(node, opts)` and `t.assertTSImportEqualsDeclaration(node, opts)`.
 
 Aliases: `Statement`
 
- - `id`: `Identifier` (required)
- - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
- - `isExport`: `boolean` (default: `null`)
+- `id`: `Identifier` (required)
+- `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
+- `isExport`: `boolean` (default: `null`)
 
 ---
 
 ### tSIndexSignature
+
 ```javascript
-t.tsIndexSignature(parameters, typeAnnotation)
+t.tsIndexSignature(parameters, typeAnnotation);
 ```
 
 See also `t.isTSIndexSignature(node, opts)` and `t.assertTSIndexSignature(node, opts)`.
 
 Aliases: `TSTypeElement`
 
- - `parameters`: `Array<Identifier>` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
+- `parameters`: `Array<Identifier>` (required)
+- `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+- `readonly`: `boolean` (default: `null`)
 
 ---
 
 ### tSIndexedAccessType
+
 ```javascript
-t.tsIndexedAccessType(objectType, indexType)
+t.tsIndexedAccessType(objectType, indexType);
 ```
 
 See also `t.isTSIndexedAccessType(node, opts)` and `t.assertTSIndexedAccessType(node, opts)`.
 
 Aliases: `TSType`
 
- - `objectType`: `TSType` (required)
- - `indexType`: `TSType` (required)
+- `objectType`: `TSType` (required)
+- `indexType`: `TSType` (required)
 
 ---
 
 ### tSInferType
+
 ```javascript
-t.tsInferType(typeParameter)
+t.tsInferType(typeParameter);
 ```
 
 See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeParameter`: `TSTypeParameter` (required)
+- `typeParameter`: `TSTypeParameter` (required)
 
 ---
 
 ### tSInterfaceBody
+
 ```javascript
-t.tsInterfaceBody(body)
+t.tsInterfaceBody(body);
 ```
 
 See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, opts)`.
 
- - `body`: `Array<TSTypeElement>` (required)
+- `body`: `Array<TSTypeElement>` (required)
 
 ---
 
 ### tSInterfaceDeclaration
+
 ```javascript
 t.tsInterfaceDeclaration(id, typeParameters, extends, body)
 ```
@@ -2237,456 +2378,482 @@ See also `t.isTSInterfaceDeclaration(node, opts)` and `t.assertTSInterfaceDeclar
 
 Aliases: `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `extends`: `Array<TSExpressionWithTypeArguments>` (default: `null`)
- - `body`: `TSInterfaceBody` (required)
- - `declare`: `boolean` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
+- `extends`: `Array<TSExpressionWithTypeArguments>` (default: `null`)
+- `body`: `TSInterfaceBody` (required)
+- `declare`: `boolean` (default: `null`)
 
 ---
 
 ### tSIntersectionType
+
 ```javascript
-t.tsIntersectionType(types)
+t.tsIntersectionType(types);
 ```
 
 See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(node, opts)`.
 
 Aliases: `TSType`
 
- - `types`: `Array<TSType>` (required)
+- `types`: `Array<TSType>` (required)
 
 ---
 
 ### tSLiteralType
+
 ```javascript
-t.tsLiteralType(literal)
+t.tsLiteralType(literal);
 ```
 
 See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
 
 Aliases: `TSType`
 
- - `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
+- `literal`: `NumericLiteral | StringLiteral | BooleanLiteral` (required)
 
 ---
 
 ### tSMappedType
+
 ```javascript
-t.tsMappedType(typeParameter, typeAnnotation)
+t.tsMappedType(typeParameter, typeAnnotation);
 ```
 
 See also `t.isTSMappedType(node, opts)` and `t.assertTSMappedType(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeParameter`: `TSTypeParameter` (required)
- - `typeAnnotation`: `TSType` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
+- `typeParameter`: `TSTypeParameter` (required)
+- `typeAnnotation`: `TSType` (default: `null`)
+- `optional`: `boolean` (default: `null`)
+- `readonly`: `boolean` (default: `null`)
 
 ---
 
 ### tSMethodSignature
+
 ```javascript
-t.tsMethodSignature(key, typeParameters, parameters, typeAnnotation)
+t.tsMethodSignature(key, typeParameters, parameters, typeAnnotation);
 ```
 
 See also `t.isTSMethodSignature(node, opts)` and `t.assertTSMethodSignature(node, opts)`.
 
 Aliases: `TSTypeElement`
 
- - `key`: `Expression` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `parameters`: `Array<Identifier | RestElement>` (default: `null`)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
+- `key`: `Expression` (required)
+- `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
+- `parameters`: `Array<Identifier | RestElement>` (default: `null`)
+- `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+- `computed`: `boolean` (default: `null`)
+- `optional`: `boolean` (default: `null`)
 
 ---
 
 ### tSModuleBlock
+
 ```javascript
-t.tsModuleBlock(body)
+t.tsModuleBlock(body);
 ```
 
 See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`.
 
- - `body`: `Array<Statement>` (required)
+- `body`: `Array<Statement>` (required)
 
 ---
 
 ### tSModuleDeclaration
+
 ```javascript
-t.tsModuleDeclaration(id, body)
+t.tsModuleDeclaration(id, body);
 ```
 
 See also `t.isTSModuleDeclaration(node, opts)` and `t.assertTSModuleDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`
 
- - `id`: `Identifier | StringLiteral` (required)
- - `body`: `TSModuleBlock | TSModuleDeclaration` (required)
- - `declare`: `boolean` (default: `null`)
- - `global`: `boolean` (default: `null`)
+- `id`: `Identifier | StringLiteral` (required)
+- `body`: `TSModuleBlock | TSModuleDeclaration` (required)
+- `declare`: `boolean` (default: `null`)
+- `global`: `boolean` (default: `null`)
 
 ---
 
 ### tSNamespaceExportDeclaration
+
 ```javascript
-t.tsNamespaceExportDeclaration(id)
+t.tsNamespaceExportDeclaration(id);
 ```
 
 See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespaceExportDeclaration(node, opts)`.
 
 Aliases: `Statement`
 
- - `id`: `Identifier` (required)
+- `id`: `Identifier` (required)
 
 ---
 
 ### tSNeverKeyword
+
 ```javascript
-t.tsNeverKeyword()
+t.tsNeverKeyword();
 ```
 
 See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSNonNullExpression
+
 ```javascript
-t.tsNonNullExpression(expression)
+t.tsNonNullExpression(expression);
 ```
 
 See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `expression`: `Expression` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### tSNullKeyword
+
 ```javascript
-t.tsNullKeyword()
+t.tsNullKeyword();
 ```
 
 See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSNumberKeyword
+
 ```javascript
-t.tsNumberKeyword()
+t.tsNumberKeyword();
 ```
 
 See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSObjectKeyword
+
 ```javascript
-t.tsObjectKeyword()
+t.tsObjectKeyword();
 ```
 
 See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSParameterProperty
+
 ```javascript
-t.tsParameterProperty(parameter)
+t.tsParameterProperty(parameter);
 ```
 
 See also `t.isTSParameterProperty(node, opts)` and `t.assertTSParameterProperty(node, opts)`.
 
 Aliases: `LVal`
 
- - `parameter`: `Identifier | AssignmentPattern` (required)
- - `accessibility`: `"public" | "private" | "protected"` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
+- `parameter`: `Identifier | AssignmentPattern` (required)
+- `accessibility`: `"public" | "private" | "protected"` (default: `null`)
+- `readonly`: `boolean` (default: `null`)
 
 ---
 
 ### tSParenthesizedType
+
 ```javascript
-t.tsParenthesizedType(typeAnnotation)
+t.tsParenthesizedType(typeAnnotation);
 ```
 
 See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeAnnotation`: `TSType` (required)
+- `typeAnnotation`: `TSType` (required)
 
 ---
 
 ### tSPropertySignature
+
 ```javascript
-t.tsPropertySignature(key, typeAnnotation, initializer)
+t.tsPropertySignature(key, typeAnnotation, initializer);
 ```
 
 See also `t.isTSPropertySignature(node, opts)` and `t.assertTSPropertySignature(node, opts)`.
 
 Aliases: `TSTypeElement`
 
- - `key`: `Expression` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
- - `initializer`: `Expression` (default: `null`)
- - `computed`: `boolean` (default: `null`)
- - `optional`: `boolean` (default: `null`)
- - `readonly`: `boolean` (default: `null`)
+- `key`: `Expression` (required)
+- `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
+- `initializer`: `Expression` (default: `null`)
+- `computed`: `boolean` (default: `null`)
+- `optional`: `boolean` (default: `null`)
+- `readonly`: `boolean` (default: `null`)
 
 ---
 
 ### tSQualifiedName
+
 ```javascript
-t.tsQualifiedName(left, right)
+t.tsQualifiedName(left, right);
 ```
 
 See also `t.isTSQualifiedName(node, opts)` and `t.assertTSQualifiedName(node, opts)`.
 
 Aliases: `TSEntityName`
 
- - `left`: `TSEntityName` (required)
- - `right`: `Identifier` (required)
+- `left`: `TSEntityName` (required)
+- `right`: `Identifier` (required)
 
 ---
 
 ### tSStringKeyword
+
 ```javascript
-t.tsStringKeyword()
+t.tsStringKeyword();
 ```
 
 See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSSymbolKeyword
+
 ```javascript
-t.tsSymbolKeyword()
+t.tsSymbolKeyword();
 ```
 
 See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSThisType
+
 ```javascript
-t.tsThisType()
+t.tsThisType();
 ```
 
 See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSTupleType
+
 ```javascript
-t.tsTupleType(elementTypes)
+t.tsTupleType(elementTypes);
 ```
 
 See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
 
 Aliases: `TSType`
 
- - `elementTypes`: `Array<TSType>` (required)
+- `elementTypes`: `Array<TSType>` (required)
 
 ---
 
 ### tSTypeAliasDeclaration
+
 ```javascript
-t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation)
+t.tsTypeAliasDeclaration(id, typeParameters, typeAnnotation);
 ```
 
 See also `t.isTSTypeAliasDeclaration(node, opts)` and `t.assertTSTypeAliasDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
- - `typeAnnotation`: `TSType` (required)
- - `declare`: `boolean` (default: `null`)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TSTypeParameterDeclaration` (default: `null`)
+- `typeAnnotation`: `TSType` (required)
+- `declare`: `boolean` (default: `null`)
 
 ---
 
 ### tSTypeAnnotation
+
 ```javascript
-t.tsTypeAnnotation(typeAnnotation)
+t.tsTypeAnnotation(typeAnnotation);
 ```
 
 See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, opts)`.
 
- - `typeAnnotation`: `TSType` (required)
+- `typeAnnotation`: `TSType` (required)
 
 ---
 
 ### tSTypeAssertion
+
 ```javascript
-t.tsTypeAssertion(typeAnnotation, expression)
+t.tsTypeAssertion(typeAnnotation, expression);
 ```
 
 See also `t.isTSTypeAssertion(node, opts)` and `t.assertTSTypeAssertion(node, opts)`.
 
 Aliases: `Expression`
 
- - `typeAnnotation`: `TSType` (required)
- - `expression`: `Expression` (required)
+- `typeAnnotation`: `TSType` (required)
+- `expression`: `Expression` (required)
 
 ---
 
 ### tSTypeLiteral
+
 ```javascript
-t.tsTypeLiteral(members)
+t.tsTypeLiteral(members);
 ```
 
 See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`.
 
 Aliases: `TSType`
 
- - `members`: `Array<TSTypeElement>` (required)
+- `members`: `Array<TSTypeElement>` (required)
 
 ---
 
 ### tSTypeOperator
+
 ```javascript
-t.tsTypeOperator(typeAnnotation)
+t.tsTypeOperator(typeAnnotation);
 ```
 
 See also `t.isTSTypeOperator(node, opts)` and `t.assertTSTypeOperator(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeAnnotation`: `TSType` (required)
- - `operator`: `string` (default: `null`)
+- `typeAnnotation`: `TSType` (required)
+- `operator`: `string` (default: `null`)
 
 ---
 
 ### tSTypeParameter
+
 ```javascript
 t.tsTypeParameter(constraint, default)
 ```
 
 See also `t.isTSTypeParameter(node, opts)` and `t.assertTSTypeParameter(node, opts)`.
 
- - `constraint`: `TSType` (default: `null`)
- - `default`: `TSType` (default: `null`)
- - `name`: `string` (default: `null`)
+- `constraint`: `TSType` (default: `null`)
+- `default`: `TSType` (default: `null`)
+- `name`: `string` (default: `null`)
 
 ---
 
 ### tSTypeParameterDeclaration
+
 ```javascript
-t.tsTypeParameterDeclaration(params)
+t.tsTypeParameterDeclaration(params);
 ```
 
 See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParameterDeclaration(node, opts)`.
 
- - `params`: `Array<TSTypeParameter>` (required)
+- `params`: `Array<TSTypeParameter>` (required)
 
 ---
 
 ### tSTypeParameterInstantiation
+
 ```javascript
-t.tsTypeParameterInstantiation(params)
+t.tsTypeParameterInstantiation(params);
 ```
 
 See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParameterInstantiation(node, opts)`.
 
- - `params`: `Array<TSType>` (required)
+- `params`: `Array<TSType>` (required)
 
 ---
 
 ### tSTypePredicate
+
 ```javascript
-t.tsTypePredicate(parameterName, typeAnnotation)
+t.tsTypePredicate(parameterName, typeAnnotation);
 ```
 
 See also `t.isTSTypePredicate(node, opts)` and `t.assertTSTypePredicate(node, opts)`.
 
 Aliases: `TSType`
 
- - `parameterName`: `Identifier | TSThisType` (required)
- - `typeAnnotation`: `TSTypeAnnotation` (required)
+- `parameterName`: `Identifier | TSThisType` (required)
+- `typeAnnotation`: `TSTypeAnnotation` (required)
 
 ---
 
 ### tSTypeQuery
+
 ```javascript
-t.tsTypeQuery(exprName)
+t.tsTypeQuery(exprName);
 ```
 
 See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
 
 Aliases: `TSType`
 
- - `exprName`: `TSEntityName` (required)
+- `exprName`: `TSEntityName` (required)
 
 ---
 
 ### tSTypeReference
+
 ```javascript
-t.tsTypeReference(typeName, typeParameters)
+t.tsTypeReference(typeName, typeParameters);
 ```
 
 See also `t.isTSTypeReference(node, opts)` and `t.assertTSTypeReference(node, opts)`.
 
 Aliases: `TSType`
 
- - `typeName`: `TSEntityName` (required)
- - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
+- `typeName`: `TSEntityName` (required)
+- `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
 ---
 
 ### tSUndefinedKeyword
+
 ```javascript
-t.tsUndefinedKeyword()
+t.tsUndefinedKeyword();
 ```
 
 See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### tSUnionType
+
 ```javascript
-t.tsUnionType(types)
+t.tsUnionType(types);
 ```
 
 See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
 
 Aliases: `TSType`
 
- - `types`: `Array<TSType>` (required)
+- `types`: `Array<TSType>` (required)
 
 ---
 
 ### tSUnknownType
+
 ```javascript
-t.tsUnknownType(types)
+t.tsUnknownType(types);
 ```
 
 See also `t.isTSUnknownType(node, opts)` and `t.assertTSUnknownType(node, opts)`.
@@ -2695,170 +2862,180 @@ Added in: `v7.2.0`
 
 Aliases: `TSType`
 
- - `types`: `Array<TSType>` (required)
+- `types`: `Array<TSType>` (required)
 
 ---
 
 ### tSVoidKeyword
+
 ```javascript
-t.tsVoidKeyword()
+t.tsVoidKeyword();
 ```
 
 See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
 
 Aliases: `TSType`
 
-
 ---
 
 ### taggedTemplateExpression
+
 ```javascript
-t.taggedTemplateExpression(tag, quasi)
+t.taggedTemplateExpression(tag, quasi);
 ```
 
 See also `t.isTaggedTemplateExpression(node, opts)` and `t.assertTaggedTemplateExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `tag`: `Expression` (required)
- - `quasi`: `TemplateLiteral` (required)
+- `tag`: `Expression` (required)
+- `quasi`: `TemplateLiteral` (required)
 
 ---
 
 ### templateElement
+
 ```javascript
-t.templateElement(value, tail)
+t.templateElement(value, tail);
 ```
 
 See also `t.isTemplateElement(node, opts)` and `t.assertTemplateElement(node, opts)`.
 
- - `value`: `{ raw: string, cooked: string }` (required)
- - `tail`: `boolean` (default: `false`)
+- `value`: `{ raw: string, cooked: string }` (required)
+- `tail`: `boolean` (default: `false`)
 
 ---
 
 ### templateLiteral
+
 ```javascript
-t.templateLiteral(quasis, expressions)
+t.templateLiteral(quasis, expressions);
 ```
 
 See also `t.isTemplateLiteral(node, opts)` and `t.assertTemplateLiteral(node, opts)`.
 
 Aliases: `Expression`, `Literal`
 
- - `quasis`: `Array<TemplateElement>` (required)
- - `expressions`: `Array<Expression>` (required)
+- `quasis`: `Array<TemplateElement>` (required)
+- `expressions`: `Array<Expression>` (required)
 
 ---
 
 ### thisExpression
+
 ```javascript
-t.thisExpression()
+t.thisExpression();
 ```
 
 See also `t.isThisExpression(node, opts)` and `t.assertThisExpression(node, opts)`.
 
 Aliases: `Expression`
 
-
 ---
 
 ### thisTypeAnnotation
+
 ```javascript
-t.thisTypeAnnotation()
+t.thisTypeAnnotation();
 ```
 
 See also `t.isThisTypeAnnotation(node, opts)` and `t.assertThisTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### throwStatement
+
 ```javascript
-t.throwStatement(argument)
+t.throwStatement(argument);
 ```
 
 See also `t.isThrowStatement(node, opts)` and `t.assertThrowStatement(node, opts)`.
 
 Aliases: `Statement`, `Terminatorless`, `CompletionStatement`
 
- - `argument`: `Expression` (required)
+- `argument`: `Expression` (required)
 
 ---
 
 ### tryStatement
+
 ```javascript
-t.tryStatement(block, handler, finalizer)
+t.tryStatement(block, handler, finalizer);
 ```
 
 See also `t.isTryStatement(node, opts)` and `t.assertTryStatement(node, opts)`.
 
 Aliases: `Statement`
 
- - `block`: `BlockStatement` (required)
- - `handler`: `CatchClause` (default: `null`)
- - `finalizer`: `BlockStatement` (default: `null`)
+- `block`: `BlockStatement` (required)
+- `handler`: `CatchClause` (default: `null`)
+- `finalizer`: `BlockStatement` (default: `null`)
 
 ---
 
 ### tupleTypeAnnotation
+
 ```javascript
-t.tupleTypeAnnotation(types)
+t.tupleTypeAnnotation(types);
 ```
 
 See also `t.isTupleTypeAnnotation(node, opts)` and `t.assertTupleTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `types`: `Array<FlowType>` (required)
+- `types`: `Array<FlowType>` (required)
 
 ---
 
 ### typeAlias
+
 ```javascript
-t.typeAlias(id, typeParameters, right)
+t.typeAlias(id, typeParameters, right);
 ```
 
 See also `t.isTypeAlias(node, opts)` and `t.assertTypeAlias(node, opts)`.
 
 Aliases: `Flow`, `FlowDeclaration`, `Statement`, `Declaration`
 
- - `id`: `Identifier` (required)
- - `typeParameters`: `TypeParameterDeclaration` (default: `null`)
- - `right`: `FlowType` (required)
+- `id`: `Identifier` (required)
+- `typeParameters`: `TypeParameterDeclaration` (default: `null`)
+- `right`: `FlowType` (required)
 
 ---
 
 ### typeAnnotation
+
 ```javascript
-t.typeAnnotation(typeAnnotation)
+t.typeAnnotation(typeAnnotation);
 ```
 
 See also `t.isTypeAnnotation(node, opts)` and `t.assertTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`
 
- - `typeAnnotation`: `FlowType` (required)
+- `typeAnnotation`: `FlowType` (required)
 
 ---
 
 ### typeCastExpression
+
 ```javascript
-t.typeCastExpression(expression, typeAnnotation)
+t.typeCastExpression(expression, typeAnnotation);
 ```
 
 See also `t.isTypeCastExpression(node, opts)` and `t.assertTypeCastExpression(node, opts)`.
 
 Aliases: `Flow`, `ExpressionWrapper`, `Expression`
 
- - `expression`: `Expression` (required)
- - `typeAnnotation`: `TypeAnnotation` (required)
+- `expression`: `Expression` (required)
+- `typeAnnotation`: `TypeAnnotation` (required)
 
 ---
 
 ### typeParameter
+
 ```javascript
 t.typeParameter(bound, default, variance)
 ```
@@ -2867,187 +3044,198 @@ See also `t.isTypeParameter(node, opts)` and `t.assertTypeParameter(node, opts)`
 
 Aliases: `Flow`
 
- - `bound`: `TypeAnnotation` (default: `null`)
- - `default`: `FlowType` (default: `null`)
- - `variance`: `Variance` (default: `null`)
- - `name`: `string` (default: `null`)
+- `bound`: `TypeAnnotation` (default: `null`)
+- `default`: `FlowType` (default: `null`)
+- `variance`: `Variance` (default: `null`)
+- `name`: `string` (default: `null`)
 
 ---
 
 ### typeParameterDeclaration
+
 ```javascript
-t.typeParameterDeclaration(params)
+t.typeParameterDeclaration(params);
 ```
 
 See also `t.isTypeParameterDeclaration(node, opts)` and `t.assertTypeParameterDeclaration(node, opts)`.
 
 Aliases: `Flow`
 
- - `params`: `Array<TypeParameter>` (required)
+- `params`: `Array<TypeParameter>` (required)
 
 ---
 
 ### typeParameterInstantiation
+
 ```javascript
-t.typeParameterInstantiation(params)
+t.typeParameterInstantiation(params);
 ```
 
 See also `t.isTypeParameterInstantiation(node, opts)` and `t.assertTypeParameterInstantiation(node, opts)`.
 
 Aliases: `Flow`
 
- - `params`: `Array<FlowType>` (required)
+- `params`: `Array<FlowType>` (required)
 
 ---
 
 ### typeofTypeAnnotation
+
 ```javascript
-t.typeofTypeAnnotation(argument)
+t.typeofTypeAnnotation(argument);
 ```
 
 See also `t.isTypeofTypeAnnotation(node, opts)` and `t.assertTypeofTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `argument`: `FlowType` (required)
+- `argument`: `FlowType` (required)
 
 ---
 
 ### unaryExpression
+
 ```javascript
-t.unaryExpression(operator, argument, prefix)
+t.unaryExpression(operator, argument, prefix);
 ```
 
 See also `t.isUnaryExpression(node, opts)` and `t.assertUnaryExpression(node, opts)`.
 
 Aliases: `UnaryLike`, `Expression`
 
- - `operator`: `"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"` (required)
- - `argument`: `Expression` (required)
- - `prefix`: `boolean` (default: `true`)
+- `operator`: `"void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof"` (required)
+- `argument`: `Expression` (required)
+- `prefix`: `boolean` (default: `true`)
 
 ---
 
 ### unionTypeAnnotation
+
 ```javascript
-t.unionTypeAnnotation(types)
+t.unionTypeAnnotation(types);
 ```
 
 See also `t.isUnionTypeAnnotation(node, opts)` and `t.assertUnionTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`
 
- - `types`: `Array<FlowType>` (required)
+- `types`: `Array<FlowType>` (required)
 
 ---
 
 ### updateExpression
+
 ```javascript
-t.updateExpression(operator, argument, prefix)
+t.updateExpression(operator, argument, prefix);
 ```
 
 See also `t.isUpdateExpression(node, opts)` and `t.assertUpdateExpression(node, opts)`.
 
 Aliases: `Expression`
 
- - `operator`: `"++" | "--"` (required)
- - `argument`: `Expression` (required)
- - `prefix`: `boolean` (default: `false`)
+- `operator`: `"++" | "--"` (required)
+- `argument`: `Expression` (required)
+- `prefix`: `boolean` (default: `false`)
 
 ---
 
 ### variableDeclaration
+
 ```javascript
-t.variableDeclaration(kind, declarations)
+t.variableDeclaration(kind, declarations);
 ```
 
 See also `t.isVariableDeclaration(node, opts)` and `t.assertVariableDeclaration(node, opts)`.
 
 Aliases: `Statement`, `Declaration`
 
- - `kind`: `"var" | "let" | "const"` (required)
- - `declarations`: `Array<VariableDeclarator>` (required)
- - `declare`: `boolean` (default: `null`)
+- `kind`: `"var" | "let" | "const"` (required)
+- `declarations`: `Array<VariableDeclarator>` (required)
+- `declare`: `boolean` (default: `null`)
 
 ---
 
 ### variableDeclarator
+
 ```javascript
-t.variableDeclarator(id, init)
+t.variableDeclarator(id, init);
 ```
 
 See also `t.isVariableDeclarator(node, opts)` and `t.assertVariableDeclarator(node, opts)`.
 
- - `id`: `LVal` (required)
- - `init`: `Expression` (default: `null`)
- - `definite`: `boolean` (default: `null`)
+- `id`: `LVal` (required)
+- `init`: `Expression` (default: `null`)
+- `definite`: `boolean` (default: `null`)
 
 ---
 
 ### variance
+
 ```javascript
-t.variance(kind)
+t.variance(kind);
 ```
 
 See also `t.isVariance(node, opts)` and `t.assertVariance(node, opts)`.
 
 Aliases: `Flow`
 
- - `kind`: `"minus" | "plus"` (required)
+- `kind`: `"minus" | "plus"` (required)
 
 ---
 
 ### voidTypeAnnotation
+
 ```javascript
-t.voidTypeAnnotation()
+t.voidTypeAnnotation();
 ```
 
 See also `t.isVoidTypeAnnotation(node, opts)` and `t.assertVoidTypeAnnotation(node, opts)`.
 
 Aliases: `Flow`, `FlowType`, `FlowBaseAnnotation`
 
-
 ---
 
 ### whileStatement
+
 ```javascript
-t.whileStatement(test, body)
+t.whileStatement(test, body);
 ```
 
 See also `t.isWhileStatement(node, opts)` and `t.assertWhileStatement(node, opts)`.
 
 Aliases: `Statement`, `BlockParent`, `Loop`, `While`, `Scopable`
 
- - `test`: `Expression` (required)
- - `body`: `BlockStatement | Statement` (required)
+- `test`: `Expression` (required)
+- `body`: `BlockStatement | Statement` (required)
 
 ---
 
 ### withStatement
+
 ```javascript
-t.withStatement(object, body)
+t.withStatement(object, body);
 ```
 
 See also `t.isWithStatement(node, opts)` and `t.assertWithStatement(node, opts)`.
 
 Aliases: `Statement`
 
- - `object`: `Expression` (required)
- - `body`: `BlockStatement | Statement` (required)
+- `object`: `Expression` (required)
+- `body`: `BlockStatement | Statement` (required)
 
 ---
 
 ### yieldExpression
+
 ```javascript
-t.yieldExpression(argument, delegate)
+t.yieldExpression(argument, delegate);
 ```
 
 See also `t.isYieldExpression(node, opts)` and `t.assertYieldExpression(node, opts)`.
 
 Aliases: `Expression`, `Terminatorless`
 
- - `argument`: `Expression` (default: `null`)
- - `delegate`: `boolean` (default: `false`)
+- `argument`: `Expression` (default: `null`)
+- `delegate`: `boolean` (default: `false`)
 
 ---
-

--- a/docs/v7-migration.md
+++ b/docs/v7-migration.md
@@ -3,7 +3,7 @@ title: "Upgrade to Babel 7"
 id: v7-migration
 ---
 
-Refer users to this document when upgrading to Babel 7.
+Refer users to this document when upgrading to Babel 7. Check [here](v7-migration-api.md) for API/integration changes.
 
 <!--truncate-->
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,41 +1,26 @@
 {
   "docs": {
-    "Guides": [
-      "index",
-      "usage",
-      "configuration",
-      "learn",
-      "v7-migration",
-      "v7-migration-api"
+    "Guides": ["index", "usage", "configuration", "learn", "v7-migration"],
+    "Config Reference": ["config-files", "options", "presets", "plugins"],
+    "Presets": [
+      "babel-preset-env",
+      "babel-preset-react",
+      "babel-preset-typescript",
+      "babel-preset-flow"
     ],
-    "General": [
-      "editors",
-      "plugins",
-      "presets",
-      "caveats",
-      "faq",
-      "roadmap"
-    ],
-    "Usage": [
-      "options",
-      "config-files",
+    "Misc": ["editors", "caveats", "faq"],
+    "Integration Packages": [
       "babel-cli",
       "babel-polyfill",
       "babel-plugin-transform-runtime",
-      "babel-register"
+      "babel-register",
+      "babel-standalone"
     ],
-    "Presets": [
-      "babel-preset-env",
-      "babel-preset-flow",
-      "babel-preset-react",
-      "babel-preset-typescript"
-    ],
-    "Tooling": [
+    "Tooling Packages": [
       "babel-parser",
       "babel-core",
       "babel-generator",
       "babel-code-frame",
-      "babel-helpers",
       "babel-runtime",
       "babel-template",
       "babel-traverse",
@@ -43,5 +28,3 @@
     ]
   }
 }
-
-

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -162,7 +162,8 @@ const siteConfig = {
   // ----
   scrollToTop: true,
   // markdownPlugins: [],
-  // cname
+  // cname,
+  // docsSideNavCollapsible: true,
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
changed sidebar a bit, will do more in a next pr.
- showing the full name of package (removed the sidebar_label, which caused some misc formatting but should be ok)

![image](https://user-images.githubusercontent.com/588473/113459920-feb47d00-93e4-11eb-8934-88e1fedaa555.png)

- only updated docs/presets and doc/plugins pages so can ignore the others mostly.
- Fixes https://github.com/babel/website/issues/2179 (just change javascript to typescript code block in 2 places)