### PR TITLE
redo current monthly sponsors calculation, mostly from webpack

### DIFF
--- a/scripts/download-sponsors.js
+++ b/scripts/download-sponsors.js
@@ -6,60 +6,189 @@ const fs = require("fs");
 
 const graphqlEndpoint = "https://api.opencollective.com/graphql/v2";
 
-const graphqlQuery = `{
+// all from webpack: https://github.com/webpack/webpack.js.org/blob/master/src/utilities/fetch-supporters.js
+const { promisify } = require("util");
+const asyncWriteFile = promisify(fs.writeFile);
+const REQUIRED_KEYS = ["totalDonations", "slug", "name"];
+const sponsorsFile2 = `${__dirname}/../website/data/sponsors.json`;
+
+// https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v2/query/TransactionsQuery.ts#L81
+const graphqlPageSize = 1000;
+
+const membersGraphqlQuery = `query account($limit: Int, $offset: Int) {
   account(slug: "babel") {
-    orders(status: ACTIVE, limit: 1000) {
-      totalCount
+    members(limit: $limit, offset: $offset) {
       nodes {
-        tier {
-          slug
-        }
-        fromAccount {
+        account {
           name
           slug
           website
           imageUrl
           description
         }
+        totalDonations {
+          value
+        }
+        createdAt
       }
     }
   }
 }`;
 
-const sponsorsFile = `${__dirname}/../website/data/sponsors.json`;
-
-console.log("Downloading sponsors data from Open Collective...");
-
-fetch(graphqlEndpoint, {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ query: graphqlQuery }),
-})
-  .then(res => res.json())
-  .then(res => res.data.account.orders.nodes)
-  .then(nodes =>
-    nodes
-      .filter(node => !!node.tier)
-      .map(node => ({
-        tier: node.tier.slug,
-        name: node.fromAccount.name,
-        slug: node.fromAccount.slug,
-        website: node.fromAccount.website,
-        avatar: node.fromAccount.imageUrl,
-        twitterHandle: node.fromAccount.twitterHandle,
-        description: node.fromAccount.description,
-      }))
-  )
-  .then(sponsors => JSON.stringify(sponsors, null, 2))
-  .then(sponsorsJson => {
-    fs.writeFile(sponsorsFile, sponsorsJson, err => {
-      if (err) {
-        console.error("Failed to write website/data/sponsors.json file: ", err);
-      } else {
-        console.log("Success: website/data/sponsors.json created.");
+// only query transactions in last year
+const transactionsGraphqlQuery = `query transactions($dateFrom: ISODateTime, $limit: Int, $offset: Int) {
+  transactions(account: {
+    slug: "babel"
+  }, dateFrom: $dateFrom, limit: $limit, offset: $offset, includeIncognitoTransactions: false) {
+    nodes {
+        amountInHostCurrency {
+          value
+        }
+        fromAccount {
+          name
+          slug
+          website
+          imageUrl
+        }
+        createdAt
       }
-    });
-  })
-  .catch(err => {
-    console.error("Failed to fetch backers: ", err);
-  });
+  }
+}`;
+
+const nodeToSupporter = node => ({
+  name: node.account.name,
+  slug: node.account.slug,
+  website: node.account.website,
+  avatar: node.account.imageUrl,
+  firstDonation: node.createdAt,
+  totalDonations: node.totalDonations.value,
+  yearlyDonations: 0,
+  monthlyDonations: 0,
+});
+
+const getAllNodes = async (graphqlQuery, getNodes, time = "year") => {
+  const body = {
+    query: graphqlQuery,
+    variables: {
+      limit: graphqlPageSize,
+      offset: 0,
+      dateFrom: new Date(
+        time === "year"
+          ? new Date().setFullYear(new Date().getFullYear() - 1) // data from last year
+          : new Date().setMonth(new Date().getMonth() - 1) // data from last month
+      ).toISOString(),
+    },
+  };
+
+  let allNodes = [];
+
+  // Handling pagination if necessary
+  // eslint-disable-next-line
+  while (true) {
+    const result = await fetch(graphqlEndpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then(response => response.json());
+    const nodes = getNodes(result.data);
+    allNodes = [...allNodes, ...nodes];
+    body.variables.offset += graphqlPageSize;
+    if (nodes.length < graphqlPageSize) {
+      return allNodes;
+    } else {
+      // sleep for a while
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+};
+
+const uniqBy = (arr, predicate) => {
+  const cb = typeof predicate === "function" ? predicate : o => o[predicate];
+
+  return [
+    ...arr
+      .reduce((map, item) => {
+        const key = item === null || item === undefined ? item : cb(item);
+
+        map.has(key) || map.set(key, item);
+
+        return map;
+      }, new Map())
+      .values(),
+  ];
+};
+
+(async () => {
+  const members = await getAllNodes(
+    membersGraphqlQuery,
+    data => data.account.members.nodes
+  );
+  let supporters = members
+    .map(nodeToSupporter)
+    .sort((a, b) => b.totalDonations - a.totalDonations);
+
+  // Deduplicating supporters with multiple orders
+  supporters = uniqBy(supporters, "slug");
+
+  const supportersBySlug = new Map();
+  for (const supporter of supporters) {
+    for (const key of REQUIRED_KEYS) {
+      if (!supporter || typeof supporter !== "object") {
+        throw new Error(
+          `Supporters: ${JSON.stringify(supporter)} is not an object.`
+        );
+      }
+      if (!(key in supporter)) {
+        throw new Error(
+          `Supporters: ${JSON.stringify(supporter)} doesn't include ${key}.`
+        );
+      }
+    }
+    supportersBySlug.set(supporter.slug, supporter);
+  }
+
+  // Calculate monthly amount from transactions
+  const transactionsYear = await getAllNodes(
+    transactionsGraphqlQuery,
+    data => data.transactions.nodes
+  );
+  for (const transaction of transactionsYear) {
+    if (!transaction.amountInHostCurrency) continue;
+    const amount = transaction.amountInHostCurrency.value;
+    if (!amount || amount <= 0) continue;
+    const supporter = supportersBySlug.get(transaction.fromAccount.slug);
+    if (!supporter) continue;
+    supporter.yearlyDonations += amount;
+  }
+
+  const transactionsMonth = await getAllNodes(
+    transactionsGraphqlQuery,
+    data => data.transactions.nodes,
+    "month"
+  );
+
+  for (const transaction of transactionsMonth) {
+    if (!transaction.amountInHostCurrency) continue;
+    const amount = transaction.amountInHostCurrency.value;
+    if (!amount || amount <= 0) continue;
+    const supporter = supportersBySlug.get(transaction.fromAccount.slug);
+    if (!supporter) continue;
+    supporter.monthlyDonations += amount;
+  }
+
+  for (const supporter of supporters) {
+    supporter.yearlyDonations = Math.round(supporter.yearlyDonations);
+    supporter.monthlyDonations = Math.round(supporter.monthlyDonations);
+  }
+
+  // Write the file
+  return asyncWriteFile(
+    sponsorsFile2,
+    JSON.stringify(supporters, null, 2)
+  ).then(() => console.log(`Fetched 1 file: sponsors.json`));
+})().catch(error => {
+  console.error("utilities/fetch-supporters:", error);
+  process.exitCode = 1;
+});

