### PR TITLE
sidebar: move plugins under presets

### DIFF
--- a/docs/plugin-transform-flow-strip-types.md
+++ b/docs/plugin-transform-flow-strip-types.md
@@ -1,7 +1,7 @@
 ---
 id: babel-plugin-transform-flow-strip-types
 title: "@babel/plugin-transform-flow-strip-types"
-sidebar_label: Flow Plugin
+sidebar_label: transform-flow-strip-types
 ---
 
 > **NOTE**: This plugin is included in `@babel/preset-flow`

--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -1,7 +1,7 @@
 ---
 id: babel-plugin-transform-react-jsx
 title: "@babel/plugin-transform-react-jsx"
-sidebar_label: React Plugin
+sidebar_label: transform-react-jsx
 ---
 
 > **NOTE**: This plugin is included in `@babel/preset-react`

--- a/docs/plugin-transform-typescript.md
+++ b/docs/plugin-transform-typescript.md
@@ -1,7 +1,7 @@
 ---
 id: babel-plugin-transform-typescript
 title: "@babel/plugin-transform-typescript"
-sidebar_label: Typescript Plugin
+sidebar_label: transform-typescript
 ---
 
 > **NOTE**: This plugin is included in `@babel/preset-typescript`

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,50 +1,208 @@
 {
-  "docs": {
-    "Guides": ["index", "usage", "configuration", "learn", "v7-migration"],
-    "Config Reference": [
-      "config-files",
-      "options",
-      "presets",
-      "plugins",
-      "plugins-list",
-      "assumptions"
-    ],
-    "Presets": [
-      "babel-preset-env",
-      "babel-preset-react",
-      "babel-preset-typescript",
-      "babel-preset-flow"
-    ],
-    "Misc": ["roadmap", "caveats", "features-timeline", "faq", "editors"],
-    "Integration Packages": [
-      "babel-cli",
-      "babel-polyfill",
-      "babel-plugin-transform-runtime",
-      "babel-register",
-      "babel-standalone"
-    ],
-    "Tooling Packages": [
-      "babel-parser",
-      "babel-core",
-      "babel-generator",
-      "babel-code-frame",
-      "babel-runtime",
-      "babel-template",
-      "babel-traverse",
-      "babel-types"
-    ],
-    "Helper Packages": [
-      "babel-helper-compilation-targets",
-      "babel-helper-module-imports",
-      "babel-helper-validator-identifier"
-    ]
-  },
+  "docs": [
+    {
+      "type": "category",
+      "label": "Guides",
+      "items": ["index", "usage", "configuration", "learn", "v7-migration"]
+    },
+    {
+      "type": "category",
+      "label": "Config Reference",
+      "items": [
+        "config-files",
+        "options",
+        "plugins",
+        "plugins-list",
+        "assumptions"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Presets",
+      "link": {
+        "type": "doc",
+        "id": "presets"
+      },
+      "items": [
+        {
+          "type": "category",
+          "label": "@babel/preset-env",
+          "link": {
+            "type": "doc",
+            "id": "babel-preset-env"
+          },
+          "items": [
+            {
+              "type": "category",
+              "label": "ES2022",
+              "items": [
+                "babel-plugin-proposal-class-properties",
+                "babel-plugin-proposal-class-static-block",
+                "babel-plugin-proposal-private-property-in-object",
+                "babel-plugin-syntax-top-level-await"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "ES2021",
+              "items": [
+                "babel-plugin-proposal-logical-assignment-operators",
+                "babel-plugin-proposal-numeric-separator"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "ES2020",
+              "items": [
+                "babel-plugin-proposal-export-namespace-from",
+                "babel-plugin-proposal-nullish-coalescing-operator",
+                "babel-plugin-proposal-optional-chaining",
+                "babel-plugin-syntax-bigint",
+                "babel-plugin-syntax-dynamic-import",
+                "babel-plugin-syntax-import-meta"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "ES2019",
+              "items": [
+                "babel-plugin-proposal-optional-catch-binding",
+                "babel-plugin-proposal-json-strings"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "ES2018",
+              "items": [
+                "babel-plugin-proposal-async-generator-functions",
+                "babel-plugin-proposal-object-rest-spread",
+                "babel-plugin-proposal-unicode-property-regex",
+                "babel-plugin-transform-dotall-regex",
+                "babel-plugin-transform-named-capturing-groups-regex"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "ES2017",
+              "items": ["babel-plugin-transform-async-to-generator"]
+            },
+            {
+              "type": "category",
+              "label": "ES2016",
+              "items": ["babel-plugin-transform-exponentiation-operator"]
+            },
+            {
+              "type": "category",
+              "label": "ES2015",
+              "items": [
+                "babel-plugin-transform-arrow-functions",
+                "babel-plugin-transform-block-scoping",
+                "babel-plugin-transform-classes",
+                "babel-plugin-transform-computed-properties",
+                "babel-plugin-transform-destructuring",
+                "babel-plugin-transform-duplicate-keys",
+                "babel-plugin-transform-for-of",
+                "babel-plugin-transform-function-name",
+                "babel-plugin-transform-instanceof",
+                "babel-plugin-transform-literals",
+                "babel-plugin-transform-new-target",
+                "babel-plugin-transform-object-super",
+                "babel-plugin-transform-parameters",
+                "babel-plugin-transform-shorthand-properties",
+                "babel-plugin-transform-spread",
+                "babel-plugin-transform-sticky-regex",
+                "babel-plugin-transform-template-literals",
+                "babel-plugin-transform-typeof-symbol",
+                "babel-plugin-transform-unicode-escapes",
+                "babel-plugin-transform-unicode-regex"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "ES5",
+              "items": ["babel-plugin-transform-property-mutators"]
+            },
+            {
+              "type": "category",
+              "label": "ES3",
+              "items": [
+                "babel-plugin-transform-member-expression-literals",
+                "babel-plugin-transform-property-literals",
+                "babel-plugin-transform-reserved-words"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "category",
+          "label": "@babel/preset-react",
+          "link": {
+            "type": "doc",
+            "id": "babel-preset-react"
+          },
+          "items": ["babel-plugin-transform-react-jsx"]
+        },
+        {
+          "type": "category",
+          "label": "@babel/preset-typescript",
+          "link": {
+            "type": "doc",
+            "id": "babel-preset-typescript"
+          },
+          "items": ["babel-plugin-transform-typescript"]
+        },
+        {
+          "type": "category",
+          "label": "@babel/preset-flow",
+          "link": {
+            "type": "doc",
+            "id": "babel-preset-flow"
+          },
+          "items": ["babel-plugin-transform-flow-strip-types"]
+        }
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Misc",
+      "items": ["roadmap", "caveats", "features-timeline", "faq", "editors"]
+    },
+    {
+      "type": "category",
+      "label": "Integration Packages",
+      "items": [
+        "babel-cli",
+        "babel-polyfill",
+        "babel-plugin-transform-runtime",
+        "babel-register",
+        "babel-standalone"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Tooling Packages",
+      "items": [
+        "babel-parser",
+        "babel-core",
+        "babel-generator",
+        "babel-code-frame",
+        "babel-runtime",
+        "babel-template",
+        "babel-traverse",
+        "babel-types"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Helper Packages",
+      "items": [
+        "babel-helper-compilation-targets",
+        "babel-helper-module-imports",
+        "babel-helper-validator-identifier"
+      ]
+    }
+  ],
   "plugins": {
-    "Extensions": [
-      "babel-plugin-transform-react-jsx",
-      "babel-plugin-transform-flow-strip-types",
-      "babel-plugin-transform-typescript"
-    ],
     "Modules": [
       "babel-plugin-transform-modules-amd",
       "babel-plugin-transform-modules-commonjs",
@@ -66,109 +224,6 @@
       "babel-plugin-proposal-regexp-modifiers",
       "babel-plugin-proposal-throw-expressions",
       "babel-plugin-proposal-unicode-sets-regex"
-    ],
-    "@babel/preset-env": [
-      {
-        "type": "category",
-        "label": "ES2022",
-        "items": [
-          "babel-plugin-proposal-class-properties",
-          "babel-plugin-proposal-class-static-block",
-          "babel-plugin-proposal-private-methods",
-          "babel-plugin-proposal-private-property-in-object",
-          "babel-plugin-syntax-top-level-await"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "ES2021",
-        "items": [
-          "babel-plugin-proposal-logical-assignment-operators",
-          "babel-plugin-proposal-numeric-separator"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "ES2020",
-        "items": [
-          "babel-plugin-proposal-dynamic-import",
-          "babel-plugin-proposal-export-namespace-from",
-          "babel-plugin-proposal-nullish-coalescing-operator",
-          "babel-plugin-proposal-optional-chaining",
-          "babel-plugin-syntax-bigint",
-          "babel-plugin-syntax-dynamic-import",
-          "babel-plugin-syntax-import-meta"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "ES2019",
-        "items": [
-          "babel-plugin-proposal-optional-catch-binding",
-          "babel-plugin-proposal-json-strings"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "ES2018",
-        "items": [
-          "babel-plugin-proposal-async-generator-functions",
-          "babel-plugin-proposal-object-rest-spread",
-          "babel-plugin-proposal-unicode-property-regex",
-          "babel-plugin-transform-dotall-regex",
-          "babel-plugin-transform-named-capturing-groups-regex"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "ES2017",
-        "items": ["babel-plugin-transform-async-to-generator"]
-      },
-      {
-        "type": "category",
-        "label": "ES2016",
-        "items": ["babel-plugin-transform-exponentiation-operator"]
-      },
-      {
-        "type": "category",
-        "label": "ES2015",
-        "items": [
-          "babel-plugin-transform-arrow-functions",
-          "babel-plugin-transform-block-scoping",
-          "babel-plugin-transform-classes",
-          "babel-plugin-transform-computed-properties",
-          "babel-plugin-transform-destructuring",
-          "babel-plugin-transform-duplicate-keys",
-          "babel-plugin-transform-for-of",
-          "babel-plugin-transform-function-name",
-          "babel-plugin-transform-instanceof",
-          "babel-plugin-transform-literals",
-          "babel-plugin-transform-new-target",
-          "babel-plugin-transform-object-super",
-          "babel-plugin-transform-parameters",
-          "babel-plugin-transform-shorthand-properties",
-          "babel-plugin-transform-spread",
-          "babel-plugin-transform-sticky-regex",
-          "babel-plugin-transform-template-literals",
-          "babel-plugin-transform-typeof-symbol",
-          "babel-plugin-transform-unicode-escapes",
-          "babel-plugin-transform-unicode-regex"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "ES5",
-        "items": ["babel-plugin-transform-property-mutators"]
-      },
-      {
-        "type": "category",
-        "label": "ES3",
-        "items": [
-          "babel-plugin-transform-member-expression-literals",
-          "babel-plugin-transform-property-literals",
-          "babel-plugin-transform-reserved-words"
-        ]
-      }
     ]
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -38,6 +38,7 @@
               "items": [
                 "babel-plugin-proposal-class-properties",
                 "babel-plugin-proposal-class-static-block",
+                "babel-plugin-proposal-private-methods",
                 "babel-plugin-proposal-private-property-in-object",
                 "babel-plugin-syntax-top-level-await"
               ]
@@ -54,6 +55,7 @@
               "type": "category",
               "label": "ES2020",
               "items": [
+                "babel-plugin-proposal-dynamic-import",
                 "babel-plugin-proposal-export-namespace-from",
                 "babel-plugin-proposal-nullish-coalescing-operator",
                 "babel-plugin-proposal-optional-chaining",


### PR DESCRIPTION
This is an experimental PR. I would like learn about your opinions.

Previously the plugins have dedicated sidebars, so there are no means to navigate to the plugin pages unless you already know the plugin name _and_ either 1) search on the docs website or 2) visit the plugin docs link from npm package readme.

In this PR we moved most plugins (except modules / proposals) under the presets page. So users can learn from the sidebar that which plugins are included in which presets and then they can check it out if they want to learn more about the presets.

The "presets" category now displays contents of "config reference / presets" page now that docusaurus 2 supports category link.

Preview link: https://deploy-preview-2739--babel.netlify.app/docs/