### PR TITLE
docs: fix misleading documentation

### DIFF
--- a/docs/plugin-proposal-function-bind.md
+++ b/docs/plugin-proposal-function-bind.md
@@ -9,7 +9,9 @@ sidebar_label: function-bind
 ```js
 obj::func;
 // is equivalent to:
-func.bind(obj)::obj.func;
+func.bind(obj)
+
+::obj.func;
 // is equivalent to:
 obj.func.bind(obj);
 
@@ -18,7 +20,7 @@ obj::func(val);
 func
   .call(obj, val)
 
-  ::obj.func(val);
+::obj.func(val);
 // is equivalent to:
 obj.func.call(obj, val);
 ```


### PR DESCRIPTION
Fix misleading documentation on function bind.
A missing new line made the first example very confusing.

![image](https://user-images.githubusercontent.com/536973/139561161-bd96cc7b-5e59-4575-9df7-95853963fbc8.png)

**From**

```js
obj::func;
// is equivalent to:
func.bind(obj)::obj.func;
// is equivalent to:
obj.func.bind(obj);
```

**To**

```js
obj::func;
// is equivalent to:
func.bind(obj)

::obj.func;
// is equivalent to:
obj.func.bind(obj);
```
