### PR TITLE
Add Babel 8 migration docs

### DIFF
--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -162,6 +162,10 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
   __Migration__: In Babel 7 the builder `t.objectTypeAnnotation` initializes them as `null`, this is inconsistent with how `@babel/parser` will parse the Flow object type annotations. In Babel 8 the new default value `[]` matches the parser behaviour. Adapt to the new default value if you are depending on this.
 
+- Reject negative and infinite number from `t.numericLiteral` ([#15802](https://github.com/babel/babel/pull/15802))
+
+  __Migration__: Babel 7 silently ignores such invalid usage. Use `t.unaryExpression("-", t.numericalLiteral(1))` to construct AST for negative number. Use `t.identifier("Infinity")` and `t.unaryExpression("-", t.identifier("Infinity"))` for infinity values.
+
 ### `@babel/parser`
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -15,8 +15,10 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
 ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
 
-- Use an identifier for `TSTypeParameter.name` ([#12829](https://github.com/babel/babel/pull/12829)). For a TS type parameter `node`, `node.name` is a string in Babel 7 while in Babel 8 it is an Identifier.
-  ```ts
+- Use an identifier for `TSTypeParameter.name` ([#12829](https://github.com/babel/babel/pull/12829)).
+
+  For a TS type parameter `node`, `node.name` is a string in Babel 7 while in Babel 8 it is an Identifier.
+  ```ts title="input.ts"
   // T is a TSTypeParameter
   function process<T>(input: T): T {}
   ```
@@ -26,7 +28,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 - Rename `parameters` to `params`, `typeAnnotation` to `returnType` for `TSCallSignatureDeclaration`, `TSConstructSignatureDeclaration`, `TSFunctionType`, `TSConstructorType` and `TSMethodSignature`
  ([#9231](https://github.com/babel/babel/issues/9231), [#13709](https://github.com/babel/babel/pull/13709))
 
-  ```ts
+  ```ts title="input.ts"
   interface Foo {
     // TSCallSignatureDeclaration
     <T>(): string;

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -164,7 +164,11 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
 - Reject negative and infinite number from `t.numericLiteral` ([#15802](https://github.com/babel/babel/pull/15802))
 
-  __Migration__: Babel 7 silently ignores such invalid usage. Use `t.unaryExpression("-", t.numericalLiteral(1))` to construct AST for negative number. Use `t.identifier("Infinity")` and `t.unaryExpression("-", t.identifier("Infinity"))` for infinity values.
+  ```js title="babel-plugin.js"
+  // NumericLiterals must be non-negative finite numbers.
+  t.numericLiteral(-1);
+  ```
+  __Migration__: Babel 7 silently ignores such invalid usage. Use `t.valueToNode(-1)` instead.
 
 ### `@babel/parser`
 

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -265,7 +265,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
 - Rename stage 4 plugin entries from `proposal-*` to `transform-*` in `plugins.json` ([#14976](https://github.com/babel/babel/pull/14976))
 
-  __Migration__: For example, use `transform-class-properties` rather than `proposal-class-properties`, for a complete list of renamed plugin, see [Packages Renames section of Babel 8 migration](./v8-migration.md#package-renames).
+  __Migration__: For example, use `transform-class-properties` rather than `proposal-class-properties`. For a complete list of renamed plugin, see [Packages Renames section of Babel 8 migration](./v8-migration.md#package-renames).
 
 ### `@babel/eslint-plugin`
 
@@ -301,3 +301,29 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   ```
 
   __Migration__: Use the `transform-*` plugin name if the plugin is listed in [the Packages Renames section of Babel 8 migration](./v8-migration.md#package-renames).
+
+## Plugin changes
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `getModuleName` from plugin pass ([#12724](https://github.com/babel/babel/pull/12724))
+
+  __Migration__: Use `.file.getModuleName` instead. For example,
+
+  ```diff title="my-babel-plugin.js"
+  module.exports = {
+    name: "my-babel-plugin",
+    visitor: {
+      Identifier(path, pass) {
+  -     const moduleName = pass.getModuleName();
+  +     const moduleName = pass.file.getModuleName();
+      }
+    }
+  }
+  ```
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove `addImport` from plugin pass ([#15576](https://github.com/babel/babel/pull/15576))
+
+  __Migration__: This change probably will not affect your plugin as this method is already throwing an error in Babel 7. Use [`addNamed`](./helper-module-imports.md#import--named-as-_named--from-source) or [`addDefault`](./helper-module-imports.md#import-_default-from-source) from `@babel/helper-module-imports` instead.

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -302,6 +302,33 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
   __Migration__: Use the `transform-*` plugin name if the plugin is listed in [the Packages Renames section of Babel 8 migration](./v8-migration.md#package-renames).
 
+### `@babel/helper-replace-supers`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove named export `environmentVisitor` ([#15550](https://github.com/babel/babel/pull/15550))
+
+  __Migration__: Import it from [`@babel/helper-environment-visitor`](./helper-environment-visitor.md).
+
+  ```diff
+  - import { environmentVisitor } from "@babel/helper-replace-supers";
+  + import environmentVisitor from `@babel/helper-environment-visitor`;
+  ```
+
+- Remove named export `skipAllButComputedKey` ([#15550](https://github.com/babel/babel/pull/15550))
+
+  __Migration__: Use [`requeueComputedKeyAndDecorators`](./helper-environment-visitor.md#requeuecomputedkeyanddecorators) instead. Find and replace the following import and usage
+  ```js title="my-babel7-plugin.js"
+  import { skipAllButComputedKey } from "@babel/helper-replace-supers";
+  skipAllButComputedKey(path);
+  ```
+  to
+  ```js title="my-babel8-plugin.js"
+  import { requeueComputedKeyAndDecorators } from `@babel/helper-environment-visitor`;
+  path.skip();
+  requeueComputedKeyAndDecorators(path);
+  ```
+
 ## Plugin changes
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -135,7 +135,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
 - Remove `t.jSX*` and `t.tS*` builder aliases ([#6989](https://github.com/babel/babel/issues/6989), [#15527](https://github.com/babel/babel/pull/15527))
 
-  __Migration__: Use `t.jsx*` and `t.ts*` instead. For example, replace `t.jSXIdentifier("foo")` by `t.jsxIdentifier("foo")`.
+  __Migration__: Use `t.jsx*` and `t.ts*` instead. For example, replace `t.jSXIdentifier("foo")` with `t.jsxIdentifier("foo")`.
 
 - Remove `selfClosing` argument from `t.jsxElement` ([#14464](https://github.com/babel/babel/pull/14464))
 
@@ -143,7 +143,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   - t.jsxElement(openingElement, closingElement, children, selfClosing?: boolean)
   + t.jsxElement(openingElement, closingElement, children)
   ```
-  __Migration__: The `selfClosing` argument is not used in the builder. You can safely remove it.
+  __Migration__: The `selfClosing` argument was already not used in the builder. You can safely remove it.
 
 - Remove `optional` argument from `t.memberExpression` ([#13407](https://github.com/babel/babel/pull/13407))
 

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -67,6 +67,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   ```json title="babel.config.json"
   { "parserOpts": { "createParenthesizedExpression": true } }
   ```
+  When `createParenthesizedExpression` is `false`, you can also use `node.extra.parens` to detect whether `node` is wrapped in parentheses.
 
 
 ## API Changes
@@ -248,12 +249,6 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 
-- [Allow skipped `NodePath`s to be requeued](https://github.com/babel/babel/blob/43b623c1f1e86e6fb86cae8d955a84fd924380a4/packages/babel-traverse/src/path/context.js#L241-L247) ([#13291](https://github.com/babel/babel/pull/13291))
-
-  **Notes**: `NodePath#requeue()` can requeue a skipped NodePath. This is actually a bugfix, but it causes an infinite loop in the tdz implementation of `@babel/plugin-transform-block-scoping` so we defer the change to Babel 8.
-
-![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
-
 - Remove `block` argument from `Scope#rename` ([#15288](https://github.com/babel/babel/pull/15288))
 
   ```diff
@@ -261,7 +256,13 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   + rename(oldName: string, newName?: string)
   ```
 
-  __Migration__: The third argument `block` is not used by the method. You can safely remove it if you are depending on `Scope#rename`.
+  __Migration__: In Babel 8 the third argument `block` is not used by the method. Consider remove it if you are depending on `Scope#rename`.
+
+- [Allow skipped `NodePath`s to be requeued](https://github.com/babel/babel/blob/43b623c1f1e86e6fb86cae8d955a84fd924380a4/packages/babel-traverse/src/path/context.js#L241-L247) ([#13291](https://github.com/babel/babel/pull/13291))
+
+  **Notes**: `NodePath#requeue()` can requeue a skipped NodePath. This is actually a bugfix, but it causes an infinite loop in the tdz implementation of `@babel/plugin-transform-block-scoping` in Babel 7. So it may break other plugins as well.
+
+  __Migration__: Adapt to the new behaviour. You can use `NodePath#shouldSkip` to check whether a NodePath has been skipped before calling `NodePath#requeue()`.
 
 ### `@babel/compat-data`
 

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -252,3 +252,11 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   ```
 
   __Migration__: The third argument `block` is not used by the method. You can safely remove it if you are depending on `Scope#rename`.
+
+### `@babel/compat-data`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove `ios_saf` from `data/native-modules.json` ([#15068](https://github.com/babel/babel/pull/15068/commits/554225d72d7781356e05b6bbc4ef85f42629d001))
+
+  __Migration__: Use `ios` instead.

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -329,6 +329,14 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   requeueComputedKeyAndDecorators(path);
   ```
 
+### `@babel/helper-simple-access`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove the the third parameter `includeUpdateExpression` from the default export ([#15550](https://github.com/babel/babel/pull/15550))
+
+  This change probabaly won't break your integration as `includeUpdateExpression` defaults to `true` in Babel 7. If you are using `includeUpdateExpression: false`, adapt to the new behaviour.
+
 ## Plugin changes
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -1,0 +1,144 @@
+---
+title: "Upgrade to Babel 8 (Integration)"
+id: v8-migration-api
+---
+
+Refer plugin developers or integration users to this document when upgrading to Babel 8.
+
+<!--truncate-->
+
+:::info
+Check out the [v8-migration guide](v8-migration.md) for other user-level changes.
+:::
+
+## AST Changes
+
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- Use an identifier for `TSTypeParameter.name` ([#12829](https://github.com/babel/babel/pull/12829)). For a TS type parameter `node`, `node.name` is a string in Babel 7 while in Babel 8 it is an Identifier.
+  ```ts
+  // T is a TSTypeParameter
+  function process<T>(input: T): T {}
+  ```
+
+  __Migration__: If you have a customized plugin accessing the name of a type parameter node, use `node.name.name` in Babel 8.
+
+- Rename `parameters` to `params`, `typeAnnotation` to `returnType` for `TSCallSignatureDeclaration`, `TSConstructSignatureDeclaration`, `TSFunctionType`, `TSConstructorType` and `TSMethodSignature`
+ ([#9231](https://github.com/babel/babel/issues/9231), [#13709](https://github.com/babel/babel/pull/13709))
+
+  ```ts
+  interface Foo {
+    // TSCallSignatureDeclaration
+    <T>(): string;
+
+    // TSMethodSignature
+    foo<T>(): string;
+
+    // TSConstructSignatureDeclaration
+    new <T>(): string;
+  }
+
+  // TSFunctionType
+  type Bar = <T>() => string;
+
+  // TSConstructorType
+  type Baz = new <T>() => string;
+  ```
+
+  **Migration**: If you have a customized plugin accessing properties of these TS nodes, make adjustments accordingly:
+    - For `node.parameters` in Babel 7, use `node.params` in Babel 8
+    - For `node.typeAnnotation` in Babel 7, use `node.returnType` in Babel 8
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Don't generate `TSParenthesizedType` unless `createParenthesizedExpression` is enabled([#9546](https://github.com/babel/babel/issues/9546), [#12608](https://github.com/babel/babel/pull/12608))
+
+  ```ts title="input.ts"
+  type T = ({});
+  // createParenthesizedExpression: true
+  TSParenthesizedType { typeAnnotation: TSTypeLiteral { members: [] } }
+  // createParenthesizedExpression: false
+  TSTypeLiteral { members: [] }
+  ```
+
+  **Migration**: If you need informations about parentheses, specify the [`createParenthesizedExpression`](./parser.md#options) parser option.
+  ```json title="babel.config.json"
+  { "parserOpts": { "createParenthesizedExpression": true } }
+  ```
+
+
+## API Changes
+
+### All packages
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- Disallow importing internal files ([#14013](https://github.com/babel/babel/pull/14013)).
+
+  __Migration__: Use the exported API only. If you are relying on Babel internals, please open an issue and let us know.
+
+### `@babel/core`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Disallow using `babel.transform`, `babel.transformFile`, `babel.transformFromAst`, `babel.parse`, `babel.loadOptions` and `babel.loadPartialConfig` synchronously ([#11110](https://github.com/babel/babel/pull/11110), [#12695](https://github.com/babel/babel/pull/12695)).
+
+  __Migration__: Use sync versions: `babel.transformSync`, `babel.transformFileSync`, `babel.transformFromAstSync`, `babel.parseSync`, `babel.loadOptionsSync` and `babel.loadPartialConfigSync`.
+
+### `@babel/types`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Reject invalid identifier names in `t.identifier` builder ([#10917](https://github.com/babel/babel/pull/10917)).
+
+  ```js title="babel-plugin.js"
+  // Empty string is an invalid identifier name
+  // highlight-error-next-line
+  t.identifier("");
+  ```
+
+  __Migration__: Call `t.identifier` with a valid name.
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove `t.jSX*` and `t.tS*` builder aliases ([#6989](https://github.com/babel/babel/issues/6989), [#15527](https://github.com/babel/babel/pull/15527))
+
+  __Migration__: Use `t.jsx*` and `t.ts*` instead. For example, replace `t.jSXIdentifier("foo")` by `t.jsxIdentifier("foo")`.
+
+- Remove `selfClosing` argument from `t.jsxElement` ([#14464](https://github.com/babel/babel/pull/14464))
+
+  ```diff
+  - t.jsxElement(openingElement, closingElement, children, selfClosing?: boolean)
+  + t.jsxElement(openingElement, closingElement, children)
+  ```
+  __Migration__: The `selfClosing` argument is not used in the builder. You can safely remove it if you are using `t.jsxElement`.
+
+- [Remove the `Noop` node type](https://github.com/babel/babel/issues/12355) ([#12361](https://github.com/babel/babel/pull/12361))
+
+  __Migration__: The `Noop` node is not used. If you are depending on the `Noop` node, please open an issue and talk about your use case.
+
+### `@babel/parser`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Align Babel parser error codes between Flow and TypeScript ([#13294](https://github.com/babel/babel/pull/13294))
+
+  **Migration**: The `error.code` for `OptionalBindingPattern` is renamed as `PatternIsOptional`.
+
+### `@babel/traverse`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- [Allow skipped `NodePath`s to be requeued](https://github.com/babel/babel/blob/43b623c1f1e86e6fb86cae8d955a84fd924380a4/packages/babel-traverse/src/path/context.js#L241-L247) ([#13291](https://github.com/babel/babel/pull/13291))
+
+  **Notes**: `NodePath#requeue()` can requeue a skipped NodePath. This is actually a bugfix, but it causes an infinite loop in the tdz implementation of `@babel/plugin-transform-block-scoping` so we defer the change to Babel 8.
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove `block` argument from `Scope#rename` ([#15288](https://github.com/babel/babel/pull/15288))
+
+  ```diff
+  - rename(oldName: string, newName?: string, block?: t.Pattern | t.Scopable)
+  + rename(oldName: string, newName?: string)
+  ```
+
+  __Migration__: The third argument `block` is not used by the method. You can safely remove it if you are depending on `Scope#rename`.

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -72,7 +72,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 ### All packages
 ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
 
-- Disallow importing internal files ([#14013](https://github.com/babel/babel/pull/14013)).
+- Disallow importing internal files ([#14013](https://github.com/babel/babel/pull/14013), [#14179](https://github.com/babel/babel/pull/14179)).
 
   __Migration__: Use the exported API only. If you are relying on Babel internals, please open an issue and let us know.
 

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -104,7 +104,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
   A `Super` node represents `super` in super call `super()` and super property `super.foo`. `super` can not be a standalone expression. In other words, `t.isExpression(t.super())` will return `false` in Babel 8.
 
-  __Migration__: Search usage of `t.isExpression`, `t.assertsExpression` and `Expression` alias in the plugin visitor, update the usage when you are handling super call and super property. For example,
+  __Migration__: Search usage of `t.isExpression`, `t.assertsExpression` and `Expression` alias in the plugin visitor, and if necessary, update the usage when you are handling super call and super property. For example,
 
   ```diff title="my-babel-plugin.js"
   // Add `.foo` to an expression
@@ -152,7 +152,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   + t.memberExpression(object, property, computed)
   ```
 
-  __Migration__: The `optional` argument is not used in the builder. You can safely remove it.
+  __Migration__: The `optional` argument was already not used in the builder. You can safely remove it.
 
 - [Remove the `Noop` node type](https://github.com/babel/babel/issues/12355) ([#12361](https://github.com/babel/babel/pull/12361))
 
@@ -162,7 +162,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
   __Migration__: In Babel 7 the builder `t.objectTypeAnnotation` initializes them as `null`, this is inconsistent with how `@babel/parser` will parse the Flow object type annotations. In Babel 8 the new default value `[]` matches the parser behaviour. Adapt to the new default value if you are depending on this.
 
-- Reject negative and infinite number from `t.numericLiteral` ([#15802](https://github.com/babel/babel/pull/15802))
+- Reject negative and NaN/infinite numbers from `t.numericLiteral` ([#15802](https://github.com/babel/babel/pull/15802))
 
   ```js title="babel-plugin.js"
   // NumericLiterals must be non-negative finite numbers.

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -346,6 +346,14 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
   This change probabaly won't break your integration as `includeUpdateExpression` defaults to `true` in Babel 7. If you are using `includeUpdateExpression: false`, adapt to the new behaviour.
 
+### `@babel/highlight`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove the `getChalk` function (https://github.com/babel/babel/pull/15812)
+
+  If you need to use `chalk`, add it to your dependencies.
+
 ## Plugin changes
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -327,3 +327,23 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 - Remove `addImport` from plugin pass ([#15576](https://github.com/babel/babel/pull/15576))
 
   __Migration__: This change probably will not affect your plugin as this method is already throwing an error in Babel 7. Use [`addNamed`](./helper-module-imports.md#import--named-as-_named--from-source) or [`addDefault`](./helper-module-imports.md#import-_default-from-source) from `@babel/helper-module-imports` instead.
+
+- Stop supporting fields as named exports ([#15576](https://github.com/babel/babel/pull/15576))
+
+  __Migration__: This change disallows plugins declared from named exports, for example,
+  ```js title="legacy-babel-plugin.js"
+  exports.name = "legacy-babel-plugin";
+  exports.visitor = {
+    Identifier() {}
+  }
+  ```
+
+  find such patterns and migrate to the following patterns.
+  ```js title="my-babel-plugin.cjs"
+  module.exports = {
+    name: "babel-plugin",
+    visitor: {
+      Identifier() {}
+    }
+  }
+  ```

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -262,3 +262,17 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 - Remove `ios_saf` from `data/native-modules.json` ([#15068](https://github.com/babel/babel/pull/15068/commits/554225d72d7781356e05b6bbc4ef85f42629d001))
 
   __Migration__: Use `ios` instead.
+
+### `@babel/eslint-plugin`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- The `default` named exports has been removed ([#14180](https://github.com/babel/babel/pull/14180))
+
+  __Migration__: This change has no effect if you are using the plugin in your ESLint config. However, if you are extending `@babel/eslint-plugin`, ensure that you obtain exports
+  from `require("@babel/eslint-plugin")` rather than `require("@babel/eslint-plugin").default`.
+
+  ```js title="my-eslint-plugin.cjs"
+  // Don't add `.default` after `require()`
+  const { rules, rulesConfig } = require("@babel/eslint-plugin")
+  ```

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -156,6 +156,10 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
   __Migration__: The `Noop` node is not used. If you are depending on the `Noop` node, please open an issue and talk about your use case.
 
+- Initialize `indexers`, `callProperties` and `internalSlots` in the node `ObjectTypeAnnotation` as an empty array in `t.objectTypeAnnotation` ([#14465](https://github.com/babel/babel/pull/14465))
+
+  __Migration__: In Babel 7 the builder `t.objectTypeAnnotation` initializes them as `null`, this is inconsistent with how `@babel/parser` will parse the Flow object type annotations. In Babel 8 the new default value `[]` matches the parser behaviour. Adapt to the new default value if you are depending on this.
+
 ### `@babel/parser`
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -263,6 +263,10 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
 
   __Migration__: Use `ios` instead.
 
+- Rename stage 4 plugin entries from `proposal-*` to `transform-*` in `plugins.json` ([#14976](https://github.com/babel/babel/pull/14976))
+
+  __Migration__: For example, use `transform-class-properties` rather than `proposal-class-properties`, for a complete list of renamed plugin, see [Packages Renames section of Babel 8 migration](./v8-migration.md#package-renames).
+
 ### `@babel/eslint-plugin`
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
@@ -276,3 +280,24 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   // Don't add `.default` after `require()`
   const { rules, rulesConfig } = require("@babel/eslint-plugin")
   ```
+
+### `@babel/helper-compilation-targets`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- `isRequired` will not accept renamed `proposal-` queries ([#14976](https://github.com/babel/babel/pull/14976))
+
+  ```diff title="my-babel-plugin.js"
+  module.exports = api => {
+    const targets = api.targets();
+    // The targets have native optional chaining support
+    // if `transform-optional-chaining` is _not_ required
+    const optionalChainingSupported = !isRequired(
+  -   "proposal-optional-chaining",
+  +   "transform-optional-chaining",
+      targets
+    );
+  };
+  ```
+
+  __Migration__: Use the `transform-*` plugin name if the plugin is listed in [the Packages Renames section of Babel 8 migration](./v8-migration.md#package-renames).

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -112,9 +112,23 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: The `uglify` target had been deprecated since 7.0.0-beta.0, if you still need this, use the [`forceAllTransforms`](preset-env.md#forcealltransforms) option.
 
-### `@babel/preset-react`
+### `@babel/preset-react` {#configuration-change-preset-react}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `useSpread` and `useBuiltIns` options ([#12593](https://github.com/babel/babel/pull/12593))
+
+  **Migration**: Babel 8 always compiles JSX spread elements to object spread:
+  ```jsx title=input.jsx
+  <div {...props}></div>
+  // transforms to
+  jsx("div", { ...props })
+  ```
+
+  If your app targets to modern browsers released after 2019, you can safely remove these options as object spread has less code footprint.
+
+  If your code needs to run in an environment which doesn't support object spread, you can either use `@babel/preset-env` (recommended) or `@babel/plugin-proposal-object-rest-spread`. If you want to transpile `Object.assign` down, you also need to enable `@babel/plugin-transform-object-assign`.
+  In Babel 7.7.0, you can opt-in this behavior by using the `useSpread` option.
 
 - Type check input options ([#12460](https://github.com/babel/babel/pull/12460))
 
@@ -255,7 +269,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 - Remove support for the 2018-09 decorators proposal. The plugin now requires a [`version`](./plugin-proposal-decorators.md#version) option ([#12712](https://github.com/babel/babel/pull/12712))
 
-  **Migration**: You should migrate to the [latest version of the proposal](github.com/tc39/proposal-decorators/) if you are using the `"2018-09"` or you have not specified a `version` option.
+  **Migration**: You should migrate to the [latest version of the proposal](https://github.com/tc39/proposal-decorators/) if you are using the `"2018-09"` or you have not specified a `version` option.
   ```diff title="babel.config.json"
   {
     "plugins": [
@@ -299,10 +313,9 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
-- [Transforms JSX spread properties using object spread](https://github.com/babel/babel/issues/9652) ([#11141](https://github.com/babel/babel/pull/11141))
+- [Transforms JSX spread properties using object spread](https://github.com/babel/babel/issues/9652) ([#12593](https://github.com/babel/babel/pull/12593))
 
-  **Migration**: If your code needs to run in an environment which doesn't support object spread, you can either use `@babel/preset-env` (recommended) or `@babel/plugin-proposal-object-rest-spread`. If you want to transpile `Object.assign` down, you also need to enable `@babel/plugin-transform-object-assign`.
-  In Babel 7.7.0, you can opt-in this behavior by using the `useSpread` option.
+  **Migration**: See the [Configuration changes / preset-react](#configuration-change-preset-react) section.
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -258,6 +258,49 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: `@babel/generator` allows to specify options for [jsesc](https://github.com/mathiasbynens/jsesc), a library used to escape printed values. If you are using the `jsonCompatibleStrings` option, you can replace it with `jsescOption: { json: true }`.
 
+### `@babel/eslint-parser` {#configuration-change-eslint-parser}
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `allowImportExportEverywhere` option ([#13921](https://github.com/babel/babel/pull/13921))
+
+  **Migration**: Use `babelOptions.parserOpts.allowImportExportEverywhere` instead.
+
+  ```diff title=".eslintrc"
+  {
+    "parser": "@babel/eslint-parser",
+    "parserOptions": {
+  -   "allowImportExportEverywhere": true,
+  +   "babelOptions": {
+  +     "parserOpts": {
+  +       "allowImportExportEverywhere": true
+  +     }
+  +   }
+    }
+  }
+  ```
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- `parserOpts.allowSuperOutsideMethod` defaults to `false` ([#13921](https://github.com/babel/babel/pull/13921))
+
+  **Migration**: If you want to restore to Babel 7 behaviour, set `babelOptions.parserOpts.allowSuperOutsideMethod` to `true`.
+
+- `allowReturnOutsideFunction` is inferred from `ecmaFeatures.globalReturn` ([#13921](https://github.com/babel/babel/pull/13921))
+
+  **Migration**: If you want to enable `allowReturnOutsideFunction`, set [`ecmaFeatures.globalReturn`](https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options) to `true`.
+
+  ```json title=".eslintrc"
+  {
+    "parser": "@babel/eslint-parser",
+    "parserOptions": {
+      "ecmaFeatures": {
+        "globalReturn": true
+      }
+    }
+  }
+  ```
+
 ### `@babel/plugin-transform-modules-systemjs` {#configuration-change-transform-systemjs}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -1,0 +1,377 @@
+---
+title: "Upgrade to Babel 8"
+id: v8-migration
+---
+
+Refer users to this document when upgrading to Babel 8 from Babel 7. If you are a plugin developer or integration user, please also check [migration guide for integration](./v8-migration-api.md).
+
+<!--truncate-->
+
+> If you are upgrading from Babel 6, please check [here](./v7-migration.md) for Babel 7 migration guide.
+
+## All of Babel
+
+### Node.js support
+
+All Babel 8 packages require Node.js >= 14.19.
+
+We highly encourage you to use a newer version of Node.js (LTS v18) since the previous versions are not maintained.
+See [nodejs/Release](https://github.com/nodejs/Release) for more information.
+
+This just means Babel _itself_ won't run on older versions of Node. It can still _output_ code that runs on old Node versions.
+
+### ESM only
+
+Babel is now shipped in native ECMAScript modules. ([#11701](https://github.com/babel/babel/pull/11701))
+
+### `@babel/core` requirements
+
+All presets and plugins require `@babel/core@^8.0.0` as peer dependency.
+
+## Package Renames
+
+The following packages has been renamed to `-transform` as they have reached Stage 4 ([#TODO](https://github.com/babel/babel/pull/TODO)):
+
+| Babel 7 | Babel 8 |
+| --- | --- |
+| `@babel/plugin-proposal-async-generator-functions` | `@babel/plugin-transform-async-generator-functions` |
+| `@babel/plugin-proposal-class-properties` | `@babel/plugin-transform-class-properties` |
+| `@babel/plugin-proposal-class-static-block` | `@babel/plugin-transform-class-static-block` |
+| `@babel/plugin-proposal-duplicate-named-capturing-groups-regex` | `@babel/plugin-transform-duplicate-named-capturing-groups-regex` |
+| `@babel/plugin-proposal-dynamic-import` | `@babel/plugin-transform-dynamic-import` |
+| `@babel/plugin-proposal-export-namespace-from` | `@babel/plugin-transform-export-namespace-from` |
+| `@babel/plugin-proposal-json-strings` | `@babel/plugin-transform-json-strings` |
+| `@babel/plugin-proposal-logical-assignment-operators` | `@babel/plugin-transform-logical-assignment-operators` |
+| `@babel/plugin-proposal-nullish-coalescing-operator` | `@babel/plugin-transform-nullish-coalescing-operator` |
+| `@babel/plugin-proposal-numeric-separator` | `@babel/plugin-transform-numeric-separator` |
+| `@babel/plugin-proposal-object-rest-spread` | `@babel/plugin-transform-object-rest-spread` |
+| `@babel/plugin-proposal-optional-catch-binding` | `@babel/plugin-transform-optional-catch-binding` |
+| `@babel/plugin-proposal-optional-chaining` | `@babel/plugin-transform-optional-chaining` |
+| `@babel/plugin-proposal-private-methods` | `@babel/plugin-transform-private-methods` |
+| `@babel/plugin-proposal-private-property-in-object` | `@babel/plugin-transform-private-property-in-object` |
+| `@babel/plugin-proposal-unicode-property-regex` | `@babel/plugin-transform-unicode-property-regex` |
+
+## Package Discontinued
+
+### `@babel/runtime-corejs2`
+
+Please upgrade to `@babel/runtime-corejs3` ([#11751](https://github.com/babel/babel/issues/10746#issuecomment-573402372)). After
+you install the new runtime, please set the [`corejs` version](https://babel.dev/docs/babel-plugin-transform-runtime#corejs) to 3.
+
+```diff title="babel.config.json"
+{
+  "plugins": ["@babel/transform-runtime", {
+-   corejs: 2
++   corejs: 3
+  }]
+}
+```
+
+### `@babel/plugin-syntax-import-assertions`
+Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://github.com/babel/babel/pull/15536)). After you replace the plugin, you should search and replace the following patterns in your codebase:
+
+```diff title="input.js"
+- import value from "module" assert { type: "json" };
++ import value from "module" with { type: "json" };
+```
+
+## Configuration Changes
+
+### `@babel/core`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- The root AMD/UMD/SystemJS options, namely [`moduleIds`](./options.md#moduleids), [`getModuleId`](./options.md#getmoduleid), [`moduleRoot`](./options.md#moduleroot), [`moduleId`](./options.md#moduleid) and [`filenameRelative`](./options.md#filenamerelative) are moved to plugin options ([#5473](https://github.com/babel/babel/issues/5473), [#12724](https://github.com/babel/babel/pull/12724)).
+
+  **Migration**: Move these options to the module plugin, for example, if you are using
+  `@babel/plugin-transform-modules-systemjs`:
+  ```js title="babel.config.js"
+  module.exports = {
+    plugins: [
+      ['@babel/plugin-transform-modules-systemjs', {
+        // highlight-start
+        moduleIds: true,
+        moduleRoot: 'myApp',
+        getModuleId (name) {
+          return name + "suffix";
+        },
+        // highlight-end
+      }],
+    ],
+  };
+  ```
+  Adapt the example above if you are using `@babel/plugin-transform-modules-amd` or `@babel/plugin-transform-modules-umd`. You can start the migration prior to Babel 8.0.
+
+  If you are using `@babel/cli` and passing them from command line, please create a Babel config `babel.config.js` and specify options there.
+
+### `@babel/preset-env`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove `uglify` target ([#12594](https://github.com/babel/babel/pull/12594))
+
+  **Migration**: The `uglify` target had been deprecated since 7.0.0-beta.0, if you still need this, use the [`forceAllTransforms`](preset-env.md#forcealltransforms) option.
+
+### `@babel/preset-react`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Type check input options ([#12460](https://github.com/babel/babel/pull/12460))
+
+  **Migration**: The preset will also report invalid option names. Refer to the [docs](./preset-react.md#options) and ensure valid usage.
+
+### `@babel/preset-typescript`
+
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- Remove `isTSX` and `allExtensions` option ([#14955](https://github.com/babel/babel/pull/14955))
+
+  **Migration**:
+  - `isTSX: true` and `allExtensions: true`
+
+    If you are already using `@babel/preset-react`, `@babel/plugin-transform-react-jsx` or any other third-party jsx presets such as `@vue/babel-preset-jsx`, and you want to transpile `.tsx` files, you can safely remove these two options. Babel 8 will automatically handle `.tsx` files using this preset and the other JSX plugin.
+
+    ```diff title="babel.config.json"
+    {
+      "presets": [
+        ["@babel/preset-react", { "runtime": "automatic" }],
+    -   ["@babel/preset-typescript", { "allExtensions": true, "isTSX": true }]
+    +   ["@babel/preset-typescript"]
+      ]
+    }
+    ```
+
+    If you want to transpile files other than `.tsx`, such as `.vue`, use `ignoreExtensions: true`:
+
+    ```diff title="babel.config.js"
+    {
+      include: /\.vue$/,
+      presets: [
+        ['@babel/preset-typescript', {
+    -     allExtensions: true, isTSX: true
+    +     ignoreExtensions: true
+        }]
+      ]
+    }
+    ```
+
+    If you want to preserve the JSX format but transpile the TypeScript part, use `ignoreExtensions: true` and add [`@babel/plugin-syntax-jsx`](./plugin-syntax-jsx.md) to `plugins`.
+
+  - `isTSX: false` and `allExtensions: true`
+
+    Use `ignoreExtensions: true`, see the example above.
+
+  - `isTSX: false` and `allExtensions: false`
+
+    You can safely remove them.
+
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `allowDeclareFields` option ([#12461](https://github.com/babel/babel/pull/12461))
+
+  **Migration**: Remove the option from your config. You will probably be fine with the new behaviour. Previously `allowDeclareFields` enables transforming the `declare` syntax introduced in TypeScript 3.7, in Babel 8 we support the syntax without such a flag. See also the [compilation changes](#compilation-change-jsx) section.
+
+- Type check input options ([#12460](https://github.com/babel/babel/pull/12460))
+
+  **Migration**: The preset will also report invalid option names. Refer to the [docs](./preset-typescript.md#options) and ensure valid usage. For example, `runtime` is not a valid `preset-typescript` option and thus should be removed.
+
+### `@babel/plugin-transform-typescript`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `allowDeclareFields` option ([#12461](https://github.com/babel/babel/pull/12461))
+
+  **Migration**: Remove the option from your config.
+
+### `@babel/plugin-syntax-typescript`
+
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- Remove `isTSX` option ([#14955](https://github.com/babel/babel/pull/14955))
+
+  **Migration**: If you are using `isTSX: true`, remove this option and add [`@babel/plugin-syntax-jsx`](./plugin-syntax-jsx.md) to `plugins`:
+
+  ```diff title="babel.config.json
+  {
+    "plugins": [
+  -   ["@babel/plugin-syntax-typescript", { "isTSX": true }]
+  +   ["@babel/plugin-syntax-typescript"]
+  +   ["@babel/plugin-syntax-jsx"]
+    ]
+  }
+  ```
+
+  If you are using `isTSX: false`, you can safely remove them.
+
+### `@babel/preset-flow`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `allowDeclareFields` option ([#12457](https://github.com/babel/babel/pull/12457))
+
+  **Migration**: Remove the option from your config. You will probably be fine with the new behaviour. Previously `allowDeclareFields` enables transforming the `declare` syntax introduced in Flow 0.120.0, in Babel 8 we support the syntax without such a flag. See also the [compilation changes](#compilation-change-flow) section.
+
+- Type check input options ([#12460](https://github.com/babel/babel/pull/12460))
+
+  **Migration**: The preset will also report invalid option names. Refer to the [docs](./preset-flow.md#options) and ensure valid usage.
+
+### `@babel/plugin-transform-flow-strip-types`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `allowDeclareFields` option ([#12457](https://github.com/babel/babel/pull/12457))
+
+  **Migration**: Remove the option from your config. You will probably be fine with the new behaviour.
+
+### `@babel/generator`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove `jsonCompatibleStrings` generator option ([#9943](https://github.com/babel/babel/issues/9943), [#12477](https://github.com/babel/babel/pull/12477))
+
+  **Migration**: `@babel/generator` allows to specify options for [jsesc](https://github.com/mathiasbynens/jsesc), a library used to escape printed values. If you are using the `jsonCompatibleStrings` option, you can replace it with `jsescOption: { json: true }`.
+
+### `@babel/plugin-transform-modules-systemjs`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- [Require `@babel/plugin-proposal-dynamic-import` when transforming `import()` to SystemJS](https://github.com/babel/babel/blob/78cd63d9cfcd96e6a151c58fed392c3ee757d861/packages/babel-plugin-transform-modules-systemjs/src/index.js#L183-L185) ([#12700](https://github.com/babel/babel/pull/12700))
+
+  **Migration**: Add `@babel/plugin-proposal-dynamic-import` to your config: you can already do it in Babel 7. If you are using `@babel/preset-env`, you don't need to do anything.
+  ```diff title="babel.config.js.diff"
+  {
+    "plugins": [
+  +   "@babel/plugin-proposal-dynamic-import",
+      "@babel/plugin-transform-modules-systemjs",
+    ]
+  }
+  ```
+  **Notes**: All the other plugins which support dynamic import (`transform-modules-commonjs` and `transform-modules-amd`) require the separate plugin since it was introduced. We couldn't change it for `transform-modules-systemjs` because that package did already support dynamic import.
+
+### `@babel/plugin-proposal-decorators`
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Remove support for the 2018-09 decorators proposal. The plugin now requires a [`version`](./plugin-proposal-decorators.md#version) option ([#12712](https://github.com/babel/babel/pull/12712))
+
+  **Migration**: You should migrate to the [latest version of the proposal](github.com/tc39/proposal-decorators/) if you are using the `"2018-09"` or you have not specified a `version` option.
+  ```diff title="babel.config.json"
+  {
+    "plugins": [
+      ["@babel/plugin-proposal-dynamic-import", {
+  -     "decoratorsBeforeExport": true,
+  -     "version": "2018-09",
+  +     "version": "2023-01"
+      }]
+    ]
+  }
+  ```
+  The syntax is the same, but you will need to rewrite your decorator functions. You can already migrate since Babel 7.21.0, using the `"version": "2023-01"` option of `@babel/plugin-proposal-decorators`.
+
+## Compilation Changes
+
+### Default target
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- Use browserslist's `defaults` as default compilation target ([#12989](https://github.com/babel/babel/pull/12989), [#15551](https://github.com/babel/babel/pull/15551)).
+
+  **Migration**: If you are already using `targets` or have a `.browserslist` config file, this change won't affect you. Otherwise, you'll probably be fine with the new behavior since the [browserslist's `defautls` covers most modern browsers](https://browsersl.ist/#q=defaults).
+
+  If you need to support legacy browsers, create a [`.browserlist` config](https://github.com/browserslist/browserslist#queries).
+
+### `@babel/preset-env`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Enable the [`bugfixes`](./preset-env.md#bugfixes) option by default ([#13866](https://github.com/babel/babel/pull/13866))
+
+  **Migration**: You will probably be fine with the new behaviour as Babel now tries to compile the broken syntax to the closest _non-broken modern syntax_ supported by your target browsers. If anyhow you want to restore the Babel 7 behaviour, you can specify `bugfixes: false`.
+
+### JSX {#compilation-change-jsx}
+
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- [Use the new JSX implementation by default](https://github.com/babel/babel/pull/11154#issuecomment-591188203) ([#12630](https://github.com/babel/babel/pull/12630))
+
+  **Migration**: If you are using a modern version of React or Preact, it should work without any configuration changes. Otherwise, you can pass the [`runtime: "classic"`](preset-react.md#runtime) option to `@babel/preset-react` or `@babel/plugin-transform-react-jsx` to be explicit about your usage of `createElement` (or the equivalent function in other libraries).
+
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- [Transforms JSX spread properties using object spread](https://github.com/babel/babel/issues/9652) ([#11141](https://github.com/babel/babel/pull/11141))
+
+  **Migration**: If your code needs to run in an environment which doesn't support object spread, you can either use `@babel/preset-env` (recommended) or `@babel/plugin-proposal-object-rest-spread`. If you want to transpile `Object.assign` down, you also need to enable `@babel/plugin-transform-object-assign`.
+  In Babel 7.7.0, you can opt-in this behavior by using the `useSpread` option.
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- [Disallow sequence expressions inside JSX attributes](https://github.com/babel/babel/issues/8604) ([#8787](https://github.com/babel/babel/pull/8787))
+
+  **Migration**: Find and replace the following code patterns. You can start the migration prior to Babel 8:
+  ```diff title=input.jsx
+  - <p key={foo, bar}></p> // Invalid
+  + <p key={(foo, bar)}></p> // Valid
+  ```
+
+- [Disallow `{`, `}`, `<` and `>` in JSX text](https://github.com/babel/babel/issues/11042) ([#11046](https://github.com/babel/babel/pull/11046))
+
+  **Migration**: Use `{'{'}`, `{'}'}`, `{'<'}` and `{'>'}` instead. Find and replace the following code patterns. You can start the migration prior to Babel 8:
+  ```diff title=input.jsx
+  - <p>">" is greater than.</p>
+  + <p>"{'>'}" is greater than.</p>
+  ```
+  **Notes**: This is technically a spec compliance fix becase the [JSX specification](https://facebook.github.io/jsx/#prod-JSXTextCharacter) already forbids them. However, we have chosen to postpone it until Babel 8 because it could break someone's code.
+
+### TypeScript {#compilation-change-ts}
+
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- [Preserve uninitialized class fields](https://github.com/babel/babel/issues/10039) ([#12461](https://github.com/babel/babel/pull/12461))
+
+  **Migration**:
+  Use the new `declare` syntax, introduced in TypeScript 3.7, if you don't want fields to be initialized to `undefined`:
+  ```ts title=input.ts
+  class A {
+    foo: string | void; // initialized to undefined
+    declare bar: number; // type-only, will be removed
+  }
+  ```
+
+### Flow {#compilation-change-flow}
+
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- [Preserve uninitialized class fields](https://github.com/babel/babel/issues/10039) ([#12457](https://github.com/babel/babel/pull/12457))
+
+  **Migration**:
+  Use the new `declare` syntax, introduced in Flow 0.120, if you don't want fields to be initialized to `undefined`:
+  ```flow title=input.js
+  class A {
+    foo: string | void; // initialized to undefined
+    declare bar: number; // type-only, will be removed
+  }
+  ```
+
+### Misc
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Output non-ASCII characters as-is in string literal ([#11384](https://github.com/babel/babel/pull/11384))
+
+  If you are using any one of `@babel/cli`, WebPack, Rollup, create-react-app or other Node.js powered bundlers, the transformed code is always encoded with `utf-8` and your app will not be affected. The issue only affects if you are manually calling the `babel.transform` API and your web server is not serving js files in the `utf8` encoding.
+
+  **Migration**: Ensure your server is always serving js files in the `utf8` encoding. If you can not control the server output, specify the `charset` attribute of the `script` tag in the html files.
+  ```html
+  <script charset="utf-8" src="your-app.js"></script>
+  ```
+  You can also restore to the Babel 7 behaviour by
+  ```js title="babel.config.js"
+  {
+    generatorOpts: {
+      jsescOption: {
+        minimal: false
+      }
+    }
+  }
+  ```

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -106,7 +106,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
   ```
   Adapt the example above if you are using `@babel/plugin-transform-modules-amd` or `@babel/plugin-transform-modules-umd`. You can start the migration prior to Babel 8.0.
 
-  If you are using `@babel/cli` and passing them from command line, please create a Babel config `babel.config.js` and specify options there.
+  If you are using `@babel/cli` and passing `--module-ids`, `--module-root` and `--module-id` from command line, please create a Babel config `babel.config.js` and specify options there.
 
 ### `@babel/preset-env` {#configuration-change-preset-env}
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -79,6 +79,32 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 + import value from "module" with { type: "json" };
 ```
 
+### Syntax plugins
+The following syntax plugins are no longer needed, you can safely remove them from your config and node modules:
+
+- `@babel/plugin-syntax-async-functions`
+- `@babel/plugin-syntax-async-generators`
+- `@babel/plugin-syntax-bigint`
+- `@babel/plugin-syntax-class-properties`
+- `@babel/plugin-syntax-class-static-block`
+- `@babel/plugin-syntax-dynamic-import`
+- `@babel/plugin-syntax-exponentiation-operator`
+- `@babel/plugin-syntax-export-extensions`
+- `@babel/plugin-syntax-export-namespace-from`
+- `@babel/plugin-syntax-import-meta`
+- `@babel/plugin-syntax-json-strings`
+- `@babel/plugin-syntax-logical-assignment-operators`
+- `@babel/plugin-syntax-module-string-names`
+- `@babel/plugin-syntax-nullish-coalescing-operator`
+- `@babel/plugin-syntax-numeric-separator`
+- `@babel/plugin-syntax-object-rest-spread`
+- `@babel/plugin-syntax-optional-catch-binding`
+- `@babel/plugin-syntax-optional-chaining`
+- `@babel/plugin-syntax-private-property-in-object`
+- `@babel/plugin-syntax-top-level-await`
+- `@babel/plugin-syntax-trailing-function-commas`
+- `@babel/plugin-syntax-unicode-sets-regex`
+
 ## Configuration Changes
 
 ### `@babel/core` {#configuration-change-preset-core}

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -110,6 +110,24 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 ### `@babel/preset-env` {#configuration-change-preset-env}
 
+![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
+
+- `includes` and `excludes` respect renamed package names ([#15576](https://github.com/babel/babel/pull/15576))
+
+  **Migration**: If `includes` or `excludes` contain any plugins mentioned in the [Packages Renames section](./v8-migration.md#package-renames), change it to the new name. For example,
+
+  ```diff title="babel.config.json"
+  {
+    "presets": [[
+      "@babel/preset-env",
+      {
+  -     "includes": ["proposal-optional-chaining"]
+  +     "includes": ["transform-optional-chaining"]
+      }
+    ]]
+  }
+  ```
+
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 
 - Remove `uglify` target ([#12594](https://github.com/babel/babel/pull/12594))

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -132,7 +132,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 - Remove `uglify` target ([#12594](https://github.com/babel/babel/pull/12594))
 
-  **Migration**: The `uglify` target had been deprecated since 7.0.0-beta.0, if you still need this, use the [`forceAllTransforms`](preset-env.md#forcealltransforms) option.
+  **Migration**: The `uglify` target had been deprecated since 7.0.0, if you still need this, use the [`forceAllTransforms`](preset-env.md#forcealltransforms) option.
 
 ### `@babel/preset-react` {#configuration-change-preset-react}
 
@@ -166,7 +166,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
 
-- Remove `isTSX` and `allExtensions` option ([#14955](https://github.com/babel/babel/pull/14955))
+- Remove `isTSX` and `allExtensions` options ([#14955](https://github.com/babel/babel/pull/14955))
 
   **Migration**:
   - `isTSX: true` and `allExtensions: true`
@@ -214,7 +214,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 - Remove `allowDeclareFields` option ([#12461](https://github.com/babel/babel/pull/12461))
 
-  **Migration**: Remove the option from your config. You will probably be fine with the new behaviour. Previously `allowDeclareFields` enables transforming the `declare` syntax introduced in TypeScript 3.7, in Babel 8 we support the syntax without such a flag. See also the [compilation changes](#compilation-change-jsx) section.
+  **Migration**: Remove the option from your config, since it's now enabled by default.  Previously `allowDeclareFields` enables transforming the `declare` syntax introduced in TypeScript 3.7, in Babel 8 we support the syntax without such a flag. See also the [compilation changes](#compilation-change-jsx) section.
 
 - Type check input options ([#12460](https://github.com/babel/babel/pull/12460))
 
@@ -254,7 +254,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 - Remove `allowDeclareFields` option ([#12457](https://github.com/babel/babel/pull/12457))
 
-  **Migration**: Remove the option from your config. You will probably be fine with the new behaviour. Previously `allowDeclareFields` enables transforming the `declare` syntax introduced in Flow 0.120.0, in Babel 8 we support the syntax without such a flag. See also the [compilation changes](#compilation-change-flow) section.
+  **Migration**: Remove the option from your config, since it's now enabled by default. Previously `allowDeclareFields` enables transforming the `declare` syntax introduced in Flow 0.120.0, in Babel 8 we support the syntax without such a flag. See also the [compilation changes](#compilation-change-flow) section.
 
 - Type check input options ([#12460](https://github.com/babel/babel/pull/12460))
 
@@ -274,7 +274,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 - Remove `estree` plugin option `classFeatures` ([#13752](https://github.com/babel/babel/pull/13752))
 
-  **Migration**: Remove the option from your config. You will probably be fine with the new behaviour. Previously the `classFeatures` plugin enables `@babel/parser` to produce class properties AST compatible with ESLint 8. In Babel 8 the `eslint-parser` only works with ESLint 8 and above.
+  **Migration**: Remove the option from your config, since it's now enabled by default. Previously the `classFeatures` plugin enables `@babel/parser` to produce class properties AST compatible with ESLint 8, following the ESTree specification. In Babel 8 the `eslint-parser` only works with ESLint 8 and above.
 
 ### `@babel/generator` {#configuration-change-generator}
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -3,7 +3,7 @@ title: "Upgrade to Babel 8"
 id: v8-migration
 ---
 
-Refer users to this document when upgrading to Babel 8 from Babel 7. If you are a plugin developer or integration user, please also check [migration guide for integration](./v8-migration-api.md).
+Refer users to this document when upgrading to Babel 8 from Babel 7. If you are a plugin developer or integration developer, please also check [migration guide for integration](./v8-migration-api.md).
 
 <!--truncate-->
 
@@ -27,6 +27,10 @@ Babel is now shipped in native ECMAScript modules. ([#11701](https://github.com/
 ### `@babel/core` requirements
 
 All presets and plugins require `@babel/core@^8.0.0` as peer dependency.
+
+### `@babel/eslint-parser` and `@babel/eslint-plugin`
+
+The parser and plugin require `eslint@^8.9.0` as peer dependency. ([#15563](https://github.com/babel/babel/issues/15563))
 
 ## Package Renames
 
@@ -77,7 +81,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 ## Configuration Changes
 
-### `@babel/core`
+### `@babel/core` {#configuration-change-preset-core}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
@@ -104,7 +108,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   If you are using `@babel/cli` and passing them from command line, please create a Babel config `babel.config.js` and specify options there.
 
-### `@babel/preset-env`
+### `@babel/preset-env` {#configuration-change-preset-env}
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 
@@ -134,7 +138,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: The preset will also report invalid option names. Refer to the [docs](./preset-react.md#options) and ensure valid usage.
 
-### `@babel/preset-typescript`
+### `@babel/preset-typescript` {#configuration-change-preset-ts}
 
 ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
 
@@ -190,7 +194,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: The preset will also report invalid option names. Refer to the [docs](./preset-typescript.md#options) and ensure valid usage. For example, `runtime` is not a valid `preset-typescript` option and thus should be removed.
 
-### `@babel/plugin-transform-typescript`
+### `@babel/plugin-transform-typescript` {#configuration-change-transform-ts}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
@@ -198,7 +202,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: Remove the option from your config.
 
-### `@babel/plugin-syntax-typescript`
+### `@babel/plugin-syntax-typescript` {#configuration-change-syntax-ts}
 
 ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
 
@@ -218,7 +222,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   If you are using `isTSX: false`, you can safely remove them.
 
-### `@babel/preset-flow`
+### `@babel/preset-flow` {#configuration-change-preset-flow}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
@@ -230,7 +234,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: The preset will also report invalid option names. Refer to the [docs](./preset-flow.md#options) and ensure valid usage.
 
-### `@babel/plugin-transform-flow-strip-types`
+### `@babel/plugin-transform-flow-strip-types` {#configuration-change-transform-flow}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
@@ -238,7 +242,15 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: Remove the option from your config. You will probably be fine with the new behaviour.
 
-### `@babel/generator`
+### `@babel/parser` {#configuration-change-parser}
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Remove `estree` plugin option `classFeatures` ([#13752](https://github.com/babel/babel/pull/13752))
+
+  **Migration**: Remove the option from your config. You will probably be fine with the new behaviour. Previously the `classFeatures` plugin enables `@babel/parser` to produce class properties AST compatible with ESLint 8. In Babel 8 the `eslint-parser` only works with ESLint 8 and above.
+
+### `@babel/generator` {#configuration-change-generator}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
@@ -246,7 +258,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: `@babel/generator` allows to specify options for [jsesc](https://github.com/mathiasbynens/jsesc), a library used to escape printed values. If you are using the `jsonCompatibleStrings` option, you can replace it with `jsescOption: { json: true }`.
 
-### `@babel/plugin-transform-modules-systemjs`
+### `@babel/plugin-transform-modules-systemjs` {#configuration-change-transform-systemjs}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
@@ -263,7 +275,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
   ```
   **Notes**: All the other plugins which support dynamic import (`transform-modules-commonjs` and `transform-modules-amd`) require the separate plugin since it was introduced. We couldn't change it for `transform-modules-systemjs` because that package did already support dynamic import.
 
-### `@babel/plugin-proposal-decorators`
+### `@babel/plugin-proposal-decorators` {#configuration-change-transform-decorators}
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
@@ -370,7 +382,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 
-- Output non-ASCII characters as-is in string literal ([#11384](https://github.com/babel/babel/pull/11384))
+- Output non-ASCII characters as-is in string literal ([#12675](https://github.com/babel/babel/pull/12675))
 
   If you are using any one of `@babel/cli`, WebPack, Rollup, create-react-app or other Node.js powered bundlers, the transformed code is always encoded with `utf-8` and your app will not be affected. The issue only affects if you are manually calling the `babel.transform` API and your web server is not serving js files in the `utf8` encoding.
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -149,7 +149,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   If your app targets to modern browsers released after 2019, you can safely remove these options as object spread has less code footprint.
 
-  If your code needs to run in an environment which doesn't support object spread, you can either use `@babel/preset-env` (recommended) or `@babel/plugin-proposal-object-rest-spread`. If you want to transpile `Object.assign` down, you also need to enable `@babel/plugin-transform-object-assign`.
+  If your code needs to run in an environment which doesn't support object spread, you can either use `@babel/preset-env` (recommended) or `@babel/plugin-transform-object-rest-spread`. If you want to transpile `Object.assign` down, you also need to enable `@babel/plugin-transform-object-assign`.
   In Babel 7.7.0, you can opt-in this behavior by using the `useSpread` option.
 
 - Type check input options ([#12460](https://github.com/babel/babel/pull/12460))
@@ -331,13 +331,13 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
-- [Require `@babel/plugin-proposal-dynamic-import` when transforming `import()` to SystemJS](https://github.com/babel/babel/blob/78cd63d9cfcd96e6a151c58fed392c3ee757d861/packages/babel-plugin-transform-modules-systemjs/src/index.js#L183-L185) ([#12700](https://github.com/babel/babel/pull/12700))
+- [Require `@babel/plugin-transform-dynamic-import` when transforming `import()` to SystemJS](https://github.com/babel/babel/blob/78cd63d9cfcd96e6a151c58fed392c3ee757d861/packages/babel-plugin-transform-modules-systemjs/src/index.js#L183-L185) ([#12700](https://github.com/babel/babel/pull/12700))
 
-  **Migration**: Add `@babel/plugin-proposal-dynamic-import` to your config: you can already do it in Babel 7. If you are using `@babel/preset-env`, you don't need to do anything.
+  **Migration**: Add `@babel/plugin-transform-dynamic-import` to your config: you can already do it in Babel 7. If you are using `@babel/preset-env`, you don't need to do anything.
   ```diff title="babel.config.js.diff"
   {
     "plugins": [
-  +   "@babel/plugin-proposal-dynamic-import",
+  +   "@babel/plugin-transform-dynamic-import",
       "@babel/plugin-transform-modules-systemjs",
     ]
   }
@@ -354,7 +354,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
   ```diff title="babel.config.json"
   {
     "plugins": [
-      ["@babel/plugin-proposal-dynamic-import", {
+      ["@babel/plugin-proposal-decorators", {
   -     "decoratorsBeforeExport": true,
   -     "version": "2018-09",
   +     "version": "2023-01"

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -34,7 +34,7 @@ The parser and plugin require `eslint@^8.9.0` as peer dependency. ([#15563](http
 
 ## Package Renames
 
-The following packages has been renamed to `-transform` as they have reached Stage 4 ([#TODO](https://github.com/babel/babel/pull/TODO)):
+The following packages has been renamed to `-transform` as they have reached Stage 4 ([#15614](https://github.com/babel/babel/pull/15614)). The rename process has been landed in Babel 7.22 so you can start the migration prior to the upgrade.
 
 | Babel 7 | Babel 8 |
 | --- | --- |

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -169,13 +169,15 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
     ```diff title="babel.config.js"
     {
-      include: /\.vue$/,
-      presets: [
-        ['@babel/preset-typescript', {
-    -     allExtensions: true, isTSX: true
-    +     ignoreExtensions: true
-        }]
-      ]
+      overrides: [{
+        include: /\.vue$/,
+        presets: [
+          ['@babel/preset-typescript', {
+    -       allExtensions: true, isTSX: true
+    +       ignoreExtensions: true
+          }]
+        ]
+      }]
     }
     ```
 
@@ -380,7 +382,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 
-- [Disallow sequence expressions inside JSX attributes](https://github.com/babel/babel/issues/8604) ([#8787](https://github.com/babel/babel/pull/8787))
+- [Disallow sequence expressions inside JSX attributes](https://github.com/babel/babel/issues/8604) ([#12447](https://github.com/babel/babel/pull/12447))
 
   **Migration**: Find and replace the following code patterns. You can start the migration prior to Babel 8:
   ```diff title=input.jsx
@@ -388,7 +390,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
   + <p key={(foo, bar)}></p> // Valid
   ```
 
-- [Disallow `{`, `}`, `<` and `>` in JSX text](https://github.com/babel/babel/issues/11042) ([#11046](https://github.com/babel/babel/pull/11046))
+- [Disallow `{`, `}`, `<` and `>` in JSX text](https://github.com/babel/babel/issues/11042) ([#12451](https://github.com/babel/babel/pull/12451))
 
   **Migration**: Use `{'{'}`, `{'}'}`, `{'<'}` and `{'>'}` instead. Find and replace the following code patterns. You can start the migration prior to Babel 8:
   ```diff title=input.jsx

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -330,7 +330,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
 - Remove support for the 2018-09 decorators proposal. The plugin now requires a [`version`](./plugin-proposal-decorators.md#version) option ([#12712](https://github.com/babel/babel/pull/12712))
 
-  **Migration**: You should migrate to the [latest version of the proposal](https://github.com/tc39/proposal-decorators/) if you are using the `"2018-09"` or you have not specified a `version` option.
+  **Migration**: You should migrate to the [latest version of the proposal](https://github.com/tc39/proposal-decorators/) `"2023-03"`, if you are using the `"2018-09"` or you have not specified a `version` option.
   ```diff title="babel.config.json"
   {
     "plugins": [
@@ -342,7 +342,7 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
     ]
   }
   ```
-  The syntax is the same, but you will need to rewrite your decorator functions. You can already migrate since Babel 7.21.0, using the `"version": "2023-01"` option of `@babel/plugin-proposal-decorators`.
+  The syntax is the same, but you will need to rewrite your decorator functions. The spec repo provides [comparison between the latest version and the `2018-09` version](https://github.com/tc39/proposal-decorators#comparison-with-the-previous-stage-2-decorators-proposal). You can already migrate since Babel 7.22.0, using the `"version": "2023-03"` option of `@babel/plugin-proposal-decorators`.
 
 ## Compilation Changes
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -138,6 +138,12 @@ Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://git
 
   **Migration**: The preset will also report invalid option names. Refer to the [docs](./preset-react.md#options) and ensure valid usage.
 
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- Disallow `filter` option in automatic runtime ([#15068](https://github.com/babel/babel/pull/15068/commits/e2dd3be6e38b0254bc69a8e52c265214235829c6))
+
+  **Migration**: The `filter` option can only be used with the `classic` runtime. If you have switched to `automatic` runtime, you can safely remove this option. Otherwise please specify `runtime: "classic"`.
+
 ### `@babel/preset-typescript` {#configuration-change-preset-ts}
 
 ![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       type: "category",
       label: "Guides",
-      items: ["index", "usage", "configuration", "learn", "v7-migration"],
+      items: ["index", "usage", "configuration", "learn", "v8-migration"],
     },
     {
       type: "category",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,9 +1,19 @@
+function bool(value) {
+  return value && value !== "false" && value !== "0";
+}
+
 module.exports = {
   docs: [
     {
       type: "category",
       label: "Guides",
-      items: ["index", "usage", "configuration", "learn", "v8-migration"],
+      items: [
+        "index",
+        "usage",
+        "configuration",
+        "learn",
+        bool(process.env.BABEL_8_BREAKING) ? "v8-migration" : "v7-migration",
+      ],
     },
     {
       type: "category",


### PR DESCRIPTION
This is a WIP as I am going through all the Babel 8 changes. The migration docs has two parts: the first is for general users and the second is for integration users / plugin developers, following what we did in Babel 7 migration docs.

Preview link:

Babel 8 Migration: https://deploy-preview-2765--babel.netlify.app/docs/v8-migration
Babel 8 Migration (Integration): https://deploy-preview-2765--babel.netlify.app/docs/v8-migration-api