### PR TITLE
docs: Correction for plugin-syntax-decorators

### DIFF
--- a/docs/plugin-syntax-decorators.md
+++ b/docs/plugin-syntax-decorators.md
@@ -48,7 +48,7 @@ Use the legacy (stage 1) decorators syntax.
 
 ### `decoratorsBeforeExport`
 
-`boolean`, defaults to `false`.
+`boolean`
 
 ```js
 // decoratorsBeforeExport: true


### PR DESCRIPTION
[This was changed a few years back](https://github.com/babel/babel/commit/d79b5eeeffab14f89c5be92888965e57fcab6436#diff-201cce1951d30fd696d97469efdf4451f2f406ac45317d947013b70a72c076d3), but this page was never updated to reflect that the `decoratorsBeforeExport` option no longer defaulted to `false`