--- a/scripts/download-sponsors.js
+++ b/scripts/download-sponsors.js
@@ -2,15 +2,13 @@
 // Downloads sponsors data from the Open Collective API.
 
 const fetch = require("node-fetch");
-const fs = require("fs");
+const fs = require("fs").promises;
 
 const graphqlEndpoint = "https://api.opencollective.com/graphql/v2";
 
 // all from webpack: https://github.com/webpack/webpack.js.org/blob/master/src/utilities/fetch-supporters.js
-const { promisify } = require("util");
-const asyncWriteFile = promisify(fs.writeFile);
 const REQUIRED_KEYS = ["totalDonations", "slug", "name"];
-const sponsorsFile2 = `${__dirname}/../website/data/sponsors.json`;
+const sponsorsFile = `${__dirname}/../website/data/sponsors.json`;
 
 // https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v2/query/TransactionsQuery.ts#L81
 const graphqlPageSize = 1000;
@@ -184,10 +182,9 @@ const uniqBy = (arr, predicate) => {
   }
 
   // Write the file
-  return asyncWriteFile(
-    sponsorsFile2,
-    JSON.stringify(supporters, null, 2)
-  ).then(() => console.log(`Fetched 1 file: sponsors.json`));
+  return fs
+    .writeFile(sponsorsFile, JSON.stringify(supporters, null, 2))
+    .then(() => console.log(`Fetched 1 file: sponsors.json`));
 })().catch(error => {
   console.error("utilities/fetch-supporters:", error);
   process.exitCode = 1;

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -78,29 +78,24 @@ const GetStarted = ({ language }) => {
         <a href={siteConfig.getPageUrl("videos.html", language)}>videos</a> on
         the people and concepts behind it.
       </p>
-      <p>
-        We&apos;re a small group of{" "}
-        <a href={siteConfig.getPageUrl("team.html", language)}>volunteers</a>{" "}
-        that spend their free time maintaining this project, funded by the
-        community. If Babel has benefited you in your work, becoming a{" "}
-        <a href="https://github.com/babel/babel/blob/master/CONTRIBUTING.md">
-          contributor
-        </a>{" "}
-        or <a href="https://opencollective.com/babel">sponsoring</a> might just
-        be a great way to give back!
-      </p>
     </div>
   );
 };
 
 const SponsorTier = props => {
-  const tierSponsors = siteConfig.sponsors.filter(
-    sponsor => sponsor.type == props.type && sponsor.tier === props.tier
-  );
+  let { min, max } = props;
+  const tierSponsors = siteConfig.sponsors.filter(sponsor => {
+    let value = Math.max(sponsor.monthly, sponsor.yearly / 12);
+    return +value >= min && (!max || (max && +value < max));
+  });
   return (
     <div>
       <h3>{props.title}</h3>
-      <div>are currently pledging {props.amount} per month</div>
+      <div>
+        are currently pledging or have donated an average of{" "}
+        {max ? `$${min}-$${max}` : `>$${min}`}
+        /month in the last year{" "}
+      </div>
       <br />
       <ul className={`sponsors-tier tier-${props.tier}`}>
         {tierSponsors.map((sponsor, i) => (
@@ -127,34 +122,47 @@ const SponsorTier = props => {
   );
 };
 
-const OpenCollectiveSponsors = () => {
-  const ocButton = {
-    title: "Become a sponsor",
-    link: "https://opencollective.com/babel",
-  };
+const ocButton = {
+  title: "Become a sponsor",
+  link: "https://opencollective.com/babel",
+};
+
+const OpenCollectiveSponsors = ({ language }) => {
   return (
     <div className="container paddingBottom">
       <div className="wrapper productShowcaseSection">
+        <h3>Current Sponsors</h3>
+        <p>
+          We&apos;re a small group of{" "}
+          <a href={siteConfig.getPageUrl("team.html", language)}>volunteers</a>{" "}
+          that spend their free time maintaining this project, funded by the
+          community. If Babel has benefited you in your work, becoming a{" "}
+          <a href="https://github.com/babel/babel/blob/master/CONTRIBUTING.md">
+            contributor
+          </a>{" "}
+          or <a href="https://opencollective.com/babel">sponsoring</a> might
+          just be a great way to give back!
+        </p>
         <div className="sponsor-tiers" id="sponsors">
-          {/* <h3>Current Sponsors</h3> */}
           <SponsorTier
             type="opencollective"
-            title="Base Support Sponsors"
-            tier="base-support-sponsor"
-            amount="$2000 or more"
+            title="Base Support"
+            tier="base-support-sponsors"
+            min={2000}
           />
           <SponsorTier
             type="opencollective"
-            title="Gold Sponsors"
+            title="Gold"
             tier="gold-sponsors"
-            amount="$1000 to $2000"
+            min={1000}
+            max={2000}
           />
           <SponsorTier
             type="opencollective"
-            title="Silver Sponsors"
+            title="Silver"
             tier="silver-sponsors"
-            button={ocButton}
-            amount="$500 to $1000"
+            min={500}
+            max={1000}
           />
         </div>
       </div>
@@ -210,11 +218,8 @@ const Index = ({ language }) => {
       <div className="mainContainer" style={{ padding: 0 }}>
         <HomeContainer>
           <GetStarted language={language} />
-          {
-            // <WorkSponsors language={language} />
-          }
         </HomeContainer>
-        <OpenCollectiveSponsors />
+        <OpenCollectiveSponsors language={language} />
       </div>
     </div>
   );

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -44,8 +44,7 @@ const sponsorsDownloaded = require(path.join(__dirname, "/data/sponsors.json"));
 const sponsors = [
   ...sponsorsManual,
   ...sponsorsDownloaded
-    // filter out Handshake for special tier
-    .filter(sponsor => sponsor.slug !== "handshake")
+    .filter(sponsor => sponsor.slug !== "github-sponsors")
     .map(sponsor => {
       let website = sponsor.website;
       if (typeof website == "string") {
@@ -58,11 +57,14 @@ const sponsors = [
 
       return {
         type: "opencollective",
-        tier: sponsor.tier,
+        tier: sponsor?.tier,
         name: sponsor.name,
         url: website,
         image: sponsor.avatar || "/img/user.svg",
         description: sponsor.description,
+        monthly: sponsor.monthlyDonations,
+        yearly: sponsor.yearlyDonations,
+        total: sponsor.totalDonations,
       };
     }),
 ];

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -57,7 +57,7 @@ const sponsors = [
 
       return {
         type: "opencollective",
-        tier: sponsor?.tier,
+        tier: sponsor.tier,
         name: sponsor.name,
         url: website,
         image: sponsor.avatar || "/img/user.svg",

--- a/website/static/css/index.css
+++ b/website/static/css/index.css
@@ -169,7 +169,7 @@
   background: none;
   border: none;
 }
-.tier-base-support-sponsor img {
+.tier-base-support-sponsors img {
   max-height: 150px;
 }
 .tier-gold-sponsors img {


### PR DESCRIPTION
> it's not that different from current

The new sponsors download graphql code is via https://github.com/webpack/webpack.js.org/blob/master/src/utilities/fetch-supporters.js. I think it is a more reliable than the old way of using "active" and "tier" because this would do it based on transactions within the last period of time (say a month or year) vs. just because someone happens to sign up at a certain tier (I recall some issues with it earlier but maybe it's fixed), either way haven't looked at any of it in a long time.

I would also like to show the total amounts donated (say for handshake or anyone else who has donated previously but just not currently), could just do it at the bottom, on another page, or make it a toggle. I forgot docu v1 doesn't really have interactivity so we'll need to move out of that.