### PR TITLE
feat: add modules option toggle

### DIFF
--- a/js/repl/PluginConfig.ts
+++ b/js/repl/PluginConfig.ts
@@ -66,7 +66,7 @@ const envPresetDefaults = {
     default: "3.21",
   },
   modules: {
-    default: "auto",
+    default: false,
   },
 } as const;
 
@@ -110,7 +110,7 @@ const replDefaults: ReplState = {
     compiledSize: 0,
     rawSize: 0,
   },
-  modules: "auto",
+  modules: false,
   presets: "react,stage-2,env",
   prettier: false,
   showSidebar: true,

--- a/js/repl/PluginConfig.ts
+++ b/js/repl/PluginConfig.ts
@@ -65,6 +65,9 @@ const envPresetDefaults = {
   corejs: {
     default: "3.21",
   },
+  modules: {
+    default: "auto",
+  },
 } as const;
 
 const runtimePolyfillConfig: PluginConfig = {
@@ -107,6 +110,7 @@ const replDefaults: ReplState = {
     compiledSize: 0,
     rawSize: 0,
   },
+  modules: "auto",
   presets: "react,stage-2,env",
   prettier: false,
   showSidebar: true,

--- a/js/repl/Repl.tsx
+++ b/js/repl/Repl.tsx
@@ -532,6 +532,9 @@ class Repl extends React.Component<Props, State> {
           this.state.envConfig.corejs = false;
         }
       }
