### PR TITLE
Remove the note about polyfill being a default behavior of the `@babel/plugin-transform-runtime`

### DIFF
--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -132,7 +132,7 @@ For more information, see [Regenerator aliasing](#regenerator-aliasing).
 
 ### `useBuiltIns`
 
-> This option was removed in v7 by just making it the default.
+> This option was removed in v7.
 
 ### `useESModules`
 

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -120,7 +120,7 @@ For more information, see [Helper aliasing](#helper-aliasing).
 
 ### `polyfill`
 
-> This option was removed in v7 by just making it the default.
+> This option was removed in v7.
 
 ### `regenerator`
 


### PR DESCRIPTION
When I tried to transform with `polyfill: false` I got this runtime error:
https://github.com/babel/babel/blob/aad7eb743d1354a5475f9d43226bfedc5f149e4b/packages/babel-plugin-transform-runtime/src/index.ts#L161-L165