### PR TITLE
fix 6.23.0 blog post link

### DIFF
--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -84,7 +84,7 @@ const Versions = () => {
                         </a>
                       </td>
                       <td>
-                        <a href={`${customFields.baseUrl}6.23.0`}>Blog Post</a>
+                        <a href={`${siteConfig.baseUrl}6.23.0`}>Blog Post</a>
                       </td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
This is a follow-up to #2733, I forgot to replace the last `customFields.baseUrl` occurrence.