### PR TITLE
Migrate `babel-callout` to infima alert

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -3,7 +3,7 @@ title: Learn ES2015
 id: learn
 ---
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h3>es6features</h3>
   <p>
     This document was originally taken from Luke Hoban's excellent <a href="https://git.io/es6features">es6features</a> repo. Go give it a star
@@ -11,7 +11,7 @@ id: learn
   </p>
 </blockquote>
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>REPL</h4>
   <p>
     Be sure to try these features out in the online <a href="/repl">REPL</a>.
@@ -132,7 +132,7 @@ var obj = {
 };
 ```
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <p>
     The <code>__proto__</code> property requires native support, and was deprecated in previous ECMAScript versions. Most engines now support the property, but <a href="https://kangax.github.io/compat-table/es6/#__proto___in_object_literals">some do not</a>. Also, note that only <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-additional-ecmascript-features-for-web-browsers">web browsers</a> are required to implement it, as it's in <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.prototype.__proto__">Annex B</a>. It is available in Node.
   </p>
@@ -306,7 +306,7 @@ interface Iterable {
 }
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Support via polyfill</h4>
   <p>
     In order to use Iterators you must include the Babel <a href="/docs/babel-polyfill">polyfill</a>.
@@ -354,7 +354,7 @@ interface Generator extends Iterator {
 }
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Support via polyfill</h4>
   <p>
     In order to use Generators you must include the Babel <a href="/docs/babel-polyfill">polyfill</a>.
@@ -433,7 +433,7 @@ import exp, {pi, e} from "lib/mathplusplus";
 console.log("e^π = " + exp(pi));
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Module Formatters</h4>
   <p>
     Babel can transpile ES2015 Modules to several different formats including
@@ -444,7 +444,7 @@ console.log("e^π = " + exp(pi));
 
 ### Module Loaders
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Not part of ES2015</h4>
   <p>
     This is left as implementation-defined within the ECMAScript 2015 specification. The eventual standard will be in WHATWG's <a href="https://whatwg.github.io/loader/">Loader specification</a>, but that is currently a work in progress. What is below is from a previous ES2015 draft.
@@ -479,7 +479,7 @@ System.get("jquery");
 System.set("jquery", Module({$: $})); // WARNING: not yet finalized
 ```
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Additional polyfill needed</h4>
   <p>
     Since Babel defaults to using common.js modules, it does not include the
@@ -487,7 +487,7 @@ System.set("jquery", Module({$: $})); // WARNING: not yet finalized
   </p>
 </blockquote>
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Using Module Loader</h4>
   <p>
     In order to use this, you'll need to tell Babel to use the
@@ -525,7 +525,7 @@ ws.add({ data: 42 });
 // Because the added object has no other references, it will not be held in the set
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Support via polyfill</h4>
   <p>
     In order to support Maps, Sets, WeakMaps, and WeakSets in all environments you must include the Babel <a href="/docs/babel-polyfill">polyfill</a>.
@@ -601,7 +601,7 @@ var handler =
 }
 ```
 
-<blockquote class="babel-callout babel-callout-danger">
+<blockquote class="alert alert--danger">
   <h4>Unsupported feature</h4>
   <p>
     Due to the limitations of ES5, Proxies cannot be transpiled or polyfilled. See support in <a href="https://kangax.github.io/compat-table/es6/#test-Proxy">various JavaScript engines</a>.
@@ -640,7 +640,7 @@ var c = new MyClass("hello")
 c["key"] === undefined
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Limited support via polyfill</h4>
   <p>
     Limited support requires the Babel <a href="/docs/babel-polyfill">polyfill</a>. Due to language limitations, some features can't be transpiled or polyfilled. See core.js's <a href="https://github.com/zloirock/core-js#caveats-when-using-symbol-polyfill">caveats section</a> for more details.
@@ -662,7 +662,7 @@ arr[1] = 12;
 arr.length == 2
 ```
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Partial support</h4>
   <p>
     Built-in subclassability should be evaluated on a case-by-case basis as classes such as <code>HTMLElement</code> <strong>can</strong> be subclassed while many such as <code>Date</code>, <code>Array</code> and <code>Error</code> <strong>cannot</strong> be due to ES5 engine limitations.
@@ -697,7 +697,7 @@ Array.of(1, 2, 3) // Similar to new Array(...), but without special one-arg beha
 Object.assign(Point, { origin: new Point(0,0) })
 ```
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Limited support from polyfill</h4>
   <p>
     Most of these APIs are supported by the Babel <a href="/docs/babel-polyfill">polyfill</a>. However, certain
@@ -715,7 +715,7 @@ Two new numeric literal forms are added for binary (`b`) and octal (`o`).
 0o767 === 503 // true
 ```
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Only supports literal form</h4>
   <p>
     Babel is only able to transform <code>0o767</code> and not
