### PR TITLE
Modify the language type of some codes (in babel-preset-typescript)

### DIFF
--- a/docs/preset-typescript.md
+++ b/docs/preset-typescript.md
@@ -19,7 +19,7 @@ const x: number = 0;
 
 **Out**
 
-```typescript
+```javascript
 const x = 0;
 ```
 
@@ -97,7 +97,7 @@ Added in: `v7.7.0`
 
 When enabled, type-only class fields are only removed if they are prefixed with the `declare` modifier:
 
-```javascript
+```typescript
 class A {
   declare foo: string; // Removed
   bar: string; // Initialized to undefined


### PR DESCRIPTION
When I checked the documentation of [`babel-preset-typescript`](https://babeljs.io/docs/en/babel-preset-typescript), I noticed some problems with the language of some sample codes:

![image](https://user-images.githubusercontent.com/10683193/113583569-5dcff700-965c-11eb-9dc4-652d8d56a7ab.png)

After TypeScript code is converted, JavaScript should be generated.

![image](https://user-images.githubusercontent.com/10683193/113583647-7dffb600-965c-11eb-806e-b05c56afc685.png)

The typed code should be TypeScript.

So I try to change it. Next, if I have time, I will check all the code formats in the webpage and try to fix the errors