### PR TITLE
Updating the name of the extension

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -38,7 +38,7 @@ Another option is to use [yajs.vim](https://github.com/othree/yajs.vim) with
 
 ### Visual Studio Code
 
-Install the [vscode-language-babel](https://marketplace.visualstudio.com/items?itemName=mgmcdermott.vscode-language-babel) extension and follow the instructions.
+Install the [Babel JavaScript](https://marketplace.visualstudio.com/items?itemName=mgmcdermott.vscode-language-babel) extension and follow the instructions.
 
 There seems to be one other way to get the syntax highlighting working and you can learn
 more about it in the [Visual Studio Code docs](https://code.visualstudio.com/Docs/languages/javascript#_javascript-projects-jsconfigjson).


### PR DESCRIPTION
## What changed

- The extension name is titled, Babel JavaScript