@@ -746,7 +746,7 @@ var p = timeout(1000).then(() => {
 })
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Support via polyfill</h4>
   <p>
     In order to support Promises you must include the Babel <a href="/docs/babel-polyfill">polyfill</a>.
@@ -774,7 +774,7 @@ var instance = Reflect.construct(C, [20, 22]);
 instance.c; // 42
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Support via polyfill</h4>
   <p>
     In order to use the Reflect API you must include the Babel <a href="/docs/babel-polyfill">polyfill</a>.
@@ -798,7 +798,7 @@ function factorial(n, acc = 1) {
 factorial(100000)
 ```
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Temporarily Removed in Babel 6</h4>
   <p>
     Only explicit self referencing tail recursion was supported due to the

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -31,7 +31,7 @@ See [name normalization](options.md#name-normalization) for more specifics on co
 
 These plugins apply transformations to your code.
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     Transform plugins will enable the corresponding syntax plugin so you don't have to specify both.
   </p>

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -44,7 +44,7 @@ See [name normalization](options.md#name-normalization) for more specifics on co
 
 ## Stage-X (Experimental Presets)
 
-<blockquote class="babel-callout babel-callout-danger">
+<blockquote class="alert alert--danger">
   <h4>Deprecated</h4>
   <p>
     As of Babel 7, we've decided to deprecate the Stage-X presets and stop publishing them. Because these proposals are inherently subject to change, it seems better to ask users to specify individual proposals as plugins vs. a catch all preset that you would need to check up on anyway. Check out our <a href="https://babeljs.io/blog/2018/07/27/removing-babels-stage-presets">blog</a> for more context.

--- a/docs/register.md
+++ b/docs/register.md
@@ -23,7 +23,7 @@ require("@babel/register");
 All subsequent files required by node with the extensions `.es6`, `.es`, `.jsx`,
 `.mjs`, and `.js` will be transformed by Babel.
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <h4>Polyfill not included</h4>
   <p>
     You must include the [polyfill](./polyfill.md) separately

--- a/website/blog/2015-03-31-5.0.0.md
+++ b/website/blog/2015-03-31-5.0.0.md
@@ -297,7 +297,7 @@ $ babel --optional optimisation.react.constantElements script.js
 
 ### [Inline Elements](https://github.com/facebook/react/issues/3228)
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Production only</h4>
   <p>
     Inline Elements should <strong>only</strong> be enabled in production as

--- a/website/data/tools/ava/usage.md
+++ b/website/data/tools/ava/usage.md
@@ -10,7 +10,7 @@ Enable Babel support either in `package.json` or `ava.config.*`
 Note that AVA _always_ adds a few custom Babel plugins when transpiling
 your plugins see <a href="https://github.com/avajs/ava/blob/master/docs/03-assertions.md#enhanced-assertion-messages">notes</a>.
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the<a href="https://github.com/avajs/babel">@ava/babel repo</a>.
   </p>

--- a/website/data/tools/babel_cli/install.md
+++ b/website/data/tools/babel_cli/install.md
@@ -14,7 +14,7 @@ We can install Babel CLI locally by running:
 npm install --save-dev @babel/core @babel/cli
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     <strong>Note:</strong> If you do not have a <code>package.json</code>,
     create one before installing. This will ensure proper interaction with the

--- a/website/data/tools/babel_cli/usage.md
+++ b/website/data/tools/babel_cli/usage.md
@@ -32,7 +32,7 @@ Alternatively, you can reference the `babel` cli inside of `node_modules`.
 ./node_modules/.bin/babel src -d lib
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For full documentation on the Babel CLI see the <a href="/docs/usage/cli/">usage docs</a>.
   </p>

--- a/website/data/tools/babel_node_debug/usage.md
+++ b/website/data/tools/babel_node_debug/usage.md
@@ -8,7 +8,7 @@ Or use the alias:
 bode-debug path/to/script.js
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/crabdude/babel-node-debug">crabdude/babel-node-debug repo</a>.
   </p>

--- a/website/data/tools/babel_register/usage.md
+++ b/website/data/tools/babel_register/usage.md
@@ -14,21 +14,21 @@ import "@babel/register";
 
 All subsequent files required by node with the extensions `.es6`, `.es`, `.jsx` and `.js` will be transformed by Babel. The polyfill specified in [polyfill](/docs/usage/polyfill/) is also automatically required.
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Not suitable for libraries</h4>
   <p>
     The require hook automatically hooks itself into <strong>all</strong> node requires. This will pollute the global scope and introduce conflicts. Because of this it's not suitable for libraries, if however you're writing an application then it's completely fine to use.
   </p>
 </blockquote>
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <h4>Not meant for production use</h4>
   <p>
     The require hook is primarily recommended for simple cases.
   </p>
 </blockquote>
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For full documentation on the Babel require hook see the <a href="/docs/usage/require/">usage docs</a>.
   </p>

--- a/website/data/tools/broccoli/usage.md
+++ b/website/data/tools/broccoli/usage.md
@@ -3,7 +3,7 @@ var babelTranspiler = require("broccoli-babel-transpiler");
 var scriptTree = babelTranspiler(inputTree, options);
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/broccoli-babel-transpiler">babel/broccoli-babel-transpiler repo</a>.
   </p>

--- a/website/data/tools/browser/install.md
+++ b/website/data/tools/browser/install.md
@@ -1,4 +1,4 @@
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <p>
     Compiling in the browser has a fairly limited use case, so if you are
     working on a production site you should be precompiling your scripts

--- a/website/data/tools/browser/usage.md
+++ b/website/data/tools/browser/usage.md
@@ -13,7 +13,7 @@ document.getElementById('output').innerHTML = getMessage();
 </script>
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     See <a href="/docs/en/babel-standalone">docs</a> for full documentation on <code>@babel/standalone</code>.
   </p>

--- a/website/data/tools/browserify/usage.md
+++ b/website/data/tools/browserify/usage.md
@@ -50,7 +50,7 @@ browserify().transform(babelify.configure({
 }
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/babelify">babel/babelify repo</a>.
   </p>

--- a/website/data/tools/brunch/usage.md
+++ b/website/data/tools/brunch/usage.md
@@ -9,7 +9,7 @@ plugins:
       semicolons: false
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/babel-brunch">babel/babel-brunch repo</a>.
   </p>

--- a/website/data/tools/connect/usage.md
+++ b/website/data/tools/connect/usage.md
@@ -12,7 +12,7 @@ app.use(babelMiddleware({
 app.use(connect.static("cache"));
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/babel-connect">babel/babel-connect repo</a>.
   </p>

--- a/website/data/tools/duo/usage.md
+++ b/website/data/tools/duo/usage.md
@@ -13,7 +13,7 @@ Duo(root)
   .run(fn);
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/duo-babel">babel/duo-babel repo</a>.
   </p>

--- a/website/data/tools/ember/usage.md
+++ b/website/data/tools/ember/usage.md
@@ -1,6 +1,6 @@
 That's it!
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/ember-cli-babel">babel/ember-cli-babel repo</a>.
   </p>

--- a/website/data/tools/grunt/usage.md
+++ b/website/data/tools/grunt/usage.md
@@ -18,7 +18,7 @@ grunt.loadNpmTasks('grunt-babel');
 grunt.registerTask("default", ["babel"]);
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/grunt-babel">babel/grunt-babel repo</a>.
   </p>

--- a/website/data/tools/gulp/usage.md
+++ b/website/data/tools/gulp/usage.md
@@ -31,7 +31,7 @@ gulp.task("default", function () {
 });
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/gulp-babel">babel/gulp-babel repo</a>.
   </p>

--- a/website/data/tools/jasmine/usage.md
+++ b/website/data/tools/jasmine/usage.md
@@ -18,7 +18,7 @@ Create a `babel.config.json` in your project root:
 }
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/piecioshka/test-jasmine-babel">piecioshka/test-jasmine-babel repo</a>.
   </p>

--- a/website/data/tools/jest/usage.md
+++ b/website/data/tools/jest/usage.md
@@ -13,7 +13,7 @@ In your `package.json` file make the following changes:
 }
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/facebook/jest/tree/master/packages/babel-jest">babel-jest repo</a>.
   </p>

--- a/website/data/tools/jspm/install.md
+++ b/website/data/tools/jspm/install.md
@@ -4,7 +4,7 @@ Select `babel` as the transpiler when running `jspm init -p` or to switch an exi
 jspm dl-loader --babel
 ```
 
-<blockquote class="babel-callout babel-callout-warning">
+<blockquote class="alert alert--warning">
   <p>
     The jspm package management CLI has been deprecated as of June 2020. See <a href="https://github.com/jspm/jspm-cli">jspm repo</a> for more details.
   </p>

--- a/website/data/tools/jspm/usage.md
+++ b/website/data/tools/jspm/usage.md
@@ -1,6 +1,6 @@
 Babel will automatically be used when loading any source with `import` or `export` module syntax.
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     JSX support is currently disabled by jspm. To re-enable it, add `"blacklist": []` to `babelOptions` in the jspm configuration file.
   </p>

--- a/website/data/tools/karma/usage.md
+++ b/website/data/tools/karma/usage.md
@@ -20,7 +20,7 @@ module.exports = function(config) {
 };
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/karma-babel-preprocessor">babel/karma-babel-preprocessor repo</a>.
   </p>

--- a/website/data/tools/metalsmith/usage.md
+++ b/website/data/tools/metalsmith/usage.md
@@ -33,7 +33,7 @@ new Metalsmith("./source")
   });
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/metalsmith-babel">babel/metalsmith-babel repo</a>.
   </p>

