### PR TITLE
fix: typo 'classess' in assumptions docs

### DIFF
--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -265,7 +265,7 @@ a.b?.();
 
 ## `setClassMethods`
 
-When declaring classess, assume that methods don't shadow getters on the superclass and that the program doesn't depend on methods being non-enumerable. Thus, it's safe to assign methods rather than using `Object.defineProperty`.
+When declaring classes, assume that methods don't shadow getters on the superclass and that the program doesn't depend on methods being non-enumerable. Thus, it's safe to assign methods rather than using `Object.defineProperty`.
 
 <div is="assumption-repl" data-assumption="setClassMethods" data-plugins="transform-classes">
 


### PR DESCRIPTION
Simple typo fix for `classess` in docs on `assumpitons`