### PR TITLE
Promote assumptions on loose docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ id: faq
 ## Why is the output of `for...of` so verbose and ugly?
 
 In order to comply with the specification, the iterator's return method must be
-called on errors. An alternative is to use [assumptions](/assumptions) such as [`ArrayLikeIsIterable`](/assumptions#arrayLikeIsIterable) and [`IterableIsArray`](/assumptions#iterableIsArray),
+called on errors. An alternative is to use [assumptions](assumptions.md) introduced in Babel 7.13, such as [`ArrayLikeIsIterable`](assumptions.md#arraylikeisiterable) and [`IterableIsArray`](assumptions.md#iterableisarray),
 but please note that there are **many** caveats to be aware of if you use assumptions and that you're willingly choosing not to comply with the spec.
 
 Please see [babel/rfcs#5](https://github.com/babel/rfcs/pull/5), [google/traceur-compiler#1773](https://github.com/google/traceur-compiler/issues/1773) and

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,17 +6,16 @@ id: faq
 ## Why is the output of `for...of` so verbose and ugly?
 
 In order to comply with the specification, the iterator's return method must be
-called on errors. An alternative is to enable [loose mode](plugin-transform-for-of.md#loose)
-but please note that there are **many** caveats to be aware of if you enable
-loose mode and that you're willingly choosing not to comply with the spec.
+called on errors. An alternative is to use [assumptions](/assumptions) such as [`ArrayLikeIsIterable`](/assumptions#arrayLikeIsIterable) and [`IterableIsArray`](/assumptions#iterableIsArray),
+but please note that there are **many** caveats to be aware of if you use assumptions and that you're willingly choosing not to comply with the spec.
 
-Please see [google/traceur-compiler#1773](https://github.com/google/traceur-compiler/issues/1773) and
+Please see [babel/rfcs#5](https://github.com/babel/rfcs/pull/5), [google/traceur-compiler#1773](https://github.com/google/traceur-compiler/issues/1773) and
 [babel/babel#838](https://github.com/babel/babel/issues/838) for more information.
 
 ## Why are `this` and `arguments` being remapped in arrow functions?
 
 Arrow functions **are not** synonymous with normal functions. `arguments` and `this` inside arrow functions
-reference their *outer function* for example:
+reference their _outer function_ for example:
 
 ```javascript
 const user = {
@@ -29,7 +28,7 @@ const user = {
   // use the method shorthand in objects
   getFullName2() {
     return this.firstName + " " + this.lastName;
-  }
+  },
 };
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ title: What is Babel?
 ## Babel is a JavaScript compiler
 
 Babel is a toolchain that is mainly used to convert ECMAScript 2015+ code into a backwards compatible version of JavaScript in current and older browsers or environments. Here are the main things Babel can do for you:
+
 - Transform syntax
 - Polyfill features that are missing in your target environment (through a third-party polyfill such as [core-js](https://github.com/zloirock/core-js))
 - Source code transformations (codemods)
@@ -13,7 +14,7 @@ Babel is a toolchain that is mainly used to convert ECMAScript 2015+ code into a
 
 ```js
 // Babel Input: ES2015 arrow function
-[1, 2, 3].map((n) => n + 1);
+[1, 2, 3].map(n => n + 1);
 
 // Babel Output: ES5 equivalent
 [1, 2, 3].map(function(n) {
@@ -52,11 +53,13 @@ export default React.createClass({
   },
 
   render() {
-    return <div>
-      Your dice roll:
-      {this.state.num}
-    </div>;
-  }
+    return (
+      <div>
+        Your dice roll:
+        {this.state.num}
+      </div>
+    );
+  },
 });
 ```
 
@@ -87,14 +90,13 @@ npm install --save-dev @babel/preset-typescript
 
 ```js
 function Greeter(greeting: string) {
-    this.greeting = greeting;
+  this.greeting = greeting;
 }
 ```
 
 > Learn more about [Flow](https://flow.org/) and [TypeScript](https://www.typescriptlang.org/)
 
-Pluggable
----------
+## Pluggable
 
 Babel is built out of plugins. Compose your own transformation pipeline using existing plugins or write your own. Easily use a set of plugins by using or creating a [preset](plugins.md#presets). [Learn more →](plugins.md)
 
@@ -102,31 +104,31 @@ Create a plugin on the fly with [astexplorer.net](https://astexplorer.net/#/KJ8A
 
 ```javascript
 // A plugin is just a function
-export default function ({types: t}) {
+export default function({ types: t }) {
   return {
     visitor: {
       Identifier(path) {
         let name = path.node.name; // reverse the name: JavaScript -> tpircSavaJ
-        path.node.name = name.split('').reverse().join('');
-      }
-    }
+        path.node.name = name
+          .split("")
+          .reverse()
+          .join("");
+      },
+    },
   };
 }
 ```
 
-Debuggable
-----------
+## Debuggable
 
 **Source map** support so you can debug your compiled code with ease.
 
-Spec Compliant
---------
+## Spec Compliant
 
 Babel tries to stay true to the ECMAScript standard, as much as reasonably possible. It may also have specific options to be more spec compliant as a tradeoff to performance.
 
-Compact
---------
+## Compact
 
 Babel tries using the least amount of code possible with no dependence on a bulky runtime.
 
-This may be difficult to do in cases, and there are "loose" options for specific transforms that may tradeoff spec compliancy for readability, file size, and speed.
+This may be difficult to do in cases, and there are ["assumptions"](/assumptions) options that tradeoff spec compliancy for readability, file size, and speed.

--- a/docs/plugin-proposal-class-properties.md
+++ b/docs/plugin-proposal-class-properties.md
@@ -85,7 +85,7 @@ require("@babel/core").transformSync("code", {
 
 When `true`, class properties are compiled to use an assignment expression instead of `Object.defineProperty`.
 
-> ⚠️ Consider migrate to top level [`setPublicClassFields` assumptions](/assumptions#setPublicClassFields)
+> ⚠️ Consider migrating to the top level [`setPublicClassFields`](/assumptions#setPublicClassFields) assumption
 
 ```jsonc
 // babel.config.json

--- a/docs/plugin-proposal-class-properties.md
+++ b/docs/plugin-proposal-class-properties.md
@@ -85,6 +85,17 @@ require("@babel/core").transformSync("code", {
 
 When `true`, class properties are compiled to use an assignment expression instead of `Object.defineProperty`.
 
+> ⚠️ Consider migrate to top level [`setPublicClassFields` assumptions](/assumptions#setPublicClassFields)
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "setPublicClassFields": true
+  }
+}
+```
+
 For an explanation of the consequences of using either, see [Definition vs. Assignment](http://2ality.com/2012/08/property-definition-assignment.html) (TL;DR in Part 5)
 
 #### Example
@@ -99,7 +110,7 @@ class Bork {
 }
 ```
 
-Without `{ "loose": true }`, the above code will compile to the following, using `Object.defineProperty`:
+Without `{ "setPublicClassFields": true }`, the above code will compile to the following, using `Object.defineProperty`:
 
 ```js
 var Bork = function Bork() {
@@ -132,7 +143,7 @@ Object.defineProperty(Bork, "b", {
 });
 ```
 
-However, with `{ "loose": true }`, it will compile using assignment expressions:
+However, with `{ "setPublicClassFields": true }`, it will compile using assignment expressions:
 
 ```js
 var Bork = function Bork() {

--- a/docs/plugin-proposal-class-properties.md
+++ b/docs/plugin-proposal-class-properties.md
@@ -85,7 +85,7 @@ require("@babel/core").transformSync("code", {
 
 When `true`, class properties are compiled to use an assignment expression instead of `Object.defineProperty`.
 
-> ⚠️ Consider migrating to the top level [`setPublicClassFields`](/assumptions#setPublicClassFields) assumption
+> ⚠️ Consider migrating to the top level [`setPublicClassFields`](assumptions.md#setpublicclassfields) assumption
 
 ```jsonc
 // babel.config.json

--- a/docs/plugin-proposal-class-static-block.md
+++ b/docs/plugin-proposal-class-static-block.md
@@ -59,19 +59,9 @@ npm install --save-dev @babel/plugin-proposal-class-static-block
 
 ### With a configuration file (Recommended)
 
-Without options:
-
 ```json
 {
   "plugins": ["@babel/plugin-proposal-class-static-block"]
-}
-```
-
-With options:
-
-```json
-{
-  "plugins": [["@babel/plugin-proposal-class-static-block", { "loose": true }]]
 }
 ```
 

--- a/docs/plugin-proposal-decorators.md
+++ b/docs/plugin-proposal-decorators.md
@@ -114,7 +114,7 @@ Use the legacy (stage 1) decorators syntax and behavior.
 
 If you are including your plugins manually and using `@babel/plugin-proposal-class-properties`, make sure that `@babel/plugin-proposal-decorators` comes _before_ `@babel/plugin-proposal-class-properties`.
 
-When using the `legacy: true` mode, `@babel/plugin-proposal-class-properties` must be used in `loose` mode to support the `@babel/plugin-proposal-decorators`.
+When using the `legacy: true` mode, the [`setPublicClassFields` assumption](assumptions.md#setpublicclassfields) must be enabled to support the `@babel/plugin-proposal-decorators`.
 
 Wrong:
 
@@ -140,9 +140,12 @@ Right:
 
 ```json
 {
+  "assumptions": {
+    "setPublicClassFields": true
+  },
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+    ["@babel/plugin-proposal-class-properties"]
   ]
 }
 ```

--- a/docs/plugin-proposal-nullish-coalescing-operator.md
+++ b/docs/plugin-proposal-nullish-coalescing-operator.md
@@ -68,6 +68,17 @@ When `true`, this transform will pretend `document.all` does not exist,
 and perform loose equality checks with `null` instead of strict equality checks
 against both `null` and `undefined`.
 
+> ⚠️ Consider migrating to the top level [`noDocumentAll`](assumptions.md#nodocumentall) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "noDocumentAll": true
+  }
+}
+```
+
 #### Example
 
 **In**

--- a/docs/plugin-proposal-object-rest-spread.md
+++ b/docs/plugin-proposal-object-rest-spread.md
@@ -64,7 +64,18 @@ By default, this plugin will produce spec compliant code by using Babel's `objec
 
 Enabling this option will use Babel's `extends` helper, which is basically the same as `Object.assign` (see `useBuiltIns` below to use it directly).
 
-⚠️ Please keep in mind that even if they're almost equivalent, there's an important difference between spread and `Object.assign`: **spread _defines_ new properties, while `Object.assign()` _sets_ them**, so using this mode might produce unexpected results in some cases.
+> ⚠️ Consider migrating to the top level [`setSpreadProperties`](assumptions.md#setspreadproperties) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "setSpreadProperties": true
+  }
+}
+```
+
+Please keep in mind that even if they're almost equivalent, there's an important difference between spread and `Object.assign`: **spread _defines_ new properties, while `Object.assign()` _sets_ them**, so using this mode might produce unexpected results in some cases.
 
 For detailed information please check out [Spread VS. Object.assign](http://2ality.com/2016/10/rest-spread-properties.html#spreading-objects-versus-objectassign) and [Assigning VS. defining properties](http://exploringjs.com/es6/ch_oop-besides-classes.html#sec_assigning-vs-defining-properties).
 
@@ -80,11 +91,11 @@ Enabling this option will use `Object.assign` directly instead of the Babel's `e
 
 ```json
 {
+  "assumptions": {
+    "setSpreadProperties": true
+  },
   "plugins": [
-    [
-      "@babel/plugin-proposal-object-rest-spread",
-      { "loose": true, "useBuiltIns": true }
-    ]
+    ["@babel/plugin-proposal-object-rest-spread", { "useBuiltIns": true }]
   ]
 }
 ```

--- a/docs/plugin-proposal-optional-chaining.md
+++ b/docs/plugin-proposal-optional-chaining.md
@@ -141,6 +141,17 @@ When `true`, this transform will pretend `document.all` does not exist,
 and perform loose equality checks with `null` instead of strict equality checks
 against both `null` and `undefined`.
 
+> ⚠️ Consider migrating to the top level [`noDocumentAll`](assumptions.md#nodocumentall) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "noDocumentAll": true
+  }
+}
+```
+
 #### Example
 
 In
@@ -149,13 +160,13 @@ In
 foo?.bar;
 ```
 
-Out (`loose === true`)
+Out (`noDocumentAll === true`)
 
 ```javascript
 foo == null ? void 0 : foo.bar;
 ```
 
-Out (`loose === false`)
+Out (`noDocumentAll === false`)
 
 ```javascript
 foo === null || foo === void 0 ? void 0 : foo.bar;

--- a/docs/plugin-proposal-private-methods.md
+++ b/docs/plugin-proposal-private-methods.md
@@ -87,6 +87,20 @@ via `Object.defineProperty` rather than a `WeakSet`. This results in improved
 performance and debugging (normal property access vs `.get()`) at the expense
 of potentially leaking "privates" via things like `Object.getOwnPropertyNames`.
 
+> ⚠️ Consider migrating to the top level [`privateFieldsAsProperties`](assumptions.md#privatefieldsasproperties) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "privateFieldsAsProperties": true,
+    "setPublicClassFields": true
+  }
+}
+```
+
+Note that both `privateFieldsAsProperties` and `setPublicClassFields` must be set to `true`.
+
 Let's use the following as an example:
 
 ```javascript
@@ -123,7 +137,7 @@ var _privateMethod2 = function _privateMethod2() {
 };
 ```
 
-With `{ loose: true }`, it becomes:
+With `{ privateFieldsAsProperties: true }`, it becomes:
 
 ```javascript
 var Foo = function Foo() {

--- a/docs/plugin-proposal-private-property-in-object.md
+++ b/docs/plugin-proposal-private-property-in-object.md
@@ -79,6 +79,20 @@ When true, private property `in` expressions will check own properties (as oppos
 performance and debugging (normal property access vs `.get()`) at the expense
 of potentially leaking "privates" via things like `Object.getOwnPropertyNames`.
 
+> ⚠️ Consider migrating to the top level [`privateFieldsAsProperties`](assumptions.md#privatefieldsasproperties) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "privateFieldsAsProperties": true,
+    "setPublicClassFields": true
+  }
+}
+```
+
+Note that both `privateFieldsAsProperties` and `setPublicClassFields` must be set to `true`.
+
 #### Example
 
 **In**

--- a/docs/plugin-transform-classes.md
+++ b/docs/plugin-transform-classes.md
@@ -125,6 +125,20 @@ require("@babel/core").transformSync("code", {
 
 `boolean`, defaults to `false`.
 
+> ⚠️ Consider migrating to the top level [`assumptions`](assumptions.md) which offers granular control over various `loose` mode deductions Babel has applied.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "constantSuper": true,
+    "noClassCalls": true,
+    "setClassMethods": true,
+    "superIsCallableConstructor": true
+  }
+}
+```
+
 #### Method enumerability
 
 Please note that in loose mode class methods **are** enumerable. This is not in line

--- a/docs/plugin-transform-computed-properties.md
+++ b/docs/plugin-transform-computed-properties.md
@@ -104,6 +104,17 @@ Just like method assignment in classes, in loose mode, computed property names
 use simple assignments instead of being defined. This is unlikely to be an issue
 in production code.
 
+> ⚠️ Consider migrating to the top level [`setComputedProperties`](assumptions.md#setcomputedproperties) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "setComputedProperties": true
+  }
+}
+```
+
 #### Example
 
 **_In_**
@@ -119,6 +130,8 @@ var obj = {
 
 **_Out_**
 
+When `setComputedProperties` is `true`.
+
 ```js
 var _obj;
 
@@ -127,6 +140,21 @@ var obj = ((_obj = {}),
 (_obj["y" + bar] = "noo"),
 (_obj.foo = "foo"),
 (_obj.bar = "bar"),
+_obj);
+```
+
+When `setComputedProperties` is `false`.
+
+```js
+import _defineProperty from "@babel/runtime/helpers/defineProperty";
+
+var _obj;
+
+var obj = ((_obj = {}),
+_defineProperty(_obj, "x" + foo, "heh"),
+_defineProperty(_obj, "y" + bar, "noo"),
+_defineProperty(_obj, "foo", "foo"),
+_defineProperty(_obj, "bar", "bar"),
 _obj);
 ```
 

--- a/docs/plugin-transform-destructuring.md
+++ b/docs/plugin-transform-destructuring.md
@@ -70,6 +70,17 @@ require("@babel/core").transformSync("code", {
 
 Enabling this option will assume that what you want to destructure is an array and won't use `Array.from` on other iterables.
 
+> ⚠️ Consider migrating to the top level [`iterableIsArray`](assumptions.md#iterableisarray) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "iterableIsArray": true
+  }
+}
+```
+
 ### `useBuiltIns`
 
 `boolean`, defaults to `false`.
@@ -116,6 +127,17 @@ An array-like object is an object with a `length` property: for example, `{ 0: "
 While it is _not_ spec-compliant to destructure array-like objects as if they were arrays, there are many objects that would be _iterables_ in modern browsers with `Symbol.iterator` support. Some notable examples are the DOM collections, like `document.querySelectorAll("img.big")`, which are the main use case for this option.
 
 Please note that Babel allows destructuring `arguments` in old engines even if this option is disabled, because it's defined as _iterable_ in the ECMAScript specification.
+
+> ⚠️ Consider migrating to the top level [`arrayLikeIsIterable`](assumptions.md#arraylikeisiterable) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "arrayLikeIsIterable": true
+  }
+}
+```
 
 ## References
 

--- a/docs/plugin-transform-for-of.md
+++ b/docs/plugin-transform-for-of.md
@@ -98,6 +98,18 @@ require("@babel/core").transformSync("code", {
 `boolean`, defaults to `false`
 
 In loose mode, arrays are put in a fast path, thus heavily increasing performance.
+
+> ⚠️ Consider migrating to the top level [`skipForOfIteratorClosing`](assumptions.md#skipforofiteratorclosing) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "skipForOfIteratorClosing": true
+  }
+}
+```
+
 All other iterables will continue to work fine.
 
 #### Example
@@ -137,7 +149,7 @@ for (
 
 #### Abrupt completions
 
-In loose mode an iterator's `return` method will not be called on abrupt completions caused by thrown errors.
+Under the `skipForOfIteratorClosing` assumption, an iterator's `return` method will not be called on abrupt completions caused by thrown errors.
 
 Please see [google/traceur-compiler#1773](https://github.com/google/traceur-compiler/issues/1773) and
 [babel/babel#838](https://github.com/babel/babel/issues/838) for more information.

--- a/docs/plugin-transform-modules-commonjs.md
+++ b/docs/plugin-transform-modules-commonjs.md
@@ -83,8 +83,18 @@ Object.defineProperty(exports, "__esModule", {
 });
 ```
 
-In environments that don't support this you can enable loose mode on `@babel/plugin-transform-modules-commonjs`
-and instead of using `Object.defineProperty` an assignment will be used instead.
+> ⚠️ Consider migrating to the top level [`enumerableModuleMeta`](assumptions.md#enumerablemodulemeta) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "enumerableModuleMeta": true
+  }
+}
+```
+
+In environments that don't support this you can enable the `enumerableModuleMeta` assumption, instead of using `Object.defineProperty` an assignment will be used instead.
 
 ```javascript
 var foo = (exports.foo = 5);

--- a/docs/plugin-transform-parameters.md
+++ b/docs/plugin-transform-parameters.md
@@ -90,14 +90,25 @@ require("@babel/core").transformSync("code", {
 
 In loose mode, parameters with default values will be counted into the arity of the function. This is not spec behavior where these parameters do not add to function arity.
 
-The `loose` implementation is a more performant solution as JavaScript engines will fully optimize a function that doesn't reference `arguments`. Please do your own benchmarking and determine if this option is the right fit for your application.
+> ⚠️ Consider migrating to the top level [`ignoreFunctionLength`](assumptions.md#ignorefunctionlength) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "ignoreFunctionLength": true
+  }
+}
+```
+
+Under the `ignoreFunctionLength` assumption, Babel will generate a more performant solution as JavaScript engines will fully optimize a function that doesn't reference `arguments`. Please do your own benchmarking and determine if this option is the right fit for your application.
 
 ```javascript
 // Spec behavior
 function bar1(arg1 = 1) {}
 bar1.length; // 0
 
-// Loose mode
+// ignoreFunctionLength: true
 function bar1(arg1 = 1) {}
 bar1.length; // 1
 ```

--- a/docs/plugin-transform-spread.md
+++ b/docs/plugin-transform-spread.md
@@ -83,7 +83,18 @@ require("@babel/core").transformSync("code", {
 
 In loose mode, **all** iterables are assumed to be arrays.
 
-Loose mode preserves "holes" when spreading an array (for example, `[ ...Array(2) ]` produces `[ (hole), (hole) ]`). Set loose to `false` to avoid this behaviour.
+> ⚠️ Consider migrating to the top level [`iterableIsArray`](assumptions.md#iterableisarray) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "iterableIsArray": true
+  }
+}
+```
+
+Under the `iterableIsArray` assumption, Babel preserves "holes" when spreading an array (for example, `[ ...Array(2) ]` produces `[ (hole), (hole) ]`). Set `iterableIsArray` to `false` to avoid this behaviour.
 
 > You can read more about configuring plugin options [here](https://babeljs.io/docs/en/plugins#plugin-options)
 
@@ -94,6 +105,17 @@ Loose mode preserves "holes" when spreading an array (for example, `[ ...Array(2
 Added in: `v7.10.0`
 
 This option allows spreading array-like objects as if they were arrays.
+
+> ⚠️ Consider migrating to the top level [`arrayLikeIsIterable`](assumptions.md#arraylikeisiterable) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "arrayLikeIsIterable": true
+  }
+}
+```
 
 An array-like object is an object with a `length` property: for example, `{ 0: "a", 1: "b", length: 2 }`. Note that, like real arrays, array-like objects can have "holes": `{ 1: "a", length: 3 }` is equivalent to `[ (hole), "a", (hole) ]`.
 

--- a/docs/plugin-transform-template-literals.md
+++ b/docs/plugin-transform-template-literals.md
@@ -73,7 +73,18 @@ require("@babel/core").transformSync("code", {
 
 `boolean`, defaults to `false`.
 
-When `true`, tagged template literal objects aren't frozen. All template literal expressions and quasis are combined with the `+` operator instead of with `String.prototype.concat`.
+> ⚠️ Consider migrating to the top level [`mutableTemplateObject`](assumptions.md#mutabletemplateobject) assumption.
+
+```jsonc
+// babel.config.json
+{
+  "assumptions": {
+    "mutableTemplateObject": true
+  }
+}
+```
+
+When `mutableTemplateObject` is `true`, tagged template literal objects aren't frozen. All template literal expressions and quasis are combined with the `+` operator instead of with `String.prototype.concat`.
 
 When `false` or not set, all template literal expressions and quasis are combined with `String.prototype.concat`. It will handle cases with `Symbol.toPrimitive` correctly and throw correctly if template literal expression is a `Symbol()`. See [babel/babel#5791](https://github.com/babel/babel/pull/5791).
 

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -197,6 +197,8 @@ Enable more spec compliant, but potentially slower, transformations for any plug
 
 Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.html) for any plugins in this preset that allow them.
 
+> ⚠️ Consider migrating to the top level [`assumptions`](assumptions.md) available since Babel 7.13.
+
 ### `modules`
 
 `"amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false`, defaults to `"auto"`.


### PR DESCRIPTION
In this PR we promote the alternative `assumptions` usage on the previous `loose` mode docs. I hope it can facilitate the transition from the vague `loose` mode to explicit assumptions.

This PR covers all the `loose` mode docs except `babel-preset-stage-*` since they are deprecated.