--- a/website/data/tools/meteor/usage.md
+++ b/website/data/tools/meteor/usage.md
@@ -1,7 +1,7 @@
 That's it! Any files with a `.js` extension will automatically be compiled
 with Babel.
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <code>ecmascript</code>
     <a href="https://github.com/meteor/meteor/blob/master/packages/ecmascript/README.md">README.md</a>.

--- a/website/data/tools/mocha/usage.md
+++ b/website/data/tools/mocha/usage.md
@@ -29,7 +29,7 @@ Create `babel.config.json` in your project root:
 }
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <code>babel</code>
     <a href="https://github.com/mochajs/mocha-examples/tree/master/packages/babel">mocha-examples</a>.

--- a/website/data/tools/node/usage.md
+++ b/website/data/tools/node/usage.md
@@ -4,7 +4,7 @@ require("@babel/core").transform("code", {
 });
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For full documentation on the Babel API see the <a href="/docs/usage/api/">usage docs</a>.
   </p>

--- a/website/data/tools/pug/usage.md
+++ b/website/data/tools/pug/usage.md
@@ -16,7 +16,7 @@ script
     person.sayName();
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/jstransformers/jstransformer-babel">jstransformers/jstransformer-babel repo</a>.
   </p>

--- a/website/data/tools/rails/usage.md
+++ b/website/data/tools/rails/usage.md
@@ -1,6 +1,6 @@
 That's it!
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/rails/webpacker">rails/webpacker repo</a>.
   </p>

