### PR TITLE
Fix spaces before links

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -6,7 +6,7 @@ id: learn
 <blockquote class="babel-callout babel-callout-info">
   <h3>es6features</h3>
   <p>
-    This document was originally taken from Luke Hoban's excellent
+    This document was originally taken from Luke Hoban's excellent&#8200;
     <a href="https://git.io/es6features">es6features</a> repo. Go give it a star
     on GitHub!
   </p>
@@ -15,7 +15,7 @@ id: learn
 <blockquote class="babel-callout babel-callout-info">
   <h4>REPL</h4>
   <p>
-    Be sure to try these features out in the online
+    Be sure to try these features out in the online&#8200;
     <a href="/repl">REPL</a>.
   </p>
 </blockquote>


### PR DESCRIPTION
The page currently looks like this:

![image](https://user-images.githubusercontent.com/29699850/219902449-302c0654-c58e-484e-b6be-f5eb17f08bec.png)

There needs to be a space before the `es6features` and `REPL` links.

But a trailing literal space character is automatically trimmed. The equivalent HTML entity `&#32;` is also trimmed. 

Some other space characters are:

| Code | Name |
| ------ | ------- |
| U+0020 | space |
| U+00A0 | no-break space |
| U+1680 | ogham space mark |
| U+180E | mongolian vowel separator |
| U+2000 | en quad |
| U+2001 | em quad |
| U+2002 | en space |
| U+2003 | em space |
| U+2004 | three-per-em space |
| U+2005 | four-per-em space |
| U+2006 | six-per-em space |
| U+2007 | figure space |
| U+2008 | punctuation space |
| U+2009 | thin space |
| U+200A | hair space |
| U+202F | narrow no-break space |
| U+205F | medium mathematical space |
| U+3000 | ideographic space |

[Source (page 12)](https://www.unicode.org/versions/Unicode15.0.0/ch06.pdf)

Of these space characters, `U+2008 punctuation space` (HTML entity `&#8200;`) looked like the best fit, since it takes the same width as a normal space and still allows line breaks between the words.