### PR TITLE
Removed 404 page

### DIFF
--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -8,7 +8,6 @@ This preset always includes the following plugins:
 - [@babel/plugin-syntax-jsx](plugin-syntax-jsx.md)
 - [@babel/plugin-transform-react-jsx](plugin-transform-react-jsx.md)
 - [@babel/plugin-transform-react-display-name](plugin-transform-react-display-name.md)
-- [@babel/plugin-transform-react-pure-annotations](plugin-transform-react-pure-annotations.md)
 
 And with the `development` option:
 


### PR DESCRIPTION
The link to [`@babel/plugin-transform-react-pure-annotations`](https://babeljs.io/docs/en/plugin-transform-react-pure-annotations.md) returned a 404 page