### PR TITLE
Clarify that generator does not guarantee the output format

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -29,6 +29,8 @@ const output = generate(
 );
 ```
 
+> **Note:** The symbols like white spaces or new line characters are not preserved in the AST. When Babel generator prints code from the AST, the output format is not guaranteed.
+
 ## Options
 
 Options for formatting output:


### PR DESCRIPTION
Fixes https://github.com/babel/babel/issues/13617

Added a note that babel-generator does not guarantee the output format