### PR TITLE
pipe: Add topicToken: ^^ and @@; prefer Hack style

### DIFF
--- a/docs/plugin-proposal-pipeline-operator.md
+++ b/docs/plugin-proposal-pipeline-operator.md
@@ -14,302 +14,82 @@ $ npm install --save-dev @babel/plugin-proposal-pipeline-operator
 
 The pipeline operator has several competing proposals.
 Configure which proposal to use with the required `"proposal"` option.
+Its value is `"hack"` by default.
 
 | Value | Proposal | Version added |
 | ----- | -------- | ------------- |
-| `"minimal"` | [Minimal F#-style pipes](https://github.com/tc39/proposal-pipeline-operator/) | `v7.0.0`
-| `"fsharp"` | [F#-style pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines) | `v7.5.0`
+| ~~`"minimal"`~~ | [Minimal F#-style pipes](https://github.com/tc39/proposal-pipeline-operator/) | `v7.0.0`
+| ~~`"fsharp"`~~ | [F#-style pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines) | `v7.5.0`
 | `"hack"` | [Hack-style pipes](https://github.com/js-choi/proposal-hack-pipes) | `v7.15.0`
 | ~~`"smart"`~~ | [Smart-mix pipes](https://github.com/js-choi/proposal-smart-pipelines) (deprecated) | `v7.3.0`
 
-If `"proposal": "hack"` is used, then a `"topicToken": "%"`, `"topicToken": "^"`, or `"topicToken": "#"` option must also be included.
-
-The `"proposal": "smart"` option is deprecated and subject to removal in a future major version.
-
-When TC39 accepts one of the proposals, that proposal will become the default and the `"proposal"` option will no longer be required.
-
-### Summary of proposals’ behavior
-
-<table>
-<thead>
-<tr>
-<th>Original expression</th>
-<th>
-
-[Minimal F# pipes](https://github.com/tc39/proposal-pipeline-operator/)<br>`{proposal: "minimal"}`
-
-</th>
-<th>
-
-[F# pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines/)<br>`{proposal: "fsharp"}`
-
-</th>
-<th>
-
-[Hack pipes](https://github.com/js-choi/proposal-hack-pipes/)<br>`{proposal: "hack",`<br>`topicToken: "%"}`
-
-</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-`o.m(x)`
-
-</td>
-<td>
-
-`x |> o.m`
-
-</td>
-<td>
-
-`x |> o.m`
-
-</td>
-<td>
-
-`x |> o.m(%)`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`o.m(0, x)`
-
-</td>
-<td>
-
-`x |> y=>o.m(0, y)`
-
-</td>
-<td>
-
-`x |> y=>o.m(0, y)`
-
-</td>
-<td>
-
-`x |> o.m(0, %)`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`new o.m(x)`
-
-</td>
-<td>
-
-`x |> y=>new o.m(y)`
-
-</td>
-<td>
-
-`x |> y=>new o.m(y)`
-
-</td>
-<td>
-
-`x |> new o.m(%)`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`o[x]`
-
-</td>
-<td>
-
-`x |> y=>o[x]`
-
-</td>
-<td>
-
-`x |> y=>o[y]`
-
-</td>
-<td>
-
-`x |> o[%]`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`x[i]`
-
-</td>
-<td>
-
-`x |> y=>x[i]`
-
-</td>
-<td>
-
-`x |> y=>y[i]`
-
-</td>
-<td>
-
-`x |> %[i]`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`x + 1`
-
-</td>
-<td>
-
-`x |> y=>y + 1`
-
-</td>
-<td>
-
-`x |> y=>y + 1`
-
-</td>
-<td>
-
-`x |> % + 1`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`[0, x]`
-
-</td>
-<td>
-
-`x |> y=>[0, y]`
-
-</td>
-<td>
-
-`x |> y=>[0, y]`
-
-</td>
-<td>
-
-`x |> [0, %]`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`{ key: x }`
-
-</td>
-<td>
-
-`x |> y=>({ key: y })`
-
-</td>
-<td>
-
-`x |> y=>({ key: y })`
-
-</td>
-<td>
-
-`x |> { key: % }`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`await o.m(x)`
-
-</td>
-<td>Not supported</td>
-<td>
-
-`x |> o.m |> await`
-
-</td>
-<td>
-
-`x |> await o.m(%)`
-
-</td>
-</tr>
-<tr>
-<td>
-
-`yield o.m(x)`
-
-</td>
-<td>Not supported</td>
-<td>Not supported</td>
-<td>
-
-`x |> (yield o.m(%))`
-
-</td>
-</tr>
-</tbody>
-</table>
-
-### With a configuration file (Recommended)
-
-For [minimal F# pipes](https://github.com/tc39/proposal-pipeline-operator/):
+If `"proposal"` is omitted, or if `"proposal": "hack"` is used, then a `"topicToken": "^^"`, `"topicToken": "^"`, or `"topicToken": "#"` option must also be included.
+
+The `"proposal": "minimal"`, `"fsharp"`, and `"smart"` options are **deprecated** and subject to removal in a future major version.
+
+### Examples
+From [react/scripts/jest/jest-cli.js][].
+```js
+// Status quo
+console.log(
+  chalk.dim(
+    `$ ${Object.keys(envars)
+      .map(envar => `${envar}=${envars[envar]}`)
+      .join(' ')}`,
+    'node',
+    args.join(' ')
+  )
+);
+
+// With pipes
+Object.keys(envars)
+  .map(envar => `${envar}=${envars[envar]}`)
+  .join(' ')
+  |> `$ ${^^}`
+  |> chalk.dim(^^, 'node', args.join(' '))
+  |> console.log(^^);
+```
+
+From [jquery/src/core/init.js][].
+```js
+// Status quo
+jQuery.merge( this, jQuery.parseHTML(
+  match[ 1 ],
+  context && context.nodeType ? context.ownerDocument || context : document,
+  true
+) );
+
+// With pipes
+context
+  |> (^^ && ^^.nodeType ? ^^.ownerDocument || ^^ : document)
+  |> jQuery.parseHTML(match[1], ^^, true)
+  |> jQuery.merge(^^);
+```
+
+[react/scripts/jest/jest-cli.js]: https://github.com/facebook/react/blob/17.0.2/scripts/jest/jest-cli.js
+[jquery/src/core/init.js]: https://github.com/jquery/jquery/blob/2.2-stable/src/core/init.js
+
+(For a summary of deprecated proposal modes’ behavior, see the [pipe wiki’s table of previous proposals](https://github.com/tc39/proposal-pipeline-operator/wiki#overview-of-previous-proposals).)
+
+
+### With a configuration file (recommended)
+
+With `^^` topic token:
 
 ```json
 {
   "plugins": [
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "minimal" }]
+    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "hack", "topicToken": "^^" }]
   ]
 }
 ```
 
-For [F# pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines/):
+With `@@` topic token:
 
 ```json
 {
   "plugins": [
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "fsharp" }]
-  ]
-}
-```
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `%` topic token:
-
-```json
-{
-  "plugins": [
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "hack", "topicToken": "%" }]
-  ]
-}
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `^` topic token:
-
-```json
-{
-  "plugins": [
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "hack", "topicToken": "^" }]
-  ]
-}
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `#` topic token:
-
-```json
-{
-  "plugins": [
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "hack", "topicToken": "#" }]
+    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "hack", "topicToken": "@@" }]
   ]
 }
 ```
@@ -320,52 +100,22 @@ Because this plugin requires a configuration option, it [cannot be directly conf
 
 ### Via Node API
 
-For [minimal F# pipes](https://github.com/tc39/proposal-pipeline-operator/)<br>`{proposal: "minimal"}`:
+With `^^` topic token:
 
 ```javascript
 require("@babel/core").transformSync("code", {
   plugins: [
-    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "minimal" } ],
+    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "hack", topicToken: "^^" } ],
   ],
 });
 ```
 
-For [F# pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines/):
+With `@@` topic token:
 
 ```javascript
 require("@babel/core").transformSync("code", {
   plugins: [
-    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "fsharp" } ],
-  ],
-});
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `%` topic token:
-
-```javascript
-require("@babel/core").transformSync("code", {
-  plugins: [
-    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "hack", topicToken: "%" } ],
-  ],
-});
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `^` topic token:
-
-```javascript
-require("@babel/core").transformSync("code", {
-  plugins: [
-    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "hack", topicToken: "^" } ],
-  ],
-});
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `#` topic token:
-
-```javascript
-require("@babel/core").transformSync("code", {
-  plugins: [
-    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "hack", topicToken: "#" } ],
+    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "hack", topicToken: "@@" } ],
   ],
 });
 ```

--- a/docs/plugin-proposal-pipeline-operator.md
+++ b/docs/plugin-proposal-pipeline-operator.md
@@ -28,6 +28,8 @@ If `"proposal"` is omitted, or if `"proposal": "hack"` is used, then a `"topicTo
 The `"proposal": "minimal"`, `"fsharp"`, and `"smart"` options are **deprecated** and subject to removal in a future major version.
 
 ### Examples
+The following examples use `topicToken: "^^"`.
+
 From [react/scripts/jest/jest-cli.js][].
 ```js
 // Status quo

--- a/docs/plugin-proposal-pipeline-operator.md
+++ b/docs/plugin-proposal-pipeline-operator.md
@@ -81,7 +81,7 @@ With `^^` topic token:
 ```json
 {
   "plugins": [
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "hack", "topicToken": "^^" }]
+    ["@babel/plugin-proposal-pipeline-operator", { "topicToken": "^^" }]
   ]
 }
 ```
@@ -91,7 +91,7 @@ With `@@` topic token:
 ```json
 {
   "plugins": [
-    ["@babel/plugin-proposal-pipeline-operator", { "proposal": "hack", "topicToken": "@@" }]
+    ["@babel/plugin-proposal-pipeline-operator", { "topicToken": "@@" }]
   ]
 }
 ```
@@ -107,7 +107,7 @@ With `^^` topic token:
 ```javascript
 require("@babel/core").transformSync("code", {
   plugins: [
-    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "hack", topicToken: "^^" } ],
+    [ "@babel/plugin-proposal-pipeline-operator", { topicToken: "^^" } ],
   ],
 });
 ```
@@ -117,7 +117,7 @@ With `@@` topic token:
 ```javascript
 require("@babel/core").transformSync("code", {
   plugins: [
-    [ "@babel/plugin-proposal-pipeline-operator", { proposal: "hack", topicToken: "@@" } ],
+    [ "@babel/plugin-proposal-pipeline-operator", { topicToken: "@@" } ],
   ],
 });
 ```

--- a/docs/plugin-syntax-pipeline-operator.md
+++ b/docs/plugin-syntax-pipeline-operator.md
@@ -18,42 +18,22 @@ $ npm install @babel/plugin-syntax-pipeline-operator
 
 ### With a configuration file (Recommended)
 
-For [minimal F# pipes](https://github.com/tc39/proposal-pipeline-operator/):
+With `^^` topic token:
 
 ```json
 {
   "plugins": [
-    [ "@babel/plugin-syntax-pipeline-operator", { "proposal": "minimal" } ]
+    [ "@babel/plugin-syntax-pipeline-operator", { "topicToken": "^^" } ]
   ]
 }
 ```
 
-For [F# pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines/):
+With `@@` topic token:
 
 ```json
 {
   "plugins": [
-    [ "@babel/plugin-syntax-pipeline-operator", { "proposal": "fsharp" } ]
-  ]
-}
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `%` topic token:
-
-```json
-{
-  "plugins": [
-    [ "@babel/plugin-syntax-pipeline-operator", { "proposal": "hack", "topicToken": "%" } ]
-  ]
-}
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `#` topic token:
-
-```json
-{
-  "plugins": [
-    [ "@babel/plugin-syntax-pipeline-operator", { "proposal": "hack", "topicToken": "#" } ]
+    [ "@babel/plugin-syntax-pipeline-operator", { "topicToken": "@@" } ]
   ]
 }
 ```
@@ -64,42 +44,22 @@ Because this plugin requires a configuration option, it [cannot be directly conf
 
 ### Via Node API
 
-For [minimal F# pipes](https://github.com/tc39/proposal-pipeline-operator/):
+With `^^` topic token:
 
 ```javascript
 require("@babel/core").transformSync("code", {
   plugins: [
-    [ "@babel/plugin-syntax-pipeline-operator", { proposal: "minimal" } ],
+    [ "@babel/plugin-syntax-pipeline-operator", { topicToken: "^^" } ],
   ],
 });
 ```
 
-For [F# pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines/):
+With `@@` topic token:
 
 ```javascript
 require("@babel/core").transformSync("code", {
   plugins: [
-    [ "@babel/plugin-syntax-pipeline-operator", { proposal: "fsharp" } ],
-  ],
-});
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `%` topic token:
-
-```javascript
-require("@babel/core").transformSync("code", {
-  plugins: [
-    [ "@babel/plugin-syntax-pipeline-operator", { proposal: "hack", topicToken: "%" } ],
-  ],
-});
-```
-
-For [Hack pipes](https://github.com/js-choi/proposal-hack-pipes/) with `#` topic token:
-
-```javascript
-require("@babel/core").transformSync("code", {
-  plugins: [
-    [ "@babel/plugin-syntax-pipeline-operator", { proposal: "hack", topicToken: "#" } ],
+    [ "@babel/plugin-syntax-pipeline-operator", { topicToken: "@@" } ],
   ],
 });
 ```


### PR DESCRIPTION
Adds topic tokens `@@` and `^^` and deprecates `%` and `^`, as per the champion group’s consensus in the 2021-11 incubator call. (Does not deprecate `#`, which is still a candidate topic token.)

Also deprecates minimal-F# and F#+await styles in addition to smart mix, as per TC39’s decision in the 2021-08 plenary meeting.

See also babel/babel#13973. A separate pull request in babel/babel will add the deprecations.