### PR TITLE
Make automatic JSX runtime default in REPL

### DIFF
--- a/js/repl/PluginConfig.ts
+++ b/js/repl/PluginConfig.ts
@@ -117,7 +117,7 @@ const replDefaults: ReplState = {
   shippedProposals: false,
   targets: "",
   version: "",
-  reactRuntime: "classic",
+  reactRuntime: "automatic",
   decoratorsVersion: "2023-01",
   decoratorsBeforeExport: false,
   pipelineProposal: "minimal",

--- a/js/repl/ReplOptions.tsx
+++ b/js/repl/ReplOptions.tsx
@@ -438,13 +438,13 @@ class ExpandedContainer extends Component<Props, State> {
                 >
                   <option
                     value="automatic"
-                    selected={!presetsOptions.reactRuntime}
+                    selected={presetsOptions.reactRuntime === "automatic"}
                   >
                     Automatic
                   </option>
                   <option
                     value="classic"
-                    selected={!!presetsOptions.reactRuntime}
+                    selected={presetsOptions.reactRuntime === "classic"}
                   >
                     Classic
                   </option>

--- a/js/repl/replUtils.ts
+++ b/js/repl/replUtils.ts
@@ -136,7 +136,7 @@ export const persistedStateToPresetsOptions = (
     decoratorsBeforeExport:
       !decoratorsLegacy && !!persistedState.decoratorsBeforeExport,
     pipelineProposal: persistedState.pipelineProposal || "minimal",
-    reactRuntime: persistedState.reactRuntime || "classic",
+    reactRuntime: persistedState.reactRuntime || "automatic",
   };
 };
 


### PR DESCRIPTION
See https://twitter.com/richardiii/status/1636477045143379968.

It's been a while, and the old one really isn't recommended for new projects.

Haven't tested.