### PR TITLE
Add `transform-react-pure-annotations` to preset-react.md

### DIFF
--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -110,7 +110,7 @@ Though the JSX spec allows this, it is disabled by default since React's JSX doe
 
 `boolean`, defaults to `true`.
 
-Enables `@babel/plugin-transform-react-pure-annotations`.
+Enables `@babel/plugin-transform-react-pure-annotations`. It will mark top-level React method calls as pure for tree shaking.
 
 ### React Automatic Runtime
 

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -8,6 +8,7 @@ This preset always includes the following plugins:
 - [@babel/plugin-syntax-jsx](plugin-syntax-jsx.md)
 - [@babel/plugin-transform-react-jsx](plugin-transform-react-jsx.md)
 - [@babel/plugin-transform-react-display-name](plugin-transform-react-display-name.md)
+- [@babel/plugin-transform-react-pure-annotations](plugin-transform-react-pure-annotations.md)
 
 And with the `development` option:
 
@@ -104,6 +105,12 @@ Toggles whether or not to throw an error if a XML namespaced tag name is used. F
     <f:image />
 
 Though the JSX spec allows this, it is disabled by default since React's JSX does not currently have support for it.
+
+#### `pure`
+
+`boolean`, defaults to `true`.
+
+Enables `@babel/plugin-transform-react-pure-annotations`.
 
 ### React Automatic Runtime
 


### PR DESCRIPTION
https://github.com/babel/babel/blob/main/packages/babel-preset-react/src/index.ts

I couldn't find plugin-transform-react-pure-annotations.md under [website/docs](https://github.com/babel/website/tree/main/docs) directory.
Even so it would be worth to list this plugin to prevent duplicate use.