### PR TITLE
Fix REPL sidebar bottom style

### DIFF
--- a/js/repl/ReplOptions.tsx
+++ b/js/repl/ReplOptions.tsx
@@ -1240,6 +1240,7 @@ const styles = {
     padding: "0 1.5rem",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
+    boxSizing: "border-box",
 
     [media.large]: {
       backgroundColor: colors.inverseBackgroundDark,


### PR DESCRIPTION

Current buggy behavior:
![image](https://user-images.githubusercontent.com/7000710/220152639-3521077a-a92c-4fe2-9ef9-269df05fb855.png)

New behavior: 
![image](https://user-images.githubusercontent.com/7000710/220152725-097b637a-1beb-4049-85d2-8bdd889aa5fb.png)
