### PR TITLE
docs: refine Babel config merging strategies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,14 +192,14 @@ babel.config.json < .babelrc < programmatic options from @babel/cli
 
 In other words, `babel.config.json` is overwritten by `.babelrc`, and `.babelrc` is overwritten by programmatic options.
 
-For each config source, Babel prints applicable config items (e.g. [`overrides`](options.md#overrides) and [`.env`](options.md#env)) in the order of ascending priority. Generally each config sources has at least one config item -- the root content of configs. If you have configured `overrides` or `env`, Babel will not print them in the root, but will instead output a separate config item titled as `.overrides[index]`, where `index` is the position of the item. This helps determine whether the item is effective on the input and which configs it will override.
+For each config source, Babel prints applicable config items (e.g. [`overrides`](options.md#overrides) and [`env`](options.md#env)) in the order of ascending priority. Generally each config sources has at least one config item -- the root content of configs. If you have configured `overrides` or `env`, Babel will not print them in the root, but will instead output a separate config item titled as `.overrides[index]`, where `index` is the position of the item. This helps determine whether the item is effective on the input and which configs it will override.
 
 If your input is ignored by `ignore` or `only`, Babel will print that this file is ignored.
 
 ### How Babel merges config items
 
 Babel's configuration merging is relatively straightforward. Options will overwrite existing options
-when they are present, and their value is not `undefined`, with a few special cases:
+when they are present and their value is not `undefined`. There are, however, a few special cases:
 
 - For `assumptions`, `parserOpts` and `generatorOpts`, objects are merged, rather than replaced, using the same logic as top-level options.
 - For `plugins` and `presets`, they are replaced based on the identity of the plugin/preset object/function itself combined with the name of the entry.
@@ -226,7 +226,7 @@ As an example, consider a config with:
 };
 ```
 
-When `NODE_ENV` is `test`, the `test` item will be merged on top of the top-level plugins.
+When `NODE_ENV` is `test`, the `sourceType` option will be replaced and the `assumptions` option will be merged. The effective config is:
 The `sourceType` option will be replaced and the `assumptions` option will be merged, resulting
 in a config as
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,7 +204,7 @@ when they are present and their value is not `undefined`. There are, however, a 
 - For `assumptions`, `parserOpts` and `generatorOpts`, objects are merged, rather than replaced.
 - For `plugins` and `presets`, they are replaced based on the identity of the plugin/preset object/function itself combined with the name of the entry.
 
-#### Option (except Plugin/Preset) merging
+#### Option (except plugin/preset) merging
 
 As an example, consider a config with:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,7 +237,7 @@ BabelConfigMerge(config, newConfigItem);
   sourceType: "module", // sourceType: "script" is overwritten
   assumptions: {
     setClassFields: true,
-    iterableIsArray: true, // assumptions: merged by Object.assign
+    iterableIsArray: true, // assumptions are merged by Object.assign
   },
 });
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,10 +201,10 @@ If your input is ignored by `ignore` or `only`, Babel will print that this file 
 Babel's configuration merging is relatively straightforward. Options will overwrite existing options
 when they are present and their value is not `undefined`. There are, however, a few special cases:
 
-- For `assumptions`, `parserOpts` and `generatorOpts`, objects are merged, rather than replaced, using the same logic as top-level options.
+- For `assumptions`, `parserOpts` and `generatorOpts`, objects are merged, rather than replaced.
 - For `plugins` and `presets`, they are replaced based on the identity of the plugin/preset object/function itself combined with the name of the entry.
 
-#### Option merging
+#### Option (except Plugin/Preset) merging
 
 As an example, consider a config with:
 
@@ -227,8 +227,6 @@ As an example, consider a config with:
 ```
 
 When `NODE_ENV` is `test`, the `sourceType` option will be replaced and the `assumptions` option will be merged. The effective config is:
-The `sourceType` option will be replaced and the `assumptions` option will be merged, resulting
-in a config as
 
 ```js
 {
@@ -256,7 +254,7 @@ overrides: [{
 }]
 ```
 
-The `overrides` item will be merged on top of the top-level plugins. Importantly, the `plugins`
+The `overrides` item will be merged on top of the top-level options. Importantly, the `plugins`
 array as a whole doesn't just replace the top-level one. The merging logic will see that `"./plug"`
 is the same plugin in both cases, and `{ thing: false, field2: true }` will replace the original
 options, resulting in a config as

--- a/docs/options.md
+++ b/docs/options.md
@@ -799,67 +799,7 @@ and will consider it an error otherwise.
 
 ### Merging
 
-Babel's configuration merging is relatively straightforward. Options will overwrite existing options
-when they are present, and their value is not `undefined`, with a few special cases:
-
-- `parserOpts` objects are merged, rather than replaced, using the same logic as top-level options.
-- `generatorOpts` objects are merged, rather than replaced, using the same logic as top-level options.
-- `plugins` and `presets` are replaced based on the identity of the plugin/preset object/function itself combined with the name of the entry.
-
-#### Plugin/Preset merging
-
-As an example, consider a config with:
-
-```js
-plugins: [
-  './other',
-  ['./plug', { thing: true, field1: true }]
-],
-overrides: [{
-  plugins: [
-    ['./plug', { thing: false, field2: true }],
-  ]
-}]
-```
-
-The `overrides` item will be merged on top of the top-level plugins. Importantly, the `plugins`
-array as a whole doesn't just replace the top-level one. The merging logic will see that `"./plug"`
-is the same plugin in both cases, and `{ thing: false, field2: true }` will replace the original
-options, resulting in a config as
-
-```js
-plugins: [
-  './other',
-  ['./plug', { thing: false, field2: true }],
-],
-```
-
-Since merging is based on identity + name, it is considered an error to use the same plugin with
-the same name twice in the same `plugins`/`presets` array. For example
-
-```js
-plugins: ["./plug", "./plug"];
-```
-
-is considered an error, because it's identical to `plugins: ['./plug']`. Additionally, even
-
-```js
-plugins: [["./plug", { one: true }], ["./plug", { two: true }]];
-```
-
-is considered an error, because the second one would just always replace the first one.
-
-If you actually _do_ want to instantiate two separate instances of a plugin, you must assign each one
-a name to disambiguate them. For example:
-
-```js
-plugins: [
-  ["./plug", { one: true }, "first-instance-name"],
-  ["./plug", { two: true }, "second-instance-name"],
-];
-```
-
-because each instance has been given a unique name and this a unique identity.
+Please refer to [How Babel merges config items](configuration.md#how-babel-merges-config-items).
 
 ### Plugin/Preset entries
 


### PR DESCRIPTION
I realize that we didn't mention how we merge `parserOpts`, `generatorOpts` and `assumptions`. This PR documents current merging strategies and updates the examples.

[Preview](https://deploy-preview-2531--babel.netlify.app/docs/en/configuration#how-babel-merges-config-items)

Resolves #2536 