### PR TITLE
updated code block title for accessibility

### DIFF
--- a/website/static/css/code-blocks.css
+++ b/website/static/css/code-blocks.css
@@ -19,8 +19,8 @@ pre {
 
 .hljs::before {
   content: "";
-  background: #fbf4d0;
-  color: #b0a673;
+  background: #fbf4da;
+  color: #846e00;
   display: block;
   font-size: 11px;
   font-weight: bold;
@@ -167,7 +167,7 @@ pre .btn-icon {
   cursor: pointer;
   border: 1px solid transparent;
   padding: 0;
-  color: #b0a673;
+  color: #846e00;
   background-color: transparent;
   height: 34px;
   transition: all 0.25s ease-out;


### PR DESCRIPTION
The color of the code block title was updated to score AA score on the color contrast as recommended by WCAG.
The language title and copy button will be more readable, especially for users with vision impairment.

## Before
<img width="683" alt="Screen Shot 2022-05-30 at 6 05 14 PM" src="https://user-images.githubusercontent.com/71072795/170993694-42471576-bda5-434b-819d-a4ff4f9f5348.png">

## After
<img width="687" alt="Screen Shot 2022-05-30 at 6 04 04 PM" src="https://user-images.githubusercontent.com/71072795/170993723-6455f2e2-c830-456d-b11d-f832ff00256a.png">

