### PR TITLE
Add Standardized alias to @babel/types

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -94,7 +94,7 @@ t.arrowFunctionExpression(params, body, async);
 See also `t.isArrowFunctionExpression(node, opts)` and `t.assertArrowFunctionExpression(node, opts)`.
 
 AST Node `ArrowFunctionExpression` shape:
-- `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+- `params`: `Array<Identifier | Pattern | RestElement>` (required)
 - `body`: `BlockStatement | Expression` (required)
 - `async`: `boolean` (default: `false`)
 - `expression`: `boolean` (required)
@@ -409,6 +409,7 @@ AST Node `ClassMethod` shape:
 - `accessibility`: `"public" | "private" | "protected"` (default: `null`, excluded from builder function)
 - `decorators`: `Array<Decorator>` (default: `null`, excluded from builder function)
 - `optional`: `boolean` (default: `null`, excluded from builder function)
+- `override`: `boolean` (default: `false`, excluded from builder function)
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
@@ -438,6 +439,7 @@ AST Node `ClassPrivateMethod` shape:
 - `decorators`: `Array<Decorator>` (default: `null`, excluded from builder function)
 - `generator`: `boolean` (default: `false`, excluded from builder function)
 - `optional`: `boolean` (default: `null`, excluded from builder function)
+- `override`: `boolean` (default: `false`, excluded from builder function)
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
@@ -491,6 +493,7 @@ AST Node `ClassProperty` shape:
 - `declare`: `boolean` (default: `null`, excluded from builder function)
 - `definite`: `boolean` (default: `null`, excluded from builder function)
 - `optional`: `boolean` (default: `null`, excluded from builder function)
+- `override`: `boolean` (default: `false`, excluded from builder function)
 - `readonly`: `boolean` (default: `null`, excluded from builder function)
 
 Aliases: [`Property`](#property)
@@ -784,13 +787,14 @@ AST Node `DirectiveLiteral` shape:
 #### doExpression
 
 ```javascript