--- a/website/data/tools/requirejs/usage.md
+++ b/website/data/tools/requirejs/usage.md
@@ -16,7 +16,7 @@ define(["es6!your-es6-module"], function (module) {
 });
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/mikach/requirejs-babel">mikach/requirejs-babel repo</a>.
   </p>

--- a/website/data/tools/rollup/usage.md
+++ b/website/data/tools/rollup/usage.md
@@ -13,7 +13,7 @@ const config = {
 export default config;
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/rollup/rollup">rollup</a> and <a href="https://github.com/rollup/plugins/tree/master/packages/babel">@rollup/plugin-babel</a> repos.
   </p>

--- a/website/data/tools/ruby/usage.md
+++ b/website/data/tools/ruby/usage.md
@@ -3,7 +3,7 @@ require 'babel/transpiler'
 Babel::Transpiler.transform File.read("foo.es6")
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/ruby-babel-transpiler">babel/ruby-babel-transpiler repo</a>.
   </p>

--- a/website/data/tools/sails/usage.md
+++ b/website/data/tools/sails/usage.md
@@ -1,6 +1,6 @@
 That's it!
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/sane/sails-hook-babel">artificialio/sails-hook-babel repo</a>.
   </p>

--- a/website/data/tools/sprockets/usage.md
+++ b/website/data/tools/sprockets/usage.md
@@ -7,7 +7,7 @@ configure_sprockets_bumble_d do |config|
 end
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/rmacklin/sprockets-bumble_d">rmacklin/sprockets-bumble_d repo</a>.
   </p>

--- a/website/data/tools/start/usage.md
+++ b/website/data/tools/start/usage.md
@@ -20,7 +20,7 @@ export const task = () =>
   )
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/deepsweet/start">deepsweet/start repo</a>.
   </p>

--- a/website/data/tools/webpack/usage.md
+++ b/website/data/tools/webpack/usage.md
@@ -19,7 +19,7 @@
 }
 ```
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://github.com/babel/babel-loader">babel/babel-loader repo</a>.
   </p>

--- a/website/data/tools/webstorm/usage.md
+++ b/website/data/tools/webstorm/usage.md
@@ -6,7 +6,7 @@ By default all files with a `.js` extension will be automatically compiled with 
 
 Lastly, in **Languages & Frameworks - JavaScript - JavaScript** language version, choose ECMAScript 6.
 
-<blockquote class="babel-callout babel-callout-info">
+<blockquote class="alert alert--info">
   <p>
     For more information see the <a href="https://blog.jetbrains.com/webstorm/2015/05/ecmascript-6-in-webstorm-transpiling#babelfilewatcher">post</a> in the WebStorm blog.
   </p>


### PR DESCRIPTION
As a follow-up to #2711 , in this PR we migrate the `babel-callout` usage to infima alert.

We can also use https://docusaurus.io/docs/markdown-features/admonitions too. But I am lazy to transform current html to markdown just for the admonition icon.

Preview link: https://deploy-preview-2730--babel.netlify.app/docs/learn