### PR TITLE
Add placeholder docs for helpers

### DIFF
--- a/docs/helper-bindify-decorators.md
+++ b/docs/helper-bindify-decorators.md
@@ -4,10 +4,10 @@ title: "@babel/helper-bindify-decorators"
 sidebar_label: helper-bindify-decorators
 ---
 
+:::danger Archived
+This library is no longer maintained. You can check out the [source](https://github.com/babel/babel-archive/tree/main/packages/babel-helper-bindify-decorators) here.
+:::
+
 ```js title="JavaScript"
 declare export default bindifyDecorators(decorators: Array<NodePath>);
 ```
-## Usage
-
-TODO
-

--- a/docs/helper-builder-binary-assignment-operator-visitor.md
+++ b/docs/helper-builder-binary-assignment-operator-visitor.md
@@ -4,5 +4,7 @@ title: "@babel/helper-builder-binary-assignment-operator-visitor"
 sidebar_label: helper-builder-binary-assignment-operator-visitor
 ---
 
-TODO
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-builder-binary-assignment-operator-visitor) here.
+:::
 

--- a/docs/helper-call-delegate.md
+++ b/docs/helper-call-delegate.md
@@ -4,5 +4,7 @@ title: "@babel/helper-call-delegate"
 sidebar_label: helper-call-delegate
 ---
 
-TODO
+:::danger Archived
+This library is no longer maintained. You can check out the [source](https://github.com/babel/babel-archive/tree/main/packages/babel-helper-call-delegate) here.
+:::
 

--- a/docs/helper-check-duplicate-nodes.md
+++ b/docs/helper-check-duplicate-nodes.md
@@ -1,0 +1,9 @@
+---
+id: babel-helper-check-duplicate-nodes
+title: "@babel/helper-check-duplicate-nodes"
+sidebar_label: helper-check-duplicate-nodes
+---
+
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-check-duplicate-nodes) here.
+:::

--- a/docs/helper-create-class-features-plugin.md
+++ b/docs/helper-create-class-features-plugin.md
@@ -1,0 +1,9 @@
+---
+id: babel-helper-create-class-features-plugin
+title: "@babel/helper-create-class-features-plugin"
+sidebar_label: helper-create-class-features-plugin
+---
+
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-create-class-features-plugin) here.
+:::

--- a/docs/helper-create-regexp-features-plugin.md
+++ b/docs/helper-create-regexp-features-plugin.md
@@ -1,0 +1,9 @@
+---
+id: babel-helper-create-regexp-features-plugin
+title: "@babel/helper-create-regexp-features-plugin"
+sidebar_label: helper-create-regexp-features-plugin
+---
+
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-create-regexp-features-plugin) here.
+:::

--- a/docs/helper-define-map.md
+++ b/docs/helper-define-map.md
@@ -4,5 +4,6 @@ title: "@babel/helper-define-map"
 sidebar_label: helper-define-map
 ---
 
-TODO
-
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-define-map) here.
+:::

--- a/docs/helper-explode-assignable-expression.md
+++ b/docs/helper-explode-assignable-expression.md
@@ -4,5 +4,6 @@ title: "@babel/helper-explode-assignable-expression"
 sidebar_label: helper-explode-assignable-expression
 ---
 
-TODO
-
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-explode-assignable-expression) here.
+:::

--- a/docs/helper-explode-class.md
+++ b/docs/helper-explode-class.md
@@ -4,5 +4,6 @@ title: "@babel/helper-explode-class"
 sidebar_label: helper-explode-class
 ---
 
-TODO
-
+:::danger Archived
+This library is no longer maintained. You can check out the [source](https://github.com/babel/babel-archive/tree/main/packages/babel-helper-explode-class) here.
+:::

--- a/docs/helper-function-name.md
+++ b/docs/helper-function-name.md
@@ -4,5 +4,6 @@ title: "@babel/helper-function-name"
 sidebar_label: helper-function-name
 ---
 
-TODO
-
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-function-name) here.
+:::

