### PR TITLE
update REPL core-js to 3.16

### DIFF
--- a/js/repl/PluginConfig.js
+++ b/js/repl/PluginConfig.js
@@ -64,7 +64,7 @@ const envPresetDefaults = {
     default: "usage",
   },
   corejs: {
-    default: "3.6",
+    default: "3.16",
   },
 };
 

--- a/js/repl/ReplOptions.js
+++ b/js/repl/ReplOptions.js
@@ -613,7 +613,7 @@ class ExpandedContainer extends Component<Props, State> {
                   }
                 >
                   <option value="2">core-js 2</option>
-                  <option value="3.6">core-js 3.6</option>
+                  <option value="3.16">core-js 3.16</option>
                 </select>
                 <select
                   value={envConfig.builtIns}

--- a/js/repl/compile.js
+++ b/js/repl/compile.js
@@ -61,7 +61,7 @@ export default function compile(code: string, config: CompileConfig): Return {
   let spec = false;
   let loose = false;
   let bugfixes = false;
-  let corejs = "3.6";
+  let corejs = "3.16";
   const transitions = new Transitions();
   const meta = {
     compiledSize: 0,


### PR DESCRIPTION
The core-js version in builtin REPL is out of dated, which is confusing users as in https://github.com/babel/babel/issues/13701.

This PR updates `core-js` version to latest `3.16`, so features like `String#replaceAll` can be properly polyfilled.