### PR TITLE
Demonstrate how to specify a core-js version.

### DIFF
--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -50,7 +50,8 @@ For example, to only include polyfills and code transforms needed for users whos
     [
       "@babel/preset-env",
       {
-        "useBuiltIns": "entry"
+        "useBuiltIns": "entry",
+        "corejs": 2
       }
     ]
   ]

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -51,7 +51,7 @@ For example, to only include polyfills and code transforms needed for users whos
       "@babel/preset-env",
       {
         "useBuiltIns": "entry",
-        "corejs": 2
+        "corejs": "3.22"
       }
     ]
   ]


### PR DESCRIPTION
Currently, for the uninitiated, if they (or me in this case) installs babel, uses it, and encounters an issue where `useBuiltIns` is the solution, they will come across documentation that shows how to specify "useBuiltIns", but will encounter a warning:

```
WARNING (@babel/preset-env): We noticed you're using the `useBuiltIns` option without declaring a core-js version. Currently, we assume version 2.x when no version is passed. Since this default version will likely change in future versions of Babel, we recommend explicitly setting the core-js version you are using via the `corejs` option.

You should also be sure that the version you pass to the `corejs` option matches the version specified in your `package.json`'s `dependencies` section. If it doesn't, you need to run one of the following commands:

  npm install --save core-js@2    npm install --save core-js@3
  yarn add core-js@2              yarn add core-js@3

More info about useBuiltIns: https://babeljs.io/docs/en/babel-preset-env#usebuiltins
More info about core-js: https://babeljs.io/docs/en/babel-preset-env#corejs
```

This warning does not demonstrate **how to declare a core-js version**, and nor does the documentation it links to. 

Yes, there is a section in the documentation called **corejs**, however it is natural for some (including myself) to look at the documentation of the thing we are using for solutions. In this case, `useBuiltIns`. 

If the example code is a recommended usage, the usage should not result in a warning. If it is not a recommended usage, then it should show the bare minimum to meet the qualifications of "recommended".