+      if (name === "modules" && value === "false") {
+        value = false;
+      }
       this.setState(
         // TODO: FIXME
         // @ts-expect-error
@@ -613,6 +616,7 @@ class Repl extends React.Component<Props, State> {
       circleciRepo: state.babel.circleciRepo,
       code: state.code,
       debug: state.debugEnvPreset,
+      modules: envConfig.modules,
       forceAllTransforms: envConfig.forceAllTransforms,
       shippedProposals: envConfig.shippedProposals,
       evaluate: state.runtimePolyfillState.isEnabled,

--- a/js/repl/ReplOptions.tsx
+++ b/js/repl/ReplOptions.tsx
@@ -651,12 +651,11 @@ class ExpandedContainer extends Component<Props, State> {
                   onChange={this._onEnvPresetSettingChange("modules")}
                   disabled={!envConfig.isEnvPresetEnabled}
                 >
-                  <option value="auto">auto</option>
+                  <option value="false">false</option>
                   <option value="amd">amd</option>
                   <option value="umd">umd</option>
                   <option value="systemjs">systemjs</option>
                   <option value="commonjs">commonjs</option>
-                  <option value="false">false</option>
                 </select>
               </label>
               <label className={styles.envPresetRow}>

--- a/js/repl/ReplOptions.tsx
+++ b/js/repl/ReplOptions.tsx
@@ -132,7 +132,7 @@ const LinkToDocs = ({ className, children, section }: LinkProps) => (
   <a
     className={className}
     target="_blank"
-    href={`/docs/en/next/babel-preset-env.html#${section}`}
+    href={`/docs/babel-preset-env#${section}`}
   >
     {children}
   </a>
@@ -142,7 +142,7 @@ const LinkToAssumptionDocs = ({ className, children, section }: LinkProps) => (
   <a
     className={className}
     target="_blank"
-    href={`/docs/en/next/assumptions#${section.toLowerCase()}`}
+    href={`/docs/assumptions#${section.toLowerCase()}`}
   >
     {children}
   </a>
@@ -638,6 +638,26 @@ class ExpandedContainer extends Component<Props, State> {
                   onChange={this._onEnvPresetSettingCheck("isBuiltInsEnabled")}
                   type="checkbox"
                 />
+              </label>
+              <label className={styles.envPresetRow}>
+                <LinkToDocs className={`${styles.envPresetLabel} ${styles.highlight}`}
+                  section="modules"
+                >
+                  Modules
+                </LinkToDocs>
+                <select
+                  value={envConfig.modules}
+                  className={styles.envPresetSelect}
+                  onChange={this._onEnvPresetSettingChange("modules")}
+                  disabled={!envConfig.isEnvPresetEnabled}
+                >
+                  <option value="auto">auto</option>
+                  <option value="amd">amd</option>
+                  <option value="umd">umd</option>
+                  <option value="systemjs">systemjs</option>
+                  <option value="commonjs">commonjs</option>
+                  <option value="false">false</option>
+                </select>
               </label>
               <label className={styles.envPresetRow}>
                 <LinkToDocs

--- a/js/repl/UriUtils.ts
+++ b/js/repl/UriUtils.ts
@@ -12,6 +12,7 @@ const URL_KEYS = [
   "code",
   "debug",
   "forceAllTransforms",
+  "modules",
   "shippedProposals",
   "circleciRepo",
   "evaluate",

--- a/js/repl/compile.ts
+++ b/js/repl/compile.ts
@@ -70,7 +70,7 @@ export default function compile(code: string, config: CompileConfig): Return {
 
   if (envConfig && envConfig.isEnvPresetEnabled) {
     const targets: any = {};
-    const { forceAllTransforms, shippedProposals } = envConfig;
+    const { forceAllTransforms, shippedProposals, modules } = envConfig;
 
     if (envConfig.browsers) {
       targets.browsers = envConfig.browsers
@@ -105,6 +105,7 @@ export default function compile(code: string, config: CompileConfig): Return {
 
     presetEnvOptions = {
       targets,
+      modules,
       forceAllTransforms,
       shippedProposals,
       useBuiltIns,

--- a/js/repl/compile.ts
+++ b/js/repl/compile.ts
@@ -109,10 +109,15 @@ export default function compile(code: string, config: CompileConfig): Return {
       forceAllTransforms,
       shippedProposals,
       useBuiltIns,
-      corejs,
+      corejs: undefined,
       spec,
       loose,
     };
+
+    if (useBuiltIns) {
+      (presetEnvOptions as any).corejs = corejs;
+    }
+
     if (Babel.version && compareVersions(Babel.version, "7.9.0") !== -1) {
       (presetEnvOptions as any).bugfixes = bugfixes;
     }

--- a/js/repl/replUtils.ts
+++ b/js/repl/replUtils.ts
@@ -153,6 +153,7 @@ export const persistedStateToEnvConfig = (
     isEnvPresetEnabled,
     isElectronEnabled: false,
     isNodeEnabled: false,
+    modules: persistedState.modules ?? envPresetDefaults.modules.default,
     forceAllTransforms: !!persistedState.forceAllTransforms,
     shippedProposals: !!persistedState.shippedProposals,
     isBuiltInsEnabled: !!persistedState.builtIns,

--- a/js/repl/types.ts
+++ b/js/repl/types.ts
@@ -30,7 +30,7 @@ export type EnvConfig = {
   isSpecEnabled: boolean;
   isLooseEnabled: boolean;
   builtIns: false | "entry" | "usage";
-  modules: false | "amd" | "umd" | "systemjs" | "commonjs" | "auto";
+  modules: false | "amd" | "umd" | "systemjs" | "commonjs";
   corejs: string | false;
   forceAllTransforms: boolean;
   shippedProposals: boolean;

--- a/js/repl/types.ts
+++ b/js/repl/types.ts
@@ -30,6 +30,7 @@ export type EnvConfig = {
   isSpecEnabled: boolean;
   isLooseEnabled: boolean;
   builtIns: false | "entry" | "usage";
+  modules: false | "amd" | "umd" | "systemjs" | "commonjs" | "auto";
   corejs: string | false;
   forceAllTransforms: boolean;
   shippedProposals: boolean;
@@ -134,6 +135,7 @@ export type ReplState = {
   timeTravel: boolean;
   sourceType: SourceType;
   forceAllTransforms: boolean;
+  modules: EnvConfig["modules"];
   shippedProposals: boolean;
   lineWrap: boolean;
   presets: string | undefined | null;


### PR DESCRIPTION
Added `modules` option toggle to REPL, also updated REPL docs links.

Preview link: https://deploy-preview-2738--babel.netlify.app/repl