### PR TITLE
Refine @babel/standalone docs

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -3,30 +3,36 @@ id: babel-standalone
 title: "@babel/standalone"
 ---
 
-@babel/standalone provides a standalone build of Babel for use in browsers and other non-Node.js environments.
+`@babel/standalone` provides a standalone build of Babel for use in browsers and other non-Node.js environments.
 
-# When (not) to use @babel/standalone
+## When (not) to use @babel/standalone
 
-If you're using Babel in production, you should normally not use @babel/standalone. Instead, you should use a build system running on Node.js, such as Webpack, Rollup, or Parcel, to transpile your JS ahead of time.
+If you're using Babel in production, you should normally not use `@babel/standalone`. Instead, you should use a build system running on Node.js, such as Webpack, Rollup, or Parcel, to transpile your JS ahead of time.
 
 However, there are some valid use cases for @babel/standalone:
 
-- It provides an easy, convenient way to prototype with Babel. Using @babel/standalone, you can get started using Babel with just a simple script tag in your HTML.
+- It provides an easy, convenient way to prototype with Babel. Using `@babel/standalone`, you can get started using Babel with just a simple script tag in your HTML.
 - Sites that compile user-provided JavaScript in real-time, like [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com/), the [REPL on the Babel site](http://babeljs.io/repl/), [JSitor](https://jsitor.com), etc.
 - Apps that embed a JavaScript engine such as V8 directly, and want to use Babel for compilation
-- Apps that want to use JavaScript as a scripting language for extending the app itself, including all the goodies that ES2015 provides.
+- Apps that want to use JavaScript as a scripting language for extending the app itself, including all the goodies that modern ES provides.
 - Other non-Node.js environments ([ReactJS.NET](http://reactjs.net/), [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler), [php-babel-transpiler](https://github.com/talyssonoc/php-babel-transpiler), etc).
 
-# Installation
+## Installation
 
-There are several ways to get a copy of @babel/standalone. Pick whichever one you like:
+There are several ways to get a copy of `@babel/standalone`. Pick whichever one you like:
 
-- Use it via UNPKG: https://unpkg.com/@babel/standalone/babel.min.js. This is a simple way to embed it on a webpage without having to do any other setup.
-- Install via NPM: `npm install --save @babel/standalone`
+- Use it via [UNPKG](https://unpkg.com/@babel/standalone/babel.min.js). This is a simple way to embed it on a webpage without having to do any other setup.
+  ```html
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  ```
+- Install it manually:
+  ```shell npm2yarn
+  npm install --save @babel/standalone
+  ```
 
-# Script Tags
+## Script Tags
 
-When loaded in a browser, @babel/standalone will automatically compile and execute all script tags with type `text/babel` or `text/jsx`:
+When loaded in a browser, `@babel/standalone` will automatically compile and execute all script tags with type `text/babel` or `text/jsx`:
 
 ```html
 <div id="output"></div>
@@ -39,35 +45,55 @@ When loaded in a browser, @babel/standalone will automatically compile and execu
 </script>
 ```
 
-If you want to use your browser's native support for ES Modules, you'd normally need to set a `type="module"` attribute on your script tag.
+### Attributes
 
+#### `data-type`
 Added in: `v7.10.0`
 
-With @babel/standalone, set a `data-type="module"` attribute instead, like this:
+If you want to use your browser's native support for ES Modules, you'd normally need to set a `type="module"` attribute on your script tag.
+
+With `@babel/standalone`, set a `data-type="module"` attribute instead, like this:
 
 ```html
 <script type="text/babel" data-type="module">
 ```
 
-You can use the `data-plugins` and `data-presets` attributes to specify the Babel plugins/presets to use:
+#### `data-presets`
+Use the `data-presets` attributes to enable builtin Babel presets. Multiple values are comma separated:
 
 ```html
-<script type="text/babel" data-presets="env,stage-3">
+<script type="text/babel" data-presets="env,react">
+```
+Most popular presets are: [`env`](./preset-env.md), [`react`](./preset-react.md), [`typescript`](./preset-typescript.md), [`flow`](./preset-flow.md). You can also use `Babel.availablePresets` to query available presets.
+
+If you want to pass additional options, refer to the [custom presets](#custom-presets-passing-options-to-built-in-presetsplugins) section.
+
+#### `data-plugins`
+Use the `data-plugins` attribute to enable builtin Babel plugins. Multiple values are comma separated.
+
+```html
+<script type="text/babel" data-plugins="proposal-class-properties">
 ```
 
+See [here](https://github.com/babel/babel/blob/main/packages/babel-standalone/src/generated/plugins.ts) for a list of builtin plugins in `@babel/standalone`. You can also access the list from `Babel.availablePlugins`.
+
+If you want to add custom plugins, refer to the [custom plugins](#custom-plugins) section.
+
+#### `src`
 Loading external scripts via `src` attribute is supported too:
 
 ```html
 <script type="text/babel" src="foo.js"></script>
 ```
 
+#### `async`
 You can also set the `async` attribute for external scripts.
 
 ```html
 <script type="text/babel" src="foo.js" async></script>
 ```
 
-# API
+## API
 
 Load `babel.js` or `babel.min.js` in your environment. This will expose [Babel's API](http://babeljs.io/docs/usage/api/) in a `Babel` object:
 
@@ -76,9 +102,9 @@ var input = 'const getMessage = () => "Hello World";';
 var output = Babel.transform(input, { presets: ["env"] }).code;
 ```
 
-Note that [config files](config-files.md) don't work in @babel/standalone, as no file system access is available. The presets and/or plugins to use **must** be specified in the options passed to `Babel.transform`.
+Note that [config files](config-files.md) don't work in `@babel/standalone`, as no file system access is available. The presets and/or plugins to use **must** be specified in the options passed to `Babel.transform`.
 
-# Customization
+## Customization
 
 ### custom plugins
 
@@ -124,7 +150,7 @@ Babel.registerPreset("env-plus", {
   plugins: [
     [
       Babel.availablePlugins["proposal-decorators"],
-      { decoratorsBeforeExport: true },
+      { version: "2023-01" },
     ],
   ],
 });


### PR DESCRIPTION
- Added examples of `data-plugins`
- Added (and how to access) list of available presets / plugins

Preview link: https://deploy-preview-2736--babel.netlify.app/docs/babel-standalone