### PR TITLE
update pipeline operator proposal links

### DIFF
--- a/docs/plugin-proposal-pipeline-operator.md
+++ b/docs/plugin-proposal-pipeline-operator.md
@@ -6,8 +6,8 @@ sidebar_label: pipeline-operator
 
 ## Installation
 
-```sh title="Shell"
-$ npm install --save-dev @babel/plugin-proposal-pipeline-operator
+```shell npm2yarn
+npm install --save-dev @babel/plugin-proposal-pipeline-operator
 ```
 
 ## Usage
@@ -18,19 +18,19 @@ Its value is `"hack"` by default.
 
 | Value | Proposal | Version added |
 | ----- | -------- | ------------- |
-| ~~`"minimal"`~~ | [Minimal F#-style pipes](https://github.com/tc39/proposal-pipeline-operator/) | `v7.0.0`
+| `"hack"` | [Hack-style pipes](https://github.com/tc39/proposal-pipeline-operator) | `v7.15.0`
 | ~~`"fsharp"`~~ | [F#-style pipes with `await`](https://github.com/valtech-nyc/proposal-fsharp-pipelines) | `v7.5.0`
-| `"hack"` | [Hack-style pipes](https://github.com/js-choi/proposal-hack-pipes) | `v7.15.0`
+| ~~`"minimal"`~~ | [Minimal F#-style pipes](https://github.com/tc39/proposal-pipeline-operator/tree/abb51b3aef5c17d5971808aee49ebe6b75d7280f) | `v7.0.0`
 | ~~`"smart"`~~ | [Smart-mix pipes](https://github.com/js-choi/proposal-smart-pipelines) (deprecated) | `v7.3.0`
 
-If `"proposal"` is omitted, or if `"proposal": "hack"` is used, then a `"topicToken": "^^"`, `"topicToken": "^"`, or `"topicToken": "#"` option must also be included.
+If `"proposal"` is omitted, or if `"proposal": "hack"` is used, then a `"topicToken"` option must be included. The `topicToken` must be one of `"%"`, `"^^"`, `"@@"`, `"^"`, or `"#"`.
 
 The `"proposal": "minimal"`, `"fsharp"`, and `"smart"` options are **deprecated** and subject to removal in a future major version.
 
 ### Examples
 The following examples use `topicToken: "^^"`.
 
-From [react/scripts/jest/jest-cli.js][].
+From [react/scripts/jest/jest-cli.js](https://github.com/facebook/react/blob/12adaffef7105e2714f82651ea51936c563fe15c/scripts/jest/jest-cli.js#L295-L303).
 ```js title="JavaScript"
 // Status quo
 console.log(
@@ -52,7 +52,7 @@ Object.keys(envars)
   |> console.log(^^);
 ```
 
-From [jquery/src/core/init.js][].
+From [jquery/src/core/init.js](https://github.com/jquery/jquery/blob/acb7c49c8d42f601fa347661b1118959079f6b52/src/core/init.js#L51-L55).
 ```js title="JavaScript"
 // Status quo
 jQuery.merge( this, jQuery.parseHTML(
@@ -67,9 +67,6 @@ context
   |> jQuery.parseHTML(match[1], ^^, true)
   |> jQuery.merge(^^);
 ```
-
-[react/scripts/jest/jest-cli.js]: https://github.com/facebook/react/blob/17.0.2/scripts/jest/jest-cli.js
-[jquery/src/core/init.js]: https://github.com/jquery/jquery/blob/2.2-stable/src/core/init.js
 
 (For a summary of deprecated proposal modes’ behavior, see the [pipe wiki’s table of previous proposals](https://github.com/tc39/proposal-pipeline-operator/wiki#overview-of-previous-proposals).)
 


### PR DESCRIPTION
Also added supported topic tokens.

Preview link: https://deploy-preview-2743--babel.netlify.app/docs/babel-plugin-proposal-pipeline-operator