### PR TITLE
adding-Emacs-editor

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -21,6 +21,12 @@ take a look at the [Setup](/setup) guide.
 Install [language-babel](https://atom.io/packages/language-babel) package
 and follow the [instructions](https://github.com/gandm/language-babel#installation).
 
+### Emacs
+
+Install the [js2-mode](https://github.com/mooz/js2-mode) that's likely the best JavaScript mode available for Emacs. It has very accurate syntax highlighting using a recursive-descent parser, strict recognition of the Ecma-262 language standard, supports most Rhino and SpiderMonkey extensions from 1.5 and up, and on-the-fly reporting of syntax errors and strict-mode warnings.
+
+In adition to [js2-mode](https://github.com/mooz/js2-mode), you can install two more packages, [js2-refactor](https://github.com/js-emacs/js2-refactor.el) that adds powerful refactorings, and [xref-js2](https://github.com/js-emacs/xref-js2) that makes it easy to jump to function references or definitions.
+
 ### Sublime Text 3
 
 First, [install Package Control](https://packagecontrol.io/installation).
@@ -35,12 +41,6 @@ improved syntax highlighting and indentation support for JavaScript to Vim.
 
 Another option is to use [yajs.vim](https://github.com/othree/yajs.vim) with
 [es.next.syntax](https://github.com/othree/es.next.syntax.vim).
-
-### Emacs
-
-Install the [js2-mode](https://github.com/mooz/js2-mode) that's likely the best JavaScript mode available for Emacs. It has very accurate syntax highlighting using a recursive-descent parser, strict recognition of the Ecma-262 language standard, supports most Rhino and SpiderMonkey extensions from 1.5 and up, and on-the-fly reporting of syntax errors and strict-mode warnings.
-
-In adition to [js2-mode](https://github.com/mooz/js2-mode), you can install two more packages,[js2-refactor](https://github.com/js-emacs/js2-refactor.el) that adds powerful refactorings, and [xref-js2](https://github.com/js-emacs/xref-js2) that makes it easy to jump to function references or definitions.
 
 ### Visual Studio Code
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -36,6 +36,12 @@ improved syntax highlighting and indentation support for JavaScript to Vim.
 Another option is to use [yajs.vim](https://github.com/othree/yajs.vim) with
 [es.next.syntax](https://github.com/othree/es.next.syntax.vim).
 
+### Emacs
+
+Install the [js2-mode](https://github.com/mooz/js2-mode) that's likely the best JavaScript mode available for Emacs. It has very accurate syntax highlighting using a recursive-descent parser, strict recognition of the Ecma-262 language standard, supports most Rhino and SpiderMonkey extensions from 1.5 and up, and on-the-fly reporting of syntax errors and strict-mode warnings.
+
+In adition to [js2-mode](https://github.com/mooz/js2-mode), you can install two more packages,[js2-refactor](https://github.com/js-emacs/js2-refactor.el) that adds powerful refactorings, and [xref-js2](https://github.com/js-emacs/xref-js2) that makes it easy to jump to function references or definitions.
+
 ### Visual Studio Code
 
 Install the [vscode-language-babel](https://marketplace.visualstudio.com/items?itemName=mgmcdermott.vscode-language-babel) extension and follow the instructions.


### PR DESCRIPTION
Hi @existentialism & @nicolo-ribaudo  , I noticed that on the [editors](https://babeljs.io/docs/en/editors) page, we don't have Emacs, although Vim has its place. So having in mind that Vim and Emacs aren’t going anywhere anytime soon, it would be fair for the Emacs crowd to have their place next to Vim on the [editors](https://babeljs.io/docs/en/editors) page :D

<img width="1680" alt="Screen Shot 2022-09-21 at 10 08 19 AM" src="https://user-images.githubusercontent.com/3509527/191450642-2ab19b6b-4fa9-4ce5-b87b-76278c8aaf20.png">

