### PR TITLE
Update docs of `@babel/parser` to follow `v7.16.0` and `v7.17.0`

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -256,6 +256,7 @@ You should enable these features only if you are using an older version.
   <summary>History</summary>
 | Version | Changes |
 | --- | --- |
+| `7.17.0` | Added `@@` and `^^` to the `topicToken` option of the `hack` pipeline operator |
 | `7.16.0` | Added `disallowAmbiguousJSXLike` for `typescript` plugin. Added `^` to the `topicToken` option of the `hack` pipeline operators |
 | `7.14.0` | Added `dts` for `typescript` plugin |
 </details>
@@ -283,7 +284,7 @@ You should enable these features only if you are using an older version.
     See [plugin-proposal-pipeline-operator](/docs/en/babel-plugin-proposal-pipeline-operator)
     for more information, including a table comparing their behavior.
 
-  - `topicToken` (required when `proposal` is `hack`, accepted values: `%`, `#`, `^`)
+  - `topicToken` (required when `proposal` is `hack`, accepted values: `%`, `#`, `^`, `@@`, `^^`)
     The `hack` proposal uses a “topic” placeholder in its pipe.
     There are two different choices for this topic placeholder.
     This option chooses what token to use to refer to the topic.

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -256,8 +256,8 @@ You should enable these features only if you are using an older version.
   <summary>History</summary>
 | Version | Changes |
 | --- | --- |
+| `7.16.0` | Added `disallowAmbiguousJSXLike` for `typescript` plugin. Added `^` to the `topicToken` option of the `hack` pipeline operators |
 | `7.14.0` | Added `dts` for `typescript` plugin |
-| `7.16.0` | Added `disallowAmbiguousJSXLike` for `typescript` plugin |
 </details>
 
 > NOTE: When a plugin is specified multiple times, only the first options are considered.
@@ -283,7 +283,7 @@ You should enable these features only if you are using an older version.
     See [plugin-proposal-pipeline-operator](/docs/en/babel-plugin-proposal-pipeline-operator)
     for more information, including a table comparing their behavior.
 
-  - `topicToken` (required when `proposal` is `hack`, accepted values: `%`, `#`)
+  - `topicToken` (required when `proposal` is `hack`, accepted values: `%`, `#`, `^`)
     The `hack` proposal uses a “topic” placeholder in its pipe.
     There are two different choices for this topic placeholder.
     This option chooses what token to use to refer to the topic.

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -193,6 +193,7 @@ require("@babel/parser").parse("code", {
   <summary>History</summary>
 | Version | Changes |
 | --- | --- |
+| `v7.17.0` | Added `regexpUnicodeSets`, `destructuringPrivate`, `decoratorAutoAccessors` |
 | `v7.15.0` | Added `hack` to the `proposal` option of `pipelineOperator`. Moved `topLevelAwait`, `privateIn` to Latest ECMAScript features |
 | `v7.14.0` | Added `asyncDoExpressions`. Moved `classProperties`, `classPrivateProperties`, `classPrivateMethods`, `moduleStringNames` to Latest ECMAScript features |
 | `v7.13.0` | Added `moduleBlocks` |
@@ -210,6 +211,8 @@ require("@babel/parser").parse("code", {
 | `asyncDoExpressions` ([proposal](https://github.com/tc39/proposal-async-do-expressions))        | `async do { await requestAPI().json() }`                 |
 | `decimal` ([proposal](https://github.com/tc39/proposal-decimal))                                | `0.3m`                                                   |
 | `decorators` ([proposal](https://github.com/tc39/proposal-decorators)) <br> `decorators-legacy` | `@a class A {}`                                          |
+| `decoratorAutoAccessors` ([proposal](https://github.com/tc39/proposal-decorators))              | `class Example { @reactive accessor myBool = false; }`   |
+| `destructuringPrivate` ([proposal](https://github.com/tc39/proposal-destructuring-private))     | `class { #x = 1; method() { const { #x: x } = this; } }` |
 | `doExpressions` ([proposal](https://github.com/tc39/proposal-do-expressions))                   | `var a = do { if (true) { 'hi'; } };`                    |
 | `exportDefaultFrom` ([proposal](https://github.com/tc39/ecmascript-export-default-from))        | `export v from "mod"`                                    |
 | `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind))                     | `a::b`, `::console.log`                                  |
@@ -218,6 +221,7 @@ require("@babel/parser").parse("code", {
 | `partialApplication` ([proposal](https://github.com/babel/proposals/issues/32))                 | `f(?, a)`                                                |
 | `pipelineOperator` ([proposal](https://github.com/babel/proposals/issues/29))                   | <code>a &#124;> b</code>                                 |
 | `recordAndTuple` ([proposal](https://github.com/tc39/proposal-record-tuple))                    | `#{x: 1}`, `#[1, 2]`                                     |
+| `regexpUnicodeSets` ([proposal](https://github.com/tc39/proposal-regexp-set-notation))          | `/[\p{Decimal_Number}--[0-9]]/v;`                        |
 | `throwExpressions` ([proposal](https://github.com/babel/proposals/issues/23))                   | `() => throw new Error("")`                              |
 
 #### Latest ECMAScript features


### PR DESCRIPTION
Update docs of `@babel/parser` to follow [`v7.16.0`](https://babeljs.io/blog/2021/10/29/7.16.0) and [`v7.17.0`](https://babeljs.io/blog/2022/02/02/7.17.0).