### PR TITLE
fix dark mode primary colors

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -17,7 +17,7 @@
 
   --ifm-blockquote-border-left-width: 4px;
 }
-[data-theme='dark'] {
+html[data-theme='dark'] {
   --ifm-color-primary: #f5da55;
   --ifm-color-primary-dark: #f3d336;
   --ifm-color-primary-darker: #f2d026;


### PR DESCRIPTION
The dark mode primary colors seem not working.

Currently main:

<img width="1298" alt="image" src="https://user-images.githubusercontent.com/3607926/221300375-10741924-2740-443e-80bb-2e9fd81b714e.png">

Expected:

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/3607926/221300521-259b71a5-98f8-4336-b7c2-419631088254.png">