### PR TITLE
Update team.yml

### DIFF
--- a/website/data/team.yml
+++ b/website/data/team.yml
@@ -207,7 +207,7 @@ alumnus:
     github: motiz88 
     twitter: motiz88
   - name: Sebastian McKenzie
-    github: kittens
+    github: sebmck
     twitter: sebmck
   - name: Stefan Penner
     github: stefanpenner


### PR DESCRIPTION
Corrected Sebastian McKenzie's GitHub account name (it was https://github.com/kittens, which does not appear to be an account identified publicly with Sebastian, nor is it the account associated with his work on Babel).