### PR TITLE
Fix link in blog post

### DIFF
--- a/website/blog/2020-05-25-7.10.0.md
+++ b/website/blog/2020-05-25-7.10.0.md
@@ -56,7 +56,7 @@ console.log(_ud835_udc9c);
 
 ### Class Properties and Private Methods to `shippedProposals` option of `@babel/preset-env` ([#11451](https://github.com/babel/babel/pull/11451))
 
-Lastly, thanks to [Jùnliàng](github.com/JLHwung) we have added `@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-private-methods` to the [`shippedProposals`](https://babeljs.io/docs/en/babel-preset-env#shippedproposals) option of `@babel/preset-env`. These proposals are not Stage 4 (i.e. part of the ECMAScript standard) yet, but they are already enabled by default in [many JavaScript engines](https://github.com/tc39/proposal-class-fields#implementations).
+Lastly, thanks to [Jùnliàng](https://github.com/JLHwung) we have added `@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-private-methods` to the [`shippedProposals`](https://babeljs.io/docs/en/babel-preset-env#shippedproposals) option of `@babel/preset-env`. These proposals are not Stage 4 (i.e. part of the ECMAScript standard) yet, but they are already enabled by default in [many JavaScript engines](https://github.com/tc39/proposal-class-fields#implementations).
 
 If you aren't familiar:
 


### PR DESCRIPTION
Previously it pointed to https://babel.dev/blog/2020/05/25/github.com/JLHwung due to being relative.