-t.doExpression(body);
+t.doExpression(body, async);
 ```
 
 See also `t.isDoExpression(node, opts)` and `t.assertDoExpression(node, opts)`.
 
 AST Node `DoExpression` shape:
 - `body`: `BlockStatement` (required)
+- `async`: `boolean` (default: `false`)
 
 Aliases: [`Expression`](#expression)
 
@@ -849,7 +853,7 @@ AST Node `EnumBooleanBody` shape:
 - `explicitType`: `boolean` (required)
 - `hasUnknownMembers`: `boolean` (required)
 
-Aliases: [`EnumBody`](#enumbody)
+Aliases: [`Flow`](#flow), [`EnumBody`](#enumbody)
 
 ---
 
@@ -865,7 +869,7 @@ AST Node `EnumBooleanMember` shape:
 - `id`: `Identifier` (required)
 - `init`: `BooleanLiteral` (required)
 
-Aliases: [`EnumMember`](#enummember)
+Aliases: [`Flow`](#flow), [`EnumMember`](#enummember)
 
 ---
 
@@ -881,7 +885,7 @@ AST Node `EnumDeclaration` shape:
 - `id`: `Identifier` (required)
 - `body`: `EnumBooleanBody | EnumNumberBody | EnumStringBody | EnumSymbolBody` (required)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`Flow`](#flow), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -896,7 +900,7 @@ See also `t.isEnumDefaultedMember(node, opts)` and `t.assertEnumDefaultedMember(
 AST Node `EnumDefaultedMember` shape:
 - `id`: `Identifier` (required)
 
-Aliases: [`EnumMember`](#enummember)
+Aliases: [`Flow`](#flow), [`EnumMember`](#enummember)
 
 ---
 
@@ -913,7 +917,7 @@ AST Node `EnumNumberBody` shape:
 - `explicitType`: `boolean` (required)
 - `hasUnknownMembers`: `boolean` (required)
 
-Aliases: [`EnumBody`](#enumbody)
+Aliases: [`Flow`](#flow), [`EnumBody`](#enumbody)
 
 ---
 
@@ -929,7 +933,7 @@ AST Node `EnumNumberMember` shape:
 - `id`: `Identifier` (required)
 - `init`: `NumericLiteral` (required)
 
-Aliases: [`EnumMember`](#enummember)
+Aliases: [`Flow`](#flow), [`EnumMember`](#enummember)
 
 ---
 
@@ -946,7 +950,7 @@ AST Node `EnumStringBody` shape:
 - `explicitType`: `boolean` (required)
 - `hasUnknownMembers`: `boolean` (required)
 
-Aliases: [`EnumBody`](#enumbody)
+Aliases: [`Flow`](#flow), [`EnumBody`](#enumbody)
 
 ---
 
@@ -962,7 +966,7 @@ AST Node `EnumStringMember` shape:
 - `id`: `Identifier` (required)
 - `init`: `StringLiteral` (required)
 
-Aliases: [`EnumMember`](#enummember)
+Aliases: [`Flow`](#flow), [`EnumMember`](#enummember)
 
 ---
 
@@ -978,7 +982,7 @@ AST Node `EnumSymbolBody` shape:
 - `members`: `Array<EnumDefaultedMember>` (required)
 - `hasUnknownMembers`: `boolean` (required)
 
-Aliases: [`EnumBody`](#enumbody)
+Aliases: [`Flow`](#flow), [`EnumBody`](#enumbody)
 
 ---
 
@@ -1184,7 +1188,7 @@ See also `t.isFunctionDeclaration(node, opts)` and `t.assertFunctionDeclaration(
 
 AST Node `FunctionDeclaration` shape:
 - `id`: `Identifier` (default: `null`)
-- `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+- `params`: `Array<Identifier | Pattern | RestElement>` (required)
 - `body`: `BlockStatement` (required)
 - `generator`: `boolean` (default: `false`)
 - `async`: `boolean` (default: `false`)
@@ -1206,7 +1210,7 @@ See also `t.isFunctionExpression(node, opts)` and `t.assertFunctionExpression(no
 
 AST Node `FunctionExpression` shape:
 - `id`: `Identifier` (default: `null`)
-- `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+- `params`: `Array<Identifier | Pattern | RestElement>` (required)
 - `body`: `BlockStatement` (required)
 - `generator`: `boolean` (default: `false`)
 - `async`: `boolean` (default: `false`)
@@ -1392,6 +1396,22 @@ AST Node `ImportSpecifier` shape:
 - `importKind`: `"type" | "typeof"` (default: `null`, excluded from builder function)
 
 Aliases: [`ModuleSpecifier`](#modulespecifier)
+
+---
+
+#### indexedAccessType
+
+```javascript
+t.indexedAccessType(objectType, indexType);
+```
+
+See also `t.isIndexedAccessType(node, opts)` and `t.assertIndexedAccessType(node, opts)`.
+
+AST Node `IndexedAccessType` shape:
+- `objectType`: `FlowType` (required)
+- `indexType`: `FlowType` (required)
+
+Aliases: [`Flow`](#flow), [`FlowType`](#flowtype)
 
 ---
 
@@ -1835,6 +1855,8 @@ t.noop();
 
 See also `t.isNoop(node, opts)` and `t.assertNoop(node, opts)`.
 
+Aliases: [`Miscellaneous`](#miscellaneous)
+
 ---
 
 #### nullLiteral
@@ -1944,7 +1966,7 @@ See also `t.isObjectMethod(node, opts)` and `t.assertObjectMethod(node, opts)`.
 AST Node `ObjectMethod` shape:
 - `kind`: `"method" | "get" | "set"` (default: `'method'`)
 - `key`: if computed then `Expression` else `Identifier | Literal` (required)
-- `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+- `params`: `Array<Identifier | Pattern | RestElement>` (required)
 - `body`: `BlockStatement` (required)
 - `computed`: `boolean` (default: `false`)
 - `generator`: `boolean` (default: `false`)
@@ -2141,6 +2163,23 @@ Aliases: [`Expression`](#expression)
 
 ---
 
+#### optionalIndexedAccessType
+
+```javascript
+t.optionalIndexedAccessType(objectType, indexType);
+```
+
+See also `t.isOptionalIndexedAccessType(node, opts)` and `t.assertOptionalIndexedAccessType(node, opts)`.
+
+AST Node `OptionalIndexedAccessType` shape:
+- `objectType`: `FlowType` (required)
+- `indexType`: `FlowType` (required)
+- `optional`: `boolean` (required)
+
+Aliases: [`Flow`](#flow), [`FlowType`](#flowtype)
+
+---
+
 #### optionalMemberExpression
 
 ```javascript
@@ -2223,6 +2262,8 @@ See also `t.isPlaceholder(node, opts)` and `t.assertPlaceholder(node, opts)`.
 AST Node `Placeholder` shape:
 - `expectedNode`: `"Identifier" | "StringLiteral" | "Expression" | "Statement" | "Declaration" | "BlockStatement" | "ClassBody" | "Pattern"` (required)
 - `name`: `Identifier` (required)
+
+Aliases: [`Miscellaneous`](#miscellaneous)
 
 ---
 
@@ -2488,7 +2529,7 @@ t.tsAnyKeyword();
 
 See also `t.isTSAnyKeyword(node, opts)` and `t.assertTSAnyKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -2503,7 +2544,7 @@ See also `t.isTSArrayType(node, opts)` and `t.assertTSArrayType(node, opts)`.
 AST Node `TSArrayType` shape:
 - `elementType`: `TSType` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2519,7 +2560,7 @@ AST Node `TSAsExpression` shape:
 - `expression`: `Expression` (required)
 - `typeAnnotation`: `TSType` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`TypeScript`](#typescript), [`Expression`](#expression)
 
 ---
 
@@ -2531,7 +2572,7 @@ t.tsBigIntKeyword();
 
 See also `t.isTSBigIntKeyword(node, opts)` and `t.assertTSBigIntKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -2543,7 +2584,7 @@ t.tsBooleanKeyword();
 
 See also `t.isTSBooleanKeyword(node, opts)` and `t.assertTSBooleanKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -2560,7 +2601,7 @@ AST Node `TSCallSignatureDeclaration` shape:
 - `parameters`: `Array<Identifier | RestElement>` (required)
 - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 
-Aliases: [`TSTypeElement`](#tstypeelement)
+Aliases: [`TypeScript`](#typescript), [`TSTypeElement`](#tstypeelement)
 
 ---
 
@@ -2578,7 +2619,7 @@ AST Node `TSConditionalType` shape:
 - `trueType`: `TSType` (required)
 - `falseType`: `TSType` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2595,7 +2636,7 @@ AST Node `TSConstructSignatureDeclaration` shape:
 - `parameters`: `Array<Identifier | RestElement>` (required)
 - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 
-Aliases: [`TSTypeElement`](#tstypeelement)
+Aliases: [`TypeScript`](#typescript), [`TSTypeElement`](#tstypeelement)
 
 ---
 
@@ -2613,7 +2654,7 @@ AST Node `TSConstructorType` shape:
 - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 - `abstract`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2628,13 +2669,13 @@ See also `t.isTSDeclareFunction(node, opts)` and `t.assertTSDeclareFunction(node
 AST Node `TSDeclareFunction` shape:
 - `id`: `Identifier` (default: `null`)
 - `typeParameters`: `TSTypeParameterDeclaration | Noop` (default: `null`)
-- `params`: `Array<Identifier | Pattern | RestElement | TSParameterProperty>` (required)
+- `params`: `Array<Identifier | Pattern | RestElement>` (required)
 - `returnType`: `TSTypeAnnotation | Noop` (default: `null`)
 - `async`: `boolean` (default: `false`, excluded from builder function)
 - `declare`: `boolean` (default: `null`, excluded from builder function)
 - `generator`: `boolean` (default: `false`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -2660,7 +2701,10 @@ AST Node `TSDeclareMethod` shape:
 - `generator`: `boolean` (default: `false`, excluded from builder function)
 - `kind`: `"get" | "set" | "method" | "constructor"` (default: `'method'`, excluded from builder function)
 - `optional`: `boolean` (default: `null`, excluded from builder function)
+- `override`: `boolean` (default: `false`, excluded from builder function)
 - `static`: `boolean` (default: `false`, excluded from builder function)
+
+Aliases: [`TypeScript`](#typescript)
 
 ---
 
@@ -2679,7 +2723,7 @@ AST Node `TSEnumDeclaration` shape:
 - `declare`: `boolean` (default: `null`, excluded from builder function)
 - `initializer`: `Expression` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -2695,6 +2739,8 @@ AST Node `TSEnumMember` shape:
 - `id`: `Identifier | StringLiteral` (required)
 - `initializer`: `Expression` (default: `null`)
 
+Aliases: [`TypeScript`](#typescript)
+
 ---
 
 #### tsExportAssignment
@@ -2708,7 +2754,7 @@ See also `t.isTSExportAssignment(node, opts)` and `t.assertTSExportAssignment(no
 AST Node `TSExportAssignment` shape:
 - `expression`: `Expression` (required)
 
-Aliases: [`Statement`](#statement)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement)
 
 ---
 
@@ -2724,7 +2770,7 @@ AST Node `TSExpressionWithTypeArguments` shape:
 - `expression`: `TSEntityName` (required)
 - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2738,6 +2784,8 @@ See also `t.isTSExternalModuleReference(node, opts)` and `t.assertTSExternalModu
 
 AST Node `TSExternalModuleReference` shape:
 - `expression`: `StringLiteral` (required)
+
+Aliases: [`TypeScript`](#typescript)
 
 ---
 
@@ -2754,7 +2802,7 @@ AST Node `TSFunctionType` shape:
 - `parameters`: `Array<Identifier | RestElement>` (required)
 - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2771,7 +2819,7 @@ AST Node `TSImportEqualsDeclaration` shape:
 - `moduleReference`: `TSEntityName | TSExternalModuleReference` (required)
 - `isExport`: `boolean` (required)
 
-Aliases: [`Statement`](#statement)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement)
 
 ---
 
@@ -2788,7 +2836,7 @@ AST Node `TSImportType` shape:
 - `qualifier`: `TSEntityName` (default: `null`)
 - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2804,8 +2852,9 @@ AST Node `TSIndexSignature` shape:
 - `parameters`: `Array<Identifier>` (required)
 - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 - `readonly`: `boolean` (default: `null`, excluded from builder function)
+- `static`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`TSTypeElement`](#tstypeelement)
+Aliases: [`TypeScript`](#typescript), [`TSTypeElement`](#tstypeelement)
 
 ---
 
@@ -2821,7 +2870,7 @@ AST Node `TSIndexedAccessType` shape:
 - `objectType`: `TSType` (required)
 - `indexType`: `TSType` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2836,7 +2885,7 @@ See also `t.isTSInferType(node, opts)` and `t.assertTSInferType(node, opts)`.
 AST Node `TSInferType` shape:
 - `typeParameter`: `TSTypeParameter` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2850,6 +2899,8 @@ See also `t.isTSInterfaceBody(node, opts)` and `t.assertTSInterfaceBody(node, op
 
 AST Node `TSInterfaceBody` shape:
 - `body`: `Array<TSTypeElement>` (required)
+
+Aliases: [`TypeScript`](#typescript)
 
 ---
 
@@ -2868,7 +2919,7 @@ AST Node `TSInterfaceDeclaration` shape:
 - `body`: `TSInterfaceBody` (required)
 - `declare`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -2883,7 +2934,7 @@ See also `t.isTSIntersectionType(node, opts)` and `t.assertTSIntersectionType(no
 AST Node `TSIntersectionType` shape:
 - `types`: `Array<TSType>` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2895,7 +2946,7 @@ t.tsIntrinsicKeyword();
 
 See also `t.isTSIntrinsicKeyword(node, opts)` and `t.assertTSIntrinsicKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -2908,9 +2959,9 @@ t.tsLiteralType(literal);
 See also `t.isTSLiteralType(node, opts)` and `t.assertTSLiteralType(node, opts)`.
 
 AST Node `TSLiteralType` shape:
-- `literal`: `NumericLiteral | StringLiteral | BooleanLiteral | BigIntLiteral` (required)
+- `literal`: `NumericLiteral | StringLiteral | BooleanLiteral | BigIntLiteral | UnaryExpression` (required)
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -2929,7 +2980,7 @@ AST Node `TSMappedType` shape:
 - `optional`: `boolean` (default: `null`, excluded from builder function)
 - `readonly`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -2947,9 +2998,10 @@ AST Node `TSMethodSignature` shape:
 - `parameters`: `Array<Identifier | RestElement>` (required)
 - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 - `computed`: `boolean` (default: `null`, excluded from builder function)
+- `kind`: `"method" | "get" | "set"` (required)
 - `optional`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`TSTypeElement`](#tstypeelement)
+Aliases: [`TypeScript`](#typescript), [`TSTypeElement`](#tstypeelement)
 
 ---
 
@@ -2964,7 +3016,7 @@ See also `t.isTSModuleBlock(node, opts)` and `t.assertTSModuleBlock(node, opts)`
 AST Node `TSModuleBlock` shape:
 - `body`: `Array<Statement>` (required)
 
-Aliases: [`Scopable`](#scopable), [`Block`](#block), [`BlockParent`](#blockparent)
+Aliases: [`TypeScript`](#typescript), [`Scopable`](#scopable), [`Block`](#block), [`BlockParent`](#blockparent)
 
 ---
 
@@ -2982,7 +3034,7 @@ AST Node `TSModuleDeclaration` shape:
 - `declare`: `boolean` (default: `null`, excluded from builder function)
 - `global`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -2999,6 +3051,8 @@ AST Node `TSNamedTupleMember` shape:
 - `elementType`: `TSType` (required)
 - `optional`: `boolean` (default: `false`)
 
+Aliases: [`TypeScript`](#typescript)
+
 ---
 
 #### tsNamespaceExportDeclaration
@@ -3012,7 +3066,7 @@ See also `t.isTSNamespaceExportDeclaration(node, opts)` and `t.assertTSNamespace
 AST Node `TSNamespaceExportDeclaration` shape:
 - `id`: `Identifier` (required)
 
-Aliases: [`Statement`](#statement)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement)
 
 ---
 
@@ -3024,7 +3078,7 @@ t.tsNeverKeyword();
 
 See also `t.isTSNeverKeyword(node, opts)` and `t.assertTSNeverKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3039,7 +3093,7 @@ See also `t.isTSNonNullExpression(node, opts)` and `t.assertTSNonNullExpression(
 AST Node `TSNonNullExpression` shape:
 - `expression`: `Expression` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`TypeScript`](#typescript), [`Expression`](#expression)
 
 ---
 
@@ -3051,7 +3105,7 @@ t.tsNullKeyword();
 
 See also `t.isTSNullKeyword(node, opts)` and `t.assertTSNullKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3063,7 +3117,7 @@ t.tsNumberKeyword();
 
 See also `t.isTSNumberKeyword(node, opts)` and `t.assertTSNumberKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3075,7 +3129,7 @@ t.tsObjectKeyword();
 
 See also `t.isTSObjectKeyword(node, opts)` and `t.assertTSObjectKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3090,7 +3144,7 @@ See also `t.isTSOptionalType(node, opts)` and `t.assertTSOptionalType(node, opts
 AST Node `TSOptionalType` shape:
 - `typeAnnotation`: `TSType` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3107,7 +3161,7 @@ AST Node `TSParameterProperty` shape:
 - `accessibility`: `"public" | "private" | "protected"` (default: `null`, excluded from builder function)
 - `readonly`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`LVal`](#lval)
+Aliases: [`TypeScript`](#typescript), [`LVal`](#lval)
 
 ---
 
@@ -3122,7 +3176,7 @@ See also `t.isTSParenthesizedType(node, opts)` and `t.assertTSParenthesizedType(
 AST Node `TSParenthesizedType` shape:
 - `typeAnnotation`: `TSType` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3142,7 +3196,7 @@ AST Node `TSPropertySignature` shape:
 - `optional`: `boolean` (default: `null`, excluded from builder function)
 - `readonly`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`TSTypeElement`](#tstypeelement)
+Aliases: [`TypeScript`](#typescript), [`TSTypeElement`](#tstypeelement)
 
 ---
 
@@ -3158,7 +3212,7 @@ AST Node `TSQualifiedName` shape:
 - `left`: `TSEntityName` (required)
 - `right`: `Identifier` (required)
 
-Aliases: [`TSEntityName`](#tsentityname)
+Aliases: [`TypeScript`](#typescript), [`TSEntityName`](#tsentityname)
 
 ---
 
@@ -3173,7 +3227,7 @@ See also `t.isTSRestType(node, opts)` and `t.assertTSRestType(node, opts)`.
 AST Node `TSRestType` shape:
 - `typeAnnotation`: `TSType` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3185,7 +3239,7 @@ t.tsStringKeyword();
 
 See also `t.isTSStringKeyword(node, opts)` and `t.assertTSStringKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3197,7 +3251,7 @@ t.tsSymbolKeyword();
 
 See also `t.isTSSymbolKeyword(node, opts)` and `t.assertTSSymbolKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3209,7 +3263,7 @@ t.tsThisType();
 
 See also `t.isTSThisType(node, opts)` and `t.assertTSThisType(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3224,7 +3278,7 @@ See also `t.isTSTupleType(node, opts)` and `t.assertTSTupleType(node, opts)`.
 AST Node `TSTupleType` shape:
 - `elementTypes`: `Array<TSType | TSNamedTupleMember>` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3242,7 +3296,7 @@ AST Node `TSTypeAliasDeclaration` shape:
 - `typeAnnotation`: `TSType` (required)
 - `declare`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`TypeScript`](#typescript), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -3256,6 +3310,8 @@ See also `t.isTSTypeAnnotation(node, opts)` and `t.assertTSTypeAnnotation(node, 
 
 AST Node `TSTypeAnnotation` shape:
 - `typeAnnotation`: `TSType` (required)
+
+Aliases: [`TypeScript`](#typescript)
 
 ---
 
@@ -3271,7 +3327,7 @@ AST Node `TSTypeAssertion` shape:
 - `typeAnnotation`: `TSType` (required)
 - `expression`: `Expression` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`TypeScript`](#typescript), [`Expression`](#expression)
 
 ---
 
@@ -3286,7 +3342,7 @@ See also `t.isTSTypeLiteral(node, opts)` and `t.assertTSTypeLiteral(node, opts)`
 AST Node `TSTypeLiteral` shape:
 - `members`: `Array<TSTypeElement>` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3302,7 +3358,7 @@ AST Node `TSTypeOperator` shape:
 - `typeAnnotation`: `TSType` (required)
 - `operator`: `string` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3319,6 +3375,8 @@ AST Node `TSTypeParameter` shape:
 - `default`: `TSType` (default: `null`)
 - `name`: `string` (required)
 
+Aliases: [`TypeScript`](#typescript)
+
 ---
 
 #### tsTypeParameterDeclaration
@@ -3332,6 +3390,8 @@ See also `t.isTSTypeParameterDeclaration(node, opts)` and `t.assertTSTypeParamet
 AST Node `TSTypeParameterDeclaration` shape:
 - `params`: `Array<TSTypeParameter>` (required)
 
+Aliases: [`TypeScript`](#typescript)
+
 ---
 
 #### tsTypeParameterInstantiation
@@ -3344,6 +3404,8 @@ See also `t.isTSTypeParameterInstantiation(node, opts)` and `t.assertTSTypeParam
 
 AST Node `TSTypeParameterInstantiation` shape:
 - `params`: `Array<TSType>` (required)
+
+Aliases: [`TypeScript`](#typescript)
 
 ---
 
@@ -3360,7 +3422,7 @@ AST Node `TSTypePredicate` shape:
 - `typeAnnotation`: `TSTypeAnnotation` (default: `null`)
 - `asserts`: `boolean` (default: `null`)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3375,7 +3437,7 @@ See also `t.isTSTypeQuery(node, opts)` and `t.assertTSTypeQuery(node, opts)`.
 AST Node `TSTypeQuery` shape:
 - `exprName`: `TSEntityName | TSImportType` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3391,7 +3453,7 @@ AST Node `TSTypeReference` shape:
 - `typeName`: `TSEntityName` (required)
 - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3403,7 +3465,7 @@ t.tsUndefinedKeyword();
 
 See also `t.isTSUndefinedKeyword(node, opts)` and `t.assertTSUndefinedKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3418,7 +3480,7 @@ See also `t.isTSUnionType(node, opts)` and `t.assertTSUnionType(node, opts)`.
 AST Node `TSUnionType` shape:
 - `types`: `Array<TSType>` (required)
 
-Aliases: [`TSType`](#tstype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype)
 
 ---
 
@@ -3430,7 +3492,7 @@ t.tsUnknownKeyword();
 
 See also `t.isTSUnknownKeyword(node, opts)` and `t.assertTSUnknownKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3442,7 +3504,7 @@ t.tsVoidKeyword();
 
 See also `t.isTSVoidKeyword(node, opts)` and `t.assertTSVoidKeyword(node, opts)`.
 
-Aliases: [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
+Aliases: [`TypeScript`](#typescript), [`TSType`](#tstype), [`TSBaseType`](#tsbasetype)
 
 ---
 
@@ -3749,6 +3811,8 @@ See also `t.isV8IntrinsicIdentifier(node, opts)` and `t.assertV8IntrinsicIdentif
 
 AST Node `V8IntrinsicIdentifier` shape:
 - `name`: `string` (required)
+
+Aliases: [`Miscellaneous`](#miscellaneous)
 
 ---
 
@@ -4110,10 +4174,20 @@ Covered nodes:
 - [`DeclareVariable`](#declarevariable)
 - [`DeclaredPredicate`](#declaredpredicate)
 - [`EmptyTypeAnnotation`](#emptytypeannotation)
+- [`EnumBooleanBody`](#enumbooleanbody)
+- [`EnumBooleanMember`](#enumbooleanmember)
+- [`EnumDeclaration`](#enumdeclaration)
+- [`EnumDefaultedMember`](#enumdefaultedmember)
+- [`EnumNumberBody`](#enumnumberbody)
+- [`EnumNumberMember`](#enumnumbermember)
+- [`EnumStringBody`](#enumstringbody)
+- [`EnumStringMember`](#enumstringmember)
+- [`EnumSymbolBody`](#enumsymbolbody)
 - [`ExistsTypeAnnotation`](#existstypeannotation)
 - [`FunctionTypeAnnotation`](#functiontypeannotation)
 - [`FunctionTypeParam`](#functiontypeparam)
 - [`GenericTypeAnnotation`](#generictypeannotation)
+- [`IndexedAccessType`](#indexedaccesstype)
 - [`InferredPredicate`](#inferredpredicate)
 - [`InterfaceDeclaration`](#interfacedeclaration)
 - [`InterfaceExtends`](#interfaceextends)
@@ -4131,6 +4205,7 @@ Covered nodes:
 - [`ObjectTypeProperty`](#objecttypeproperty)
 - [`ObjectTypeSpreadProperty`](#objecttypespreadproperty)
 - [`OpaqueType`](#opaquetype)
+- [`OptionalIndexedAccessType`](#optionalindexedaccesstype)
 - [`QualifiedTypeIdentifier`](#qualifiedtypeidentifier)
 - [`StringLiteralTypeAnnotation`](#stringliteraltypeannotation)
 - [`StringTypeAnnotation`](#stringtypeannotation)
@@ -4216,6 +4291,7 @@ Covered nodes:
 - [`ExistsTypeAnnotation`](#existstypeannotation)
 - [`FunctionTypeAnnotation`](#functiontypeannotation)
 - [`GenericTypeAnnotation`](#generictypeannotation)
+- [`IndexedAccessType`](#indexedaccesstype)
 - [`InterfaceTypeAnnotation`](#interfacetypeannotation)
 - [`IntersectionTypeAnnotation`](#intersectiontypeannotation)
 - [`MixedTypeAnnotation`](#mixedtypeannotation)
@@ -4224,6 +4300,7 @@ Covered nodes:
 - [`NumberLiteralTypeAnnotation`](#numberliteraltypeannotation)
 - [`NumberTypeAnnotation`](#numbertypeannotation)
 - [`ObjectTypeAnnotation`](#objecttypeannotation)
+- [`OptionalIndexedAccessType`](#optionalindexedaccesstype)
 - [`StringLiteralTypeAnnotation`](#stringliteraltypeannotation)
 - [`StringTypeAnnotation`](#stringtypeannotation)
 - [`SymbolTypeAnnotation`](#symboltypeannotation)
@@ -4393,6 +4470,18 @@ Covered nodes:
 - [`ClassMethod`](#classmethod)
 - [`ClassPrivateMethod`](#classprivatemethod)
 - [`ObjectMethod`](#objectmethod)
+
+#### Miscellaneous
+
+A cover of non-standard AST types that are sometimes useful for development.
+```javascript
+t.isMiscellaneous(node);
+```
+
+Covered nodes: 
+- [`Noop`](#noop)
+- [`Placeholder`](#placeholder)
+- [`V8IntrinsicIdentifier`](#v8intrinsicidentifier)
 
 #### ModuleDeclaration
 
@@ -4693,6 +4782,78 @@ Covered nodes:
 - [`ReturnStatement`](#returnstatement)
 - [`ThrowStatement`](#throwstatement)
 - [`YieldExpression`](#yieldexpression)
+
+#### TypeScript
+
+A cover of AST nodes defined for TypeScript.
+```javascript
+t.isTypeScript(node);
+```
+
+Covered nodes: 
+- [`TSAnyKeyword`](#tsanykeyword)
+- [`TSArrayType`](#tsarraytype)
+- [`TSAsExpression`](#tsasexpression)
+- [`TSBigIntKeyword`](#tsbigintkeyword)
+- [`TSBooleanKeyword`](#tsbooleankeyword)
+- [`TSCallSignatureDeclaration`](#tscallsignaturedeclaration)
+- [`TSConditionalType`](#tsconditionaltype)
+- [`TSConstructSignatureDeclaration`](#tsconstructsignaturedeclaration)
+- [`TSConstructorType`](#tsconstructortype)
+- [`TSDeclareFunction`](#tsdeclarefunction)
+- [`TSDeclareMethod`](#tsdeclaremethod)
+- [`TSEnumDeclaration`](#tsenumdeclaration)
+- [`TSEnumMember`](#tsenummember)
+- [`TSExportAssignment`](#tsexportassignment)
+- [`TSExpressionWithTypeArguments`](#tsexpressionwithtypearguments)
+- [`TSExternalModuleReference`](#tsexternalmodulereference)
+- [`TSFunctionType`](#tsfunctiontype)
+- [`TSImportEqualsDeclaration`](#tsimportequalsdeclaration)
+- [`TSImportType`](#tsimporttype)
+- [`TSIndexSignature`](#tsindexsignature)
+- [`TSIndexedAccessType`](#tsindexedaccesstype)
+- [`TSInferType`](#tsinfertype)
+- [`TSInterfaceBody`](#tsinterfacebody)
+- [`TSInterfaceDeclaration`](#tsinterfacedeclaration)
+- [`TSIntersectionType`](#tsintersectiontype)
+- [`TSIntrinsicKeyword`](#tsintrinsickeyword)
+- [`TSLiteralType`](#tsliteraltype)
+- [`TSMappedType`](#tsmappedtype)
+- [`TSMethodSignature`](#tsmethodsignature)
+- [`TSModuleBlock`](#tsmoduleblock)
+- [`TSModuleDeclaration`](#tsmoduledeclaration)
+- [`TSNamedTupleMember`](#tsnamedtuplemember)
+- [`TSNamespaceExportDeclaration`](#tsnamespaceexportdeclaration)
+- [`TSNeverKeyword`](#tsneverkeyword)
+- [`TSNonNullExpression`](#tsnonnullexpression)
+- [`TSNullKeyword`](#tsnullkeyword)
+- [`TSNumberKeyword`](#tsnumberkeyword)
+- [`TSObjectKeyword`](#tsobjectkeyword)
+- [`TSOptionalType`](#tsoptionaltype)
+- [`TSParameterProperty`](#tsparameterproperty)
+- [`TSParenthesizedType`](#tsparenthesizedtype)
+- [`TSPropertySignature`](#tspropertysignature)
+- [`TSQualifiedName`](#tsqualifiedname)
+- [`TSRestType`](#tsresttype)
+- [`TSStringKeyword`](#tsstringkeyword)
+- [`TSSymbolKeyword`](#tssymbolkeyword)
+- [`TSThisType`](#tsthistype)
+- [`TSTupleType`](#tstupletype)
+- [`TSTypeAliasDeclaration`](#tstypealiasdeclaration)
+- [`TSTypeAnnotation`](#tstypeannotation)
+- [`TSTypeAssertion`](#tstypeassertion)
+- [`TSTypeLiteral`](#tstypeliteral)
+- [`TSTypeOperator`](#tstypeoperator)
+- [`TSTypeParameter`](#tstypeparameter)
+- [`TSTypeParameterDeclaration`](#tstypeparameterdeclaration)
+- [`TSTypeParameterInstantiation`](#tstypeparameterinstantiation)
+- [`TSTypePredicate`](#tstypepredicate)
+- [`TSTypeQuery`](#tstypequery)
+- [`TSTypeReference`](#tstypereference)
+- [`TSUndefinedKeyword`](#tsundefinedkeyword)
+- [`TSUnionType`](#tsuniontype)
+- [`TSUnknownKeyword`](#tsunknownkeyword)
+- [`TSVoidKeyword`](#tsvoidkeyword)
 
 #### UnaryLike
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -36,6 +36,8 @@ t.argumentPlaceholder();
 
 See also `t.isArgumentPlaceholder(node, opts)` and `t.assertArgumentPlaceholder(node, opts)`.
 
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal)
+
 ---
 
 #### arrayExpression
@@ -49,7 +51,7 @@ See also `t.isArrayExpression(node, opts)` and `t.assertArrayExpression(node, op
 AST Node `ArrayExpression` shape:
 - `elements`: `Array<null | Expression | SpreadElement>` (default: `[]`)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -66,7 +68,7 @@ AST Node `ArrayPattern` shape:
 - `decorators`: `Array<Decorator>` (default: `null`, excluded from builder function)
 - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Pattern`](#pattern), [`PatternLike`](#patternlike), [`LVal`](#lval)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Pattern`](#pattern), [`PatternLike`](#patternlike), [`LVal`](#lval)
 
 ---
 
@@ -102,7 +104,7 @@ AST Node `ArrowFunctionExpression` shape:
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Scopable`](#scopable), [`Function`](#function), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Expression`](#expression), [`Pureish`](#pureish)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Function`](#function), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Expression`](#expression), [`Pureish`](#pureish)
 
 ---
 
@@ -119,7 +121,7 @@ AST Node `AssignmentExpression` shape:
 - `left`: `LVal` (required)
 - `right`: `Expression` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -137,7 +139,7 @@ AST Node `AssignmentPattern` shape:
 - `decorators`: `Array<Decorator>` (default: `null`, excluded from builder function)
 - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Pattern`](#pattern), [`PatternLike`](#patternlike), [`LVal`](#lval)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Pattern`](#pattern), [`PatternLike`](#patternlike), [`LVal`](#lval)
 
 ---
 
@@ -152,7 +154,7 @@ See also `t.isAwaitExpression(node, opts)` and `t.assertAwaitExpression(node, op
 AST Node `AwaitExpression` shape:
 - `argument`: `Expression` (required)
 
-Aliases: [`Expression`](#expression), [`Terminatorless`](#terminatorless)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Terminatorless`](#terminatorless)
 
 ---
 
@@ -167,7 +169,7 @@ See also `t.isBigIntLiteral(node, opts)` and `t.assertBigIntLiteral(node, opts)`
 AST Node `BigIntLiteral` shape:
 - `value`: `string` (required)
 
-Aliases: [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
 
 ---
 
@@ -184,7 +186,7 @@ AST Node `BinaryExpression` shape:
 - `left`: `Expression | PrivateName` (required)
 - `right`: `Expression` (required)
 
-Aliases: [`Binary`](#binary), [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Binary`](#binary), [`Expression`](#expression)
 
 ---
 
@@ -200,7 +202,7 @@ AST Node `BindExpression` shape:
 - `object`: `Expression` (required)
 - `callee`: `Expression` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -216,7 +218,7 @@ AST Node `BlockStatement` shape:
 - `body`: `Array<Statement>` (required)
 - `directives`: `Array<Directive>` (default: `[]`)
 
-Aliases: [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`Block`](#block), [`Statement`](#statement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`Block`](#block), [`Statement`](#statement)
 
 ---
 
@@ -231,7 +233,7 @@ See also `t.isBooleanLiteral(node, opts)` and `t.assertBooleanLiteral(node, opts
 AST Node `BooleanLiteral` shape:
 - `value`: `boolean` (required)
 
-Aliases: [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
 
 ---
 
@@ -273,7 +275,7 @@ See also `t.isBreakStatement(node, opts)` and `t.assertBreakStatement(node, opts
 AST Node `BreakStatement` shape:
 - `label`: `Identifier` (default: `null`)
 
-Aliases: [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
 
 ---
 
@@ -292,7 +294,7 @@ AST Node `CallExpression` shape:
 - `typeArguments`: `TypeParameterInstantiation` (default: `null`, excluded from builder function)
 - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`, excluded from builder function)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -308,7 +310,7 @@ AST Node `CatchClause` shape:
 - `param`: `Identifier | ArrayPattern | ObjectPattern` (default: `null`)
 - `body`: `BlockStatement` (required)
 
-Aliases: [`Scopable`](#scopable), [`BlockParent`](#blockparent)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`BlockParent`](#blockparent)
 
 ---
 
@@ -322,6 +324,8 @@ See also `t.isClassBody(node, opts)` and `t.assertClassBody(node, opts)`.
 
 AST Node `ClassBody` shape:
 - `body`: `Array<ClassMethod | ClassPrivateMethod | ClassProperty | ClassPrivateProperty | TSDeclareMethod | TSIndexSignature>` (required)
+
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
 
 ---
 
@@ -345,7 +349,7 @@ AST Node `ClassDeclaration` shape:
 - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Scopable`](#scopable), [`Class`](#class), [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Class`](#class), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -367,7 +371,7 @@ AST Node `ClassExpression` shape:
 - `superTypeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Scopable`](#scopable), [`Class`](#class), [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Class`](#class), [`Expression`](#expression)
 
 ---
 
@@ -413,7 +417,7 @@ AST Node `ClassMethod` shape:
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Function`](#function), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Method`](#method)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Function`](#function), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Method`](#method)
 
 ---
 
@@ -443,7 +447,7 @@ AST Node `ClassPrivateMethod` shape:
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Function`](#function), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Method`](#method), [`Private`](#private)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Function`](#function), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Method`](#method), [`Private`](#private)
 
 ---
 
@@ -462,7 +466,7 @@ AST Node `ClassPrivateProperty` shape:
 - `static` (required)
 - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Property`](#property), [`Private`](#private)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Property`](#property), [`Private`](#private)
 
 ---
 
@@ -496,7 +500,7 @@ AST Node `ClassProperty` shape:
 - `override`: `boolean` (default: `false`, excluded from builder function)
 - `readonly`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`Property`](#property)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Property`](#property)
 
 ---
 
@@ -513,7 +517,7 @@ AST Node `ConditionalExpression` shape:
 - `consequent`: `Expression` (required)
 - `alternate`: `Expression` (required)
 
-Aliases: [`Expression`](#expression), [`Conditional`](#conditional)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Conditional`](#conditional)
 
 ---
 
@@ -528,7 +532,7 @@ See also `t.isContinueStatement(node, opts)` and `t.assertContinueStatement(node
 AST Node `ContinueStatement` shape:
 - `label`: `Identifier` (default: `null`)
 
-Aliases: [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
 
 ---
 
@@ -540,7 +544,7 @@ t.debuggerStatement();
 
 See also `t.isDebuggerStatement(node, opts)` and `t.assertDebuggerStatement(node, opts)`.
 
-Aliases: [`Statement`](#statement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement)
 
 ---
 
@@ -555,7 +559,7 @@ See also `t.isDecimalLiteral(node, opts)` and `t.assertDecimalLiteral(node, opts
 AST Node `DecimalLiteral` shape:
 - `value`: `string` (required)
 
-Aliases: [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
 
 ---
 
@@ -756,6 +760,8 @@ See also `t.isDecorator(node, opts)` and `t.assertDecorator(node, opts)`.
 AST Node `Decorator` shape:
 - `expression`: `Expression` (required)
 
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal)
+
 ---
 
 #### directive
@@ -769,6 +775,8 @@ See also `t.isDirective(node, opts)` and `t.assertDirective(node, opts)`.
 AST Node `Directive` shape:
 - `value`: `DirectiveLiteral` (required)
 
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
+
 ---
 
 #### directiveLiteral
@@ -781,6 +789,8 @@ See also `t.isDirectiveLiteral(node, opts)` and `t.assertDirectiveLiteral(node, 
 
 AST Node `DirectiveLiteral` shape:
 - `value`: `string` (required)
+
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
 
 ---
 
@@ -796,7 +806,7 @@ AST Node `DoExpression` shape:
 - `body`: `BlockStatement` (required)
 - `async`: `boolean` (default: `false`)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -812,7 +822,7 @@ AST Node `DoWhileStatement` shape:
 - `test`: `Expression` (required)
 - `body`: `Statement` (required)
 
-Aliases: [`Statement`](#statement), [`BlockParent`](#blockparent), [`Loop`](#loop), [`While`](#while), [`Scopable`](#scopable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`BlockParent`](#blockparent), [`Loop`](#loop), [`While`](#while), [`Scopable`](#scopable)
 
 ---
 
@@ -824,7 +834,7 @@ t.emptyStatement();
 
 See also `t.isEmptyStatement(node, opts)` and `t.assertEmptyStatement(node, opts)`.
 
-Aliases: [`Statement`](#statement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement)
 
 ---
 
@@ -1011,7 +1021,7 @@ AST Node `ExportAllDeclaration` shape:
 - `assertions`: `Array<ImportAttribute>` (default: `null`, excluded from builder function)
 - `exportKind`: `"type" | "value"` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration), [`ExportDeclaration`](#exportdeclaration)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration), [`ExportDeclaration`](#exportdeclaration)
 
 ---
 
@@ -1026,7 +1036,7 @@ See also `t.isExportDefaultDeclaration(node, opts)` and `t.assertExportDefaultDe
 AST Node `ExportDefaultDeclaration` shape:
 - `declaration`: `FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression` (required)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration), [`ExportDeclaration`](#exportdeclaration)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration), [`ExportDeclaration`](#exportdeclaration)
 
 ---
 
@@ -1041,7 +1051,7 @@ See also `t.isExportDefaultSpecifier(node, opts)` and `t.assertExportDefaultSpec
 AST Node `ExportDefaultSpecifier` shape:
 - `exported`: `Identifier` (required)
 
-Aliases: [`ModuleSpecifier`](#modulespecifier)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`ModuleSpecifier`](#modulespecifier)
 
 ---
 
@@ -1060,7 +1070,7 @@ AST Node `ExportNamedDeclaration` shape:
 - `assertions`: `Array<ImportAttribute>` (default: `null`, excluded from builder function)
 - `exportKind`: `"type" | "value"` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration), [`ExportDeclaration`](#exportdeclaration)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration), [`ExportDeclaration`](#exportdeclaration)
 
 ---
 
@@ -1075,7 +1085,7 @@ See also `t.isExportNamespaceSpecifier(node, opts)` and `t.assertExportNamespace
 AST Node `ExportNamespaceSpecifier` shape:
 - `exported`: `Identifier` (required)
 
-Aliases: [`ModuleSpecifier`](#modulespecifier)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`ModuleSpecifier`](#modulespecifier)
 
 ---
 
@@ -1091,7 +1101,7 @@ AST Node `ExportSpecifier` shape:
 - `local`: `Identifier` (required)
 - `exported`: `Identifier | StringLiteral` (required)
 
-Aliases: [`ModuleSpecifier`](#modulespecifier)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`ModuleSpecifier`](#modulespecifier)
 
 ---
 
@@ -1106,7 +1116,7 @@ See also `t.isExpressionStatement(node, opts)` and `t.assertExpressionStatement(
 AST Node `ExpressionStatement` shape:
 - `expression`: `Expression` (required)
 
-Aliases: [`Statement`](#statement), [`ExpressionWrapper`](#expressionwrapper)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`ExpressionWrapper`](#expressionwrapper)
 
 ---
 
@@ -1123,6 +1133,8 @@ AST Node `File` shape:
 - `comments`: `Array<CommentBlock | CommentLine>` (default: `null`)
 - `tokens`: `Array<any>` (default: `null`)
 
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
+
 ---
 
 #### forInStatement
@@ -1138,7 +1150,7 @@ AST Node `ForInStatement` shape:
 - `right`: `Expression` (required)
 - `body`: `Statement` (required)
 
-Aliases: [`Scopable`](#scopable), [`Statement`](#statement), [`For`](#for), [`BlockParent`](#blockparent), [`Loop`](#loop), [`ForXStatement`](#forxstatement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Statement`](#statement), [`For`](#for), [`BlockParent`](#blockparent), [`Loop`](#loop), [`ForXStatement`](#forxstatement)
 
 ---
 
@@ -1156,7 +1168,7 @@ AST Node `ForOfStatement` shape:
 - `body`: `Statement` (required)
 - `await`: `boolean` (default: `false`)
 
-Aliases: [`Scopable`](#scopable), [`Statement`](#statement), [`For`](#for), [`BlockParent`](#blockparent), [`Loop`](#loop), [`ForXStatement`](#forxstatement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Statement`](#statement), [`For`](#for), [`BlockParent`](#blockparent), [`Loop`](#loop), [`ForXStatement`](#forxstatement)
 
 ---
 
@@ -1174,7 +1186,7 @@ AST Node `ForStatement` shape:
 - `update`: `Expression` (default: `null`)
 - `body`: `Statement` (required)
 
-Aliases: [`Scopable`](#scopable), [`Statement`](#statement), [`For`](#for), [`BlockParent`](#blockparent), [`Loop`](#loop)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Statement`](#statement), [`For`](#for), [`BlockParent`](#blockparent), [`Loop`](#loop)
 
 ---
 
@@ -1196,7 +1208,7 @@ AST Node `FunctionDeclaration` shape:
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Scopable`](#scopable), [`Function`](#function), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Statement`](#statement), [`Pureish`](#pureish), [`Declaration`](#declaration)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Function`](#function), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Statement`](#statement), [`Pureish`](#pureish), [`Declaration`](#declaration)
 
 ---
 
@@ -1217,7 +1229,7 @@ AST Node `FunctionExpression` shape:
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Scopable`](#scopable), [`Function`](#function), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Expression`](#expression), [`Pureish`](#pureish)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`Function`](#function), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Expression`](#expression), [`Pureish`](#pureish)
 
 ---
 
@@ -1287,7 +1299,7 @@ AST Node `Identifier` shape:
 - `optional`: `boolean` (default: `null`, excluded from builder function)
 - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Expression`](#expression), [`PatternLike`](#patternlike), [`LVal`](#lval), [`TSEntityName`](#tsentityname)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`PatternLike`](#patternlike), [`LVal`](#lval), [`TSEntityName`](#tsentityname)
 
 ---
 
@@ -1304,7 +1316,7 @@ AST Node `IfStatement` shape:
 - `consequent`: `Statement` (required)
 - `alternate`: `Statement` (default: `null`)
 
-Aliases: [`Statement`](#statement), [`Conditional`](#conditional)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Conditional`](#conditional)
 
 ---
 
@@ -1316,7 +1328,7 @@ t.import();
 
 See also `t.isImport(node, opts)` and `t.assertImport(node, opts)`.
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -1331,6 +1343,8 @@ See also `t.isImportAttribute(node, opts)` and `t.assertImportAttribute(node, op
 AST Node `ImportAttribute` shape:
 - `key`: `Identifier | StringLiteral` (required)
 - `value`: `StringLiteral` (required)
+
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal)
 
 ---
 
@@ -1348,7 +1362,7 @@ AST Node `ImportDeclaration` shape:
 - `assertions`: `Array<ImportAttribute>` (default: `null`, excluded from builder function)
 - `importKind`: `"type" | "typeof" | "value"` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Declaration`](#declaration), [`ModuleDeclaration`](#moduledeclaration)
 
 ---
 
@@ -1363,7 +1377,7 @@ See also `t.isImportDefaultSpecifier(node, opts)` and `t.assertImportDefaultSpec
 AST Node `ImportDefaultSpecifier` shape:
 - `local`: `Identifier` (required)
 
-Aliases: [`ModuleSpecifier`](#modulespecifier)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`ModuleSpecifier`](#modulespecifier)
 
 ---
 
@@ -1378,7 +1392,7 @@ See also `t.isImportNamespaceSpecifier(node, opts)` and `t.assertImportNamespace
 AST Node `ImportNamespaceSpecifier` shape:
 - `local`: `Identifier` (required)
 
-Aliases: [`ModuleSpecifier`](#modulespecifier)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`ModuleSpecifier`](#modulespecifier)
 
 ---
 
@@ -1395,7 +1409,7 @@ AST Node `ImportSpecifier` shape:
 - `imported`: `Identifier | StringLiteral` (required)
 - `importKind`: `"type" | "typeof"` (default: `null`, excluded from builder function)
 
-Aliases: [`ModuleSpecifier`](#modulespecifier)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`ModuleSpecifier`](#modulespecifier)
 
 ---
 
@@ -1489,6 +1503,8 @@ See also `t.isInterpreterDirective(node, opts)` and `t.assertInterpreterDirectiv
 
 AST Node `InterpreterDirective` shape:
 - `value`: `string` (required)
+
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
 
 ---
 
@@ -1746,7 +1762,7 @@ AST Node `LabeledStatement` shape:
 - `label`: `Identifier` (required)
 - `body`: `Statement` (required)
 
-Aliases: [`Statement`](#statement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement)
 
 ---
 
@@ -1763,7 +1779,7 @@ AST Node `LogicalExpression` shape:
 - `left`: `Expression` (required)
 - `right`: `Expression` (required)
 
-Aliases: [`Binary`](#binary), [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Binary`](#binary), [`Expression`](#expression)
 
 ---
 
@@ -1781,7 +1797,7 @@ AST Node `MemberExpression` shape:
 - `computed`: `boolean` (default: `false`)
 - `optional`: `true | false` (default: `null`)
 
-Aliases: [`Expression`](#expression), [`LVal`](#lval)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`LVal`](#lval)
 
 ---
 
@@ -1797,7 +1813,7 @@ AST Node `MetaProperty` shape:
 - `meta`: `Identifier` (required)
 - `property`: `Identifier` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -1824,7 +1840,7 @@ See also `t.isModuleExpression(node, opts)` and `t.assertModuleExpression(node, 
 AST Node `ModuleExpression` shape:
 - `body`: `Program` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -1843,7 +1859,7 @@ AST Node `NewExpression` shape:
 - `typeArguments`: `TypeParameterInstantiation` (default: `null`, excluded from builder function)
 - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`, excluded from builder function)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
 
 ---
 
@@ -1867,7 +1883,7 @@ t.nullLiteral();
 
 See also `t.isNullLiteral(node, opts)` and `t.assertNullLiteral(node, opts)`.
 
-Aliases: [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
 
 ---
 
@@ -1936,7 +1952,7 @@ See also `t.isNumericLiteral(node, opts)` and `t.assertNumericLiteral(node, opts
 AST Node `NumericLiteral` shape:
 - `value`: `number` (required)
 
-Aliases: [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
 
 ---
 
@@ -1951,7 +1967,7 @@ See also `t.isObjectExpression(node, opts)` and `t.assertObjectExpression(node, 
 AST Node `ObjectExpression` shape:
 - `properties`: `Array<ObjectMethod | ObjectProperty | SpreadElement>` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -1975,7 +1991,7 @@ AST Node `ObjectMethod` shape:
 - `returnType`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 - `typeParameters`: `TypeParameterDeclaration | TSTypeParameterDeclaration | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`UserWhitespacable`](#userwhitespacable), [`Function`](#function), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Method`](#method), [`ObjectMember`](#objectmember)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`UserWhitespacable`](#userwhitespacable), [`Function`](#function), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`FunctionParent`](#functionparent), [`Method`](#method), [`ObjectMember`](#objectmember)
 
 ---
 
@@ -1992,7 +2008,7 @@ AST Node `ObjectPattern` shape:
 - `decorators`: `Array<Decorator>` (default: `null`, excluded from builder function)
 - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`Pattern`](#pattern), [`PatternLike`](#patternlike), [`LVal`](#lval)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Pattern`](#pattern), [`PatternLike`](#patternlike), [`LVal`](#lval)
 
 ---
 
@@ -2011,7 +2027,7 @@ AST Node `ObjectProperty` shape:
 - `shorthand`: `boolean` (default: `false`)
 - `decorators`: `Array<Decorator>` (default: `null`)
 
-Aliases: [`UserWhitespacable`](#userwhitespacable), [`Property`](#property), [`ObjectMember`](#objectmember)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`UserWhitespacable`](#userwhitespacable), [`Property`](#property), [`ObjectMember`](#objectmember)
 
 ---
 
@@ -2159,7 +2175,7 @@ AST Node `OptionalCallExpression` shape:
 - `typeArguments`: `TypeParameterInstantiation` (default: `null`, excluded from builder function)
 - `typeParameters`: `TSTypeParameterInstantiation` (default: `null`, excluded from builder function)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -2194,7 +2210,7 @@ AST Node `OptionalMemberExpression` shape:
 - `computed`: `boolean` (default: `false`)
 - `optional`: `boolean` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -2209,7 +2225,7 @@ See also `t.isParenthesizedExpression(node, opts)` and `t.assertParenthesizedExp
 AST Node `ParenthesizedExpression` shape:
 - `expression`: `Expression` (required)
 
-Aliases: [`Expression`](#expression), [`ExpressionWrapper`](#expressionwrapper)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`ExpressionWrapper`](#expressionwrapper)
 
 ---
 
@@ -2224,6 +2240,8 @@ See also `t.isPipelineBareFunction(node, opts)` and `t.assertPipelineBareFunctio
 AST Node `PipelineBareFunction` shape:
 - `callee`: `Expression` (required)
 
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal)
+
 ---
 
 #### pipelinePrimaryTopicReference
@@ -2234,7 +2252,7 @@ t.pipelinePrimaryTopicReference();
 
 See also `t.isPipelinePrimaryTopicReference(node, opts)` and `t.assertPipelinePrimaryTopicReference(node, opts)`.
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -2248,6 +2266,8 @@ See also `t.isPipelineTopicExpression(node, opts)` and `t.assertPipelineTopicExp
 
 AST Node `PipelineTopicExpression` shape:
 - `expression`: `Expression` (required)
+
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal)
 
 ---
 
@@ -2278,7 +2298,7 @@ See also `t.isPrivateName(node, opts)` and `t.assertPrivateName(node, opts)`.
 AST Node `PrivateName` shape:
 - `id`: `Identifier` (required)
 
-Aliases: [`Private`](#private)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Private`](#private)
 
 ---
 
@@ -2297,7 +2317,7 @@ AST Node `Program` shape:
 - `interpreter`: `InterpreterDirective` (default: `null`)
 - `sourceFile`: `string` (required)
 
-Aliases: [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`Block`](#block)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`BlockParent`](#blockparent), [`Block`](#block)
 
 ---
 
@@ -2328,7 +2348,7 @@ See also `t.isRecordExpression(node, opts)` and `t.assertRecordExpression(node, 
 AST Node `RecordExpression` shape:
 - `properties`: `Array<ObjectProperty | SpreadElement>` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -2344,7 +2364,7 @@ AST Node `RegExpLiteral` shape:
 - `pattern`: `string` (required)
 - `flags`: `string` (default: `''`)
 
-Aliases: [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal)
 
 ---
 
@@ -2361,7 +2381,7 @@ AST Node `RestElement` shape:
 - `decorators`: `Array<Decorator>` (default: `null`, excluded from builder function)
 - `typeAnnotation`: `TypeAnnotation | TSTypeAnnotation | Noop` (default: `null`, excluded from builder function)
 
-Aliases: [`LVal`](#lval), [`PatternLike`](#patternlike)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`LVal`](#lval), [`PatternLike`](#patternlike)
 
 ---
 
@@ -2376,7 +2396,7 @@ See also `t.isReturnStatement(node, opts)` and `t.assertReturnStatement(node, op
 AST Node `ReturnStatement` shape:
 - `argument`: `Expression` (default: `null`)
 
-Aliases: [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
 
 ---
 
@@ -2391,7 +2411,7 @@ See also `t.isSequenceExpression(node, opts)` and `t.assertSequenceExpression(no
 AST Node `SequenceExpression` shape:
 - `expressions`: `Array<Expression>` (required)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -2406,7 +2426,7 @@ See also `t.isSpreadElement(node, opts)` and `t.assertSpreadElement(node, opts)`
 AST Node `SpreadElement` shape:
 - `argument`: `Expression` (required)
 
-Aliases: [`UnaryLike`](#unarylike)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`UnaryLike`](#unarylike)
 
 ---
 
@@ -2421,7 +2441,7 @@ See also `t.isStaticBlock(node, opts)` and `t.assertStaticBlock(node, opts)`.
 AST Node `StaticBlock` shape:
 - `body`: `Array<Statement>` (required)
 
-Aliases: [`Scopable`](#scopable), [`BlockParent`](#blockparent)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Scopable`](#scopable), [`BlockParent`](#blockparent)
 
 ---
 
@@ -2436,7 +2456,7 @@ See also `t.isStringLiteral(node, opts)` and `t.assertStringLiteral(node, opts)`
 AST Node `StringLiteral` shape:
 - `value`: `string` (required)
 
-Aliases: [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Pureish`](#pureish), [`Literal`](#literal), [`Immutable`](#immutable)
 
 ---
 
@@ -2475,7 +2495,7 @@ t.super();
 
 See also `t.isSuper(node, opts)` and `t.assertSuper(node, opts)`.
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -2491,6 +2511,8 @@ AST Node `SwitchCase` shape:
 - `test`: `Expression` (default: `null`)
 - `consequent`: `Array<Statement>` (required)
 
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
+
 ---
 
 #### switchStatement
@@ -2505,7 +2527,7 @@ AST Node `SwitchStatement` shape:
 - `discriminant`: `Expression` (required)
 - `cases`: `Array<SwitchCase>` (required)
 
-Aliases: [`Statement`](#statement), [`BlockParent`](#blockparent), [`Scopable`](#scopable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`BlockParent`](#blockparent), [`Scopable`](#scopable)
 
 ---
 
@@ -3521,7 +3543,7 @@ AST Node `TaggedTemplateExpression` shape:
 - `quasi`: `TemplateLiteral` (required)
 - `typeParameters`: `TypeParameterInstantiation | TSTypeParameterInstantiation` (default: `null`, excluded from builder function)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -3537,6 +3559,8 @@ AST Node `TemplateElement` shape:
 - `value`: `{ raw: string, cooked?: string }` (required)
 - `tail`: `boolean` (default: `false`)
 
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
+
 ---
 
 #### templateLiteral
@@ -3551,7 +3575,7 @@ AST Node `TemplateLiteral` shape:
 - `quasis`: `Array<TemplateElement>` (required)
 - `expressions`: `Array<Expression | TSType>` (required)
 
-Aliases: [`Expression`](#expression), [`Literal`](#literal)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Literal`](#literal)
 
 ---
 
@@ -3563,7 +3587,7 @@ t.thisExpression();
 
 See also `t.isThisExpression(node, opts)` and `t.assertThisExpression(node, opts)`.
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -3590,7 +3614,7 @@ See also `t.isThrowStatement(node, opts)` and `t.assertThrowStatement(node, opts
 AST Node `ThrowStatement` shape:
 - `argument`: `Expression` (required)
 
-Aliases: [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Terminatorless`](#terminatorless), [`CompletionStatement`](#completionstatement)
 
 ---
 
@@ -3607,7 +3631,7 @@ AST Node `TryStatement` shape:
 - `handler`: `CatchClause` (default: `null`)
 - `finalizer`: `BlockStatement` (default: `null`)
 
-Aliases: [`Statement`](#statement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement)
 
 ---
 
@@ -3622,7 +3646,7 @@ See also `t.isTupleExpression(node, opts)` and `t.assertTupleExpression(node, op
 AST Node `TupleExpression` shape:
 - `elements`: `Array<Expression | SpreadElement>` (default: `[]`)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Proposal`](#proposal), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -3765,7 +3789,7 @@ AST Node `UnaryExpression` shape:
 - `argument`: `Expression` (required)
 - `prefix`: `boolean` (default: `true`)
 
-Aliases: [`UnaryLike`](#unarylike), [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`UnaryLike`](#unarylike), [`Expression`](#expression)
 
 ---
 
@@ -3797,7 +3821,7 @@ AST Node `UpdateExpression` shape:
 - `argument`: `Expression` (required)
 - `prefix`: `boolean` (default: `false`)
 
-Aliases: [`Expression`](#expression)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression)
 
 ---
 
@@ -3829,7 +3853,7 @@ AST Node `VariableDeclaration` shape:
 - `declarations`: `Array<VariableDeclarator>` (required)
 - `declare`: `boolean` (default: `null`, excluded from builder function)
 
-Aliases: [`Statement`](#statement), [`Declaration`](#declaration)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`Declaration`](#declaration)
 
 ---
 
@@ -3845,6 +3869,8 @@ AST Node `VariableDeclarator` shape:
 - `id`: `LVal` (required)
 - `init`: `Expression` (default: `null`)
 - `definite`: `boolean` (default: `null`, excluded from builder function)
+
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal)
 
 ---
 
@@ -3887,7 +3913,7 @@ AST Node `WhileStatement` shape:
 - `test`: `Expression` (required)
 - `body`: `Statement` (required)
 
-Aliases: [`Statement`](#statement), [`BlockParent`](#blockparent), [`Loop`](#loop), [`While`](#while), [`Scopable`](#scopable)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement), [`BlockParent`](#blockparent), [`Loop`](#loop), [`While`](#while), [`Scopable`](#scopable)
 
 ---
 
@@ -3903,7 +3929,7 @@ AST Node `WithStatement` shape:
 - `object`: `Expression` (required)
 - `body`: `Statement` (required)
 
-Aliases: [`Statement`](#statement)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Statement`](#statement)
 
 ---
 
@@ -3919,7 +3945,7 @@ AST Node `YieldExpression` shape:
 - `argument`: `Expression` (default: `null`)
 - `delegate`: `boolean` (default: `false`)
 
-Aliases: [`Expression`](#expression), [`Terminatorless`](#terminatorless)
+Aliases: [`Standardized`](#standardized), [`StandardizedOrProposal`](#standardizedorproposal), [`Expression`](#expression), [`Terminatorless`](#terminatorless)
 
 ---
 
@@ -4112,7 +4138,6 @@ Covered nodes:
 - [`MemberExpression`](#memberexpression)
 - [`MetaProperty`](#metaproperty)
 - [`ModuleExpression`](#moduleexpression)
-- [`NewExpression`](#newexpression)
 - [`NullLiteral`](#nullliteral)
 - [`NumericLiteral`](#numericliteral)
 - [`ObjectExpression`](#objectexpression)
@@ -4572,6 +4597,29 @@ Covered nodes:
 - [`ClassProperty`](#classproperty)
 - [`ObjectProperty`](#objectproperty)
 
+#### Proposal
+
+A cover of AST nodes which are proprosed for inclusion in ECMAScript.
+```javascript
+t.isProposal(node);
+```
+
+Covered nodes: 
+- [`ArgumentPlaceholder`](#argumentplaceholder)
+- [`BindExpression`](#bindexpression)
+- [`DecimalLiteral`](#decimalliteral)
+- [`Decorator`](#decorator)
+- [`DoExpression`](#doexpression)
+- [`ExportDefaultSpecifier`](#exportdefaultspecifier)
+- [`ImportAttribute`](#importattribute)
+- [`ModuleExpression`](#moduleexpression)
+- [`PipelineBareFunction`](#pipelinebarefunction)
+- [`PipelinePrimaryTopicReference`](#pipelineprimarytopicreference)
+- [`PipelineTopicExpression`](#pipelinetopicexpression)
+- [`RecordExpression`](#recordexpression)
+- [`StaticBlock`](#staticblock)
+- [`TupleExpression`](#tupleexpression)
+
 #### Pureish
 
 A cover of AST nodes which do not have side-effects. In other words, there is no observable behaviour changes if they are evaluated more than once.
@@ -4618,6 +4666,208 @@ Covered nodes:
 - [`SwitchStatement`](#switchstatement)
 - [`TSModuleBlock`](#tsmoduleblock)
 - [`WhileStatement`](#whilestatement)
+
+#### Standardized
+
+A cover of AST nodes which are part of an official ECMAScript specification.
+```javascript
+t.isStandardized(node);
+```
+
+Covered nodes: 
+- [`ArrayExpression`](#arrayexpression)
+- [`ArrayPattern`](#arraypattern)
+- [`ArrowFunctionExpression`](#arrowfunctionexpression)
+- [`AssignmentExpression`](#assignmentexpression)
+- [`AssignmentPattern`](#assignmentpattern)
+- [`AwaitExpression`](#awaitexpression)
+- [`BigIntLiteral`](#bigintliteral)
+- [`BinaryExpression`](#binaryexpression)
+- [`BlockStatement`](#blockstatement)
+- [`BooleanLiteral`](#booleanliteral)
+- [`BreakStatement`](#breakstatement)
+- [`CallExpression`](#callexpression)
+- [`CatchClause`](#catchclause)
+- [`ClassBody`](#classbody)
+- [`ClassDeclaration`](#classdeclaration)
+- [`ClassExpression`](#classexpression)
+- [`ClassMethod`](#classmethod)
+- [`ClassPrivateMethod`](#classprivatemethod)
+- [`ClassPrivateProperty`](#classprivateproperty)
+- [`ClassProperty`](#classproperty)
+- [`ConditionalExpression`](#conditionalexpression)
+- [`ContinueStatement`](#continuestatement)
+- [`DebuggerStatement`](#debuggerstatement)
+- [`Directive`](#directive)
+- [`DirectiveLiteral`](#directiveliteral)
+- [`DoWhileStatement`](#dowhilestatement)
+- [`EmptyStatement`](#emptystatement)
+- [`ExportAllDeclaration`](#exportalldeclaration)
+- [`ExportDefaultDeclaration`](#exportdefaultdeclaration)
+- [`ExportNamedDeclaration`](#exportnameddeclaration)
+- [`ExportNamespaceSpecifier`](#exportnamespacespecifier)
+- [`ExportSpecifier`](#exportspecifier)
+- [`ExpressionStatement`](#expressionstatement)
+- [`File`](#file)
+- [`ForInStatement`](#forinstatement)
+- [`ForOfStatement`](#forofstatement)
+- [`ForStatement`](#forstatement)
+- [`FunctionDeclaration`](#functiondeclaration)
+- [`FunctionExpression`](#functionexpression)
+- [`Identifier`](#identifier)
+- [`IfStatement`](#ifstatement)
+- [`Import`](#import)
+- [`ImportDeclaration`](#importdeclaration)
+- [`ImportDefaultSpecifier`](#importdefaultspecifier)
+- [`ImportNamespaceSpecifier`](#importnamespacespecifier)
+- [`ImportSpecifier`](#importspecifier)
+- [`InterpreterDirective`](#interpreterdirective)
+- [`LabeledStatement`](#labeledstatement)
+- [`LogicalExpression`](#logicalexpression)
+- [`MemberExpression`](#memberexpression)
+- [`MetaProperty`](#metaproperty)
+- [`NewExpression`](#newexpression)
+- [`NullLiteral`](#nullliteral)
+- [`NumericLiteral`](#numericliteral)
+- [`ObjectExpression`](#objectexpression)
+- [`ObjectMethod`](#objectmethod)
+- [`ObjectPattern`](#objectpattern)
+- [`ObjectProperty`](#objectproperty)
+- [`OptionalCallExpression`](#optionalcallexpression)
+- [`OptionalMemberExpression`](#optionalmemberexpression)
+- [`ParenthesizedExpression`](#parenthesizedexpression)
+- [`PrivateName`](#privatename)
+- [`Program`](#program)
+- [`RegExpLiteral`](#regexpliteral)
+- [`RestElement`](#restelement)
+- [`ReturnStatement`](#returnstatement)
+- [`SequenceExpression`](#sequenceexpression)
+- [`SpreadElement`](#spreadelement)
+- [`StringLiteral`](#stringliteral)
+- [`Super`](#super)
+- [`SwitchCase`](#switchcase)
+- [`SwitchStatement`](#switchstatement)
+- [`TaggedTemplateExpression`](#taggedtemplateexpression)
+- [`TemplateElement`](#templateelement)
+- [`TemplateLiteral`](#templateliteral)
+- [`ThisExpression`](#thisexpression)
+- [`ThrowStatement`](#throwstatement)
+- [`TryStatement`](#trystatement)
+- [`UnaryExpression`](#unaryexpression)
+- [`UpdateExpression`](#updateexpression)
+- [`VariableDeclaration`](#variabledeclaration)
+- [`VariableDeclarator`](#variabledeclarator)
+- [`WhileStatement`](#whilestatement)
+- [`WithStatement`](#withstatement)
+- [`YieldExpression`](#yieldexpression)
+
+#### StandardizedOrProposal
+
+A cover of AST nodes which are part of an official ECMAScript specification or a proposed for inclusion.
+```javascript
+t.isStandardizedOrProposal(node);
+```
+
+Covered nodes: 
+- [`ArgumentPlaceholder`](#argumentplaceholder)
+- [`ArrayExpression`](#arrayexpression)
+- [`ArrayPattern`](#arraypattern)
+- [`ArrowFunctionExpression`](#arrowfunctionexpression)
+- [`AssignmentExpression`](#assignmentexpression)
+- [`AssignmentPattern`](#assignmentpattern)
+- [`AwaitExpression`](#awaitexpression)
+- [`BigIntLiteral`](#bigintliteral)
+- [`BinaryExpression`](#binaryexpression)
+- [`BindExpression`](#bindexpression)
+- [`BlockStatement`](#blockstatement)
+- [`BooleanLiteral`](#booleanliteral)
+- [`BreakStatement`](#breakstatement)
+- [`CallExpression`](#callexpression)
+- [`CatchClause`](#catchclause)
+- [`ClassBody`](#classbody)
+- [`ClassDeclaration`](#classdeclaration)
+- [`ClassExpression`](#classexpression)
+- [`ClassMethod`](#classmethod)
+- [`ClassPrivateMethod`](#classprivatemethod)
+- [`ClassPrivateProperty`](#classprivateproperty)
+- [`ClassProperty`](#classproperty)
+- [`ConditionalExpression`](#conditionalexpression)
+- [`ContinueStatement`](#continuestatement)
+- [`DebuggerStatement`](#debuggerstatement)
+- [`DecimalLiteral`](#decimalliteral)
+- [`Decorator`](#decorator)
+- [`Directive`](#directive)
+- [`DirectiveLiteral`](#directiveliteral)
+- [`DoExpression`](#doexpression)
+- [`DoWhileStatement`](#dowhilestatement)
+- [`EmptyStatement`](#emptystatement)
+- [`ExportAllDeclaration`](#exportalldeclaration)
+- [`ExportDefaultDeclaration`](#exportdefaultdeclaration)
+- [`ExportDefaultSpecifier`](#exportdefaultspecifier)
+- [`ExportNamedDeclaration`](#exportnameddeclaration)
+- [`ExportNamespaceSpecifier`](#exportnamespacespecifier)
+- [`ExportSpecifier`](#exportspecifier)
+- [`ExpressionStatement`](#expressionstatement)
+- [`File`](#file)
+- [`ForInStatement`](#forinstatement)
+- [`ForOfStatement`](#forofstatement)
+- [`ForStatement`](#forstatement)
+- [`FunctionDeclaration`](#functiondeclaration)
+- [`FunctionExpression`](#functionexpression)
+- [`Identifier`](#identifier)
+- [`IfStatement`](#ifstatement)
+- [`Import`](#import)
+- [`ImportAttribute`](#importattribute)
+- [`ImportDeclaration`](#importdeclaration)
+- [`ImportDefaultSpecifier`](#importdefaultspecifier)
+- [`ImportNamespaceSpecifier`](#importnamespacespecifier)
+- [`ImportSpecifier`](#importspecifier)
+- [`InterpreterDirective`](#interpreterdirective)
+- [`LabeledStatement`](#labeledstatement)
+- [`LogicalExpression`](#logicalexpression)
+- [`MemberExpression`](#memberexpression)
+- [`MetaProperty`](#metaproperty)
+- [`ModuleExpression`](#moduleexpression)
+- [`NewExpression`](#newexpression)
+- [`NullLiteral`](#nullliteral)
+- [`NumericLiteral`](#numericliteral)
+- [`ObjectExpression`](#objectexpression)
+- [`ObjectMethod`](#objectmethod)
+- [`ObjectPattern`](#objectpattern)
+- [`ObjectProperty`](#objectproperty)
+- [`OptionalCallExpression`](#optionalcallexpression)
+- [`OptionalMemberExpression`](#optionalmemberexpression)
+- [`ParenthesizedExpression`](#parenthesizedexpression)
+- [`PipelineBareFunction`](#pipelinebarefunction)
+- [`PipelinePrimaryTopicReference`](#pipelineprimarytopicreference)
+- [`PipelineTopicExpression`](#pipelinetopicexpression)
+- [`PrivateName`](#privatename)
+- [`Program`](#program)
+- [`RecordExpression`](#recordexpression)
+- [`RegExpLiteral`](#regexpliteral)
+- [`RestElement`](#restelement)
+- [`ReturnStatement`](#returnstatement)
+- [`SequenceExpression`](#sequenceexpression)
+- [`SpreadElement`](#spreadelement)
+- [`StaticBlock`](#staticblock)
+- [`StringLiteral`](#stringliteral)
+- [`Super`](#super)
+- [`SwitchCase`](#switchcase)
+- [`SwitchStatement`](#switchstatement)
+- [`TaggedTemplateExpression`](#taggedtemplateexpression)
+- [`TemplateElement`](#templateelement)
+- [`TemplateLiteral`](#templateliteral)
+- [`ThisExpression`](#thisexpression)
+- [`ThrowStatement`](#throwstatement)
+- [`TryStatement`](#trystatement)
+- [`TupleExpression`](#tupleexpression)
+- [`UnaryExpression`](#unaryexpression)
+- [`UpdateExpression`](#updateexpression)
+- [`VariableDeclaration`](#variabledeclaration)
+- [`VariableDeclarator`](#variabledeclarator)
+- [`WhileStatement`](#whilestatement)
+- [`WithStatement`](#withstatement)
+- [`YieldExpression`](#yieldexpression)
 
 #### Statement
 


### PR DESCRIPTION
Re: https://github.com/babel/babel/pull/13666

Seems these docs were a bit out of date. We should probably automate this, I generated it by running

```bash
$ cd babel
$ node packages/babel-types/scripts/generators/docs.js > ../babel-website/docs/types.md
```