### PR TITLE
fix summary table

### DIFF
--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -247,6 +247,7 @@ class Foo {
 
 <details>
   <summary>History</summary>
+
 | Version | Changes |
 | --- | --- |
 | v7.21.0 | Added `privateFieldsAsSymbols` assumption |

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -35,6 +35,7 @@ const output = generate(
 
 <details>
   <summary>History</summary>
+
 | Version | Changes |
 | --- | --- |
 | v7.21.0 | Added `inputSourceMap` |


### PR DESCRIPTION
The MDX requires line breaks after `<summary>` tag.