### PR TITLE
fix: markdown formatting in Babel docs

### DIFF
--- a/docs/plugin-proposal-class-properties.md
+++ b/docs/plugin-proposal-class-properties.md
@@ -5,6 +5,7 @@ sidebar_label: class-properties
 ---
 
 > **NOTE**: This plugin is included in `@babel/preset-env`, in [ES2022](https://github.com/tc39/proposals/blob/master/finished-proposals.md)
+
 ## Example
 
 Below is a class with four class properties which will be transformed.


### PR DESCRIPTION
Markdown formatting for the "Example" heading is broken, there's no line break between the blockquote and the heading. This PR fixes it

## Broken

URL: https://babeljs.io/docs/babel-plugin-proposal-class-properties#installation

<img width="886" alt="image" src="https://user-images.githubusercontent.com/18097732/222658608-2c14b069-ab60-4190-8f5b-1a5ec547a893.png">

## Fixed

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/18097732/222658744-a8cad604-3d7e-4a8a-86f4-22fb09d756ff.png">