--- a/docs/helper-module-transforms.md
+++ b/docs/helper-module-transforms.md
@@ -4,5 +4,6 @@ title: "@babel/helper-module-transforms"
 sidebar_label: helper-module-transforms
 ---
 
-TODO
-
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-module-transforms) here.
+:::

--- a/docs/helper-optimise-call-expression.md
+++ b/docs/helper-optimise-call-expression.md
@@ -4,5 +4,6 @@ title: "@babel/helper-optimise-call-expression"
 sidebar_label: helper-optimise-call-expression
 ---
 
-TODO
-
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-optimise-call-expression) here.
+:::

--- a/docs/helper-regex.md
+++ b/docs/helper-regex.md
@@ -4,5 +4,6 @@ title: "@babel/helper-regex"
 sidebar_label: helper-regex
 ---
 
-TODO
-
+:::danger Archived
+This library is no longer maintained. You can check out the [source](https://github.com/babel/babel-archive/tree/main/packages/babel-helper-regex) here.
+:::

--- a/docs/helper-remap-async-to-generator.md
+++ b/docs/helper-remap-async-to-generator.md
@@ -4,5 +4,6 @@ title: "@babel/helper-remap-async-to-generator"
 sidebar_label: helper-remap-async-to-generator
 ---
 
-TODO
-
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-remap-async-to-generator) here.
+:::

--- a/docs/helper-replace-supers.md
+++ b/docs/helper-replace-supers.md
@@ -4,5 +4,6 @@ title: "@babel/helper-replace-supers"
 sidebar_label: helper-replace-supers
 ---
 
-TODO
-
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-replace-supers) here.
+:::

--- a/docs/helper-skip-transparent-expression-wrappers.md
+++ b/docs/helper-skip-transparent-expression-wrappers.md
@@ -1,0 +1,9 @@
+---
+id: babel-helper-skip-transparent-expression-wrappers
+title: "@babel/helper-skip-transparent-expression-wrappers"
+sidebar_label: helper-skip-transparent-expression-wrappers
+---
+
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-skip-transparent-expression-wrappers) here.
+:::

--- a/docs/helper-string-parser.md
+++ b/docs/helper-string-parser.md
@@ -1,0 +1,9 @@
+---
+id: babel-helper-string-parser
+title: "@babel/helper-string-parser"
+sidebar_label: helper-string-parser
+---
+
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-string-parser) here.
+:::

--- a/docs/helper-validator-option.md
+++ b/docs/helper-validator-option.md
@@ -1,0 +1,9 @@
+---
+id: babel-helper-validator-option
+title: "@babel/helper-validator-option"
+sidebar_label: helper-validator-option
+---
+
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-validator-option) here.
+:::

--- a/scripts/generate-helper-docs-template.mjs
+++ b/scripts/generate-helper-docs-template.mjs
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+
+function createHelperDocsTemplate(helperName) {
+  return `---
+id: babel-helper-${helperName}
+title: "@babel/helper-${helperName}"
+sidebar_label: helper-${helperName}
+---
+
+:::caution Pending docs
+This library is an internal Babel helper. You can check out the [source](https://github.com/babel/babel/tree/main/packages/babel-helper-${helperName}) here.
+:::
+`;
+}
+
+function outputHelperDocs(helperName) {
+  const markdownOutput = createHelperDocsTemplate(helperName);
+  const path = new URL(`../docs/helper-${helperName}.md`, import.meta.url);
+  fs.writeFileSync(path, markdownOutput, { encoding: "utf-8", flag: "wx+" });
+  console.log(`Created ${path}`);
+}
+
+if (process.argv[2]) {
+  const helperName = process.argv[2].replace(/^babel-helper-/, "");
+  outputHelperDocs(helperName);
+} else {
+  console.log(
+    "Usage: node ./scripts/generate-helper-docs-template.mjs" +
+      " [babel helper name, e.g. annotate-as-pure]"
+  );
+}


### PR DESCRIPTION
In this PR we add placeholder docs for all helper packages. So users won't see a 404 error when visiting such links from npm/github.

- For maintaining helpers, added a pending docs note and point to the GH source
- For archived helpers, added an archived note and point to the Babel archives