### PR TITLE
[7.18.0] Update docs for `importInterop` option

### DIFF
--- a/docs/plugin-transform-modules-amd.md
+++ b/docs/plugin-transform-modules-amd.md
@@ -4,6 +4,13 @@ title: @babel/plugin-transform-modules-amd
 sidebar_label: AMD
 ---
 
+<details>
+  <summary>History</summary>
+| Version | Changes |
+| --- | --- |
+| `v7.14.0` | Implemented the `importInterop` option |
+</details>
+
 > **NOTE**: This plugin is included in `@babel/preset-env` under the `modules` option
 
 This plugin transforms ECMAScript modules to [AMD](https://github.com/amdjs/amdjs-api/blob/master/AMD.md). Note that only the _syntax_ of import/export statements (`import "./mod.js"`) and import expressions (`import('./mod.js')`) is transformed, as Babel is unaware of the different resolution algorithms between implementations of ECMAScript modules and AMD.
@@ -62,4 +69,4 @@ require("@babel/core").transformSync("code", {
 
 ### Options
 
-See options for `@babel/plugin-transform-modules-commonjs`.
+See options for [`@babel/plugin-transform-modules-commonjs`](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs#options).

--- a/docs/plugin-transform-modules-commonjs.md
+++ b/docs/plugin-transform-modules-commonjs.md
@@ -82,15 +82,7 @@ require("@babel/core").transformSync("code", {
 CommonJS modules and ECMAScript modules are not fully compatible. However, compilers, bundlers and JavaScript
 runtimes developed different strategies to make them work together as well as possible.
 
-This option specify which interop strategy Babel should use. When it's a function, Babel calls it, and the
-function should return the interop to use for that specific import. For example:
-
-```js
-// foo.js
-import { a } from 'b';
-```
-
-When processing this file, babel will call your `importInterop` function with `('b', '/full/path/to/foo.js')`;
+This option specify which interop strategy Babel should use. When it's a function, Babel calls it passing the import specifier and the importer path. For example, when compiling a `/full/path/to/foo.js` file containing `import { a } from 'b'`, Babel will call it with parameters `('b', '/full/path/to/foo.js')`.
 
 #### `"babel"`
 

--- a/docs/plugin-transform-modules-commonjs.md
+++ b/docs/plugin-transform-modules-commonjs.md
@@ -90,7 +90,7 @@ function should return the interop to use for that specific import. For example:
 import { a } from 'b';
 ```
 
-When processing this file, babel will call your `importInterop` function with `('b', '/full/path/to/foo.js');
+When processing this file, babel will call your `importInterop` function with `('b', '/full/path/to/foo.js')`;
 
 #### `"babel"`
 

--- a/docs/plugin-transform-modules-commonjs.md
+++ b/docs/plugin-transform-modules-commonjs.md
@@ -77,14 +77,20 @@ require("@babel/core").transformSync("code", {
 
 ### `importInterop`
 
-`"babel" | "node" | "none"`, or `(specifier: string) => "babel" | "node" | "none"`. Defaults to `"babel"`.
+`"babel" | "node" | "none"`, or `(specifier: string, requestingFilename: string | undefined) => "babel" | "node" | "none"`. Defaults to `"babel"`.
 
 CommonJS modules and ECMAScript modules are not fully compatible. However, compilers, bundlers and JavaScript
 runtimes developed different strategies to make them work together as well as possible.
 
-This option specify which interop strategy Babel should use. When it's a function, Babel calls this function
-passing the import specifier (for example, `@babel/core` in `import { transform } from "@babel/core"`), and the
-function should return the interop to use for that specific import.
+This option specify which interop strategy Babel should use. When it's a function, Babel calls it, and the
+function should return the interop to use for that specific import. For example:
+
+```js
+// foo.js
+import { a } from 'b';
+```
+
+When processing this file, babel will call your `importInterop` function with `('b', '/full/path/to/foo.js');
 
 #### `"babel"`
 

--- a/docs/plugin-transform-modules-umd.md
+++ b/docs/plugin-transform-modules-umd.md
@@ -224,3 +224,7 @@ require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-modules-umd"],
 });
 ```
+
+### Options
+
+See options for [`@babel/plugin-transform-modules-commonjs`](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs#options).

--- a/docs/plugin-transform-modules-umd.md
+++ b/docs/plugin-transform-modules-umd.md
@@ -4,6 +4,13 @@ title: @babel/plugin-transform-modules-umd
 sidebar_label: UMD
 ---
 
+<details>
+  <summary>History</summary>
+| Version | Changes |
+| --- | --- |
+| `v7.14.0` | Implemented the `importInterop` option |
+</details>
+
 > **NOTE**: This plugin is included in `@babel/preset-env` under the `modules` option
 
 This plugin transforms ES2015 modules to [UMD](https://github.com/umdjs/umd). Note that only the _syntax_ of import/export statements (`import "./mod.js"`) is transformed, as Babel is unaware of different resolution algorithms between implementations of ES2015 modules and UMD.


### PR DESCRIPTION
It looks like the `umd` and `amd` plugins also support `importInterop` in the code, but don't mention it in the docs. Should I just copy/paste the entire `importInterop` section from the CJS docs? It's not obvious to me that that will be accurate. :smile:

https://github.com/babel/babel/pull/14456