### PR TITLE
Update outdated plugin-transform-react-constant-elements.md

### DIFF
--- a/docs/plugin-transform-react-constant-elements.md
+++ b/docs/plugin-transform-react-constant-elements.md
@@ -15,16 +15,28 @@ React elements to the highest possible scope, preventing multiple unnecessary re
 const Hr = () => {
   return <hr className="hr" />;
 };
+
+const WithChildren = (props) => {
+  return <div className={props.className}>
+    <hr />
+  </div>;
+}
 ```
 
 **Out**
 
 ```jsx title="JSX"
-const _ref = <hr className="hr" />;
+var _hr, _hr2;
 
 const Hr = () => {
-  return _ref;
+  return _hr || (_hr = <hr className="hr" />);
 };
+
+const WithChildren = (props) => {
+  return <div className={props.className}>
+    {_hr2 || (_hr2 = <hr />)}
+  </div>;
+}
 ```
 
 **Deopts**


### PR DESCRIPTION
The behavior of `@babel/plugin-transform-react-constant-elements` has already been changed since 2021, see https://github.com/babel/babel/pull/12967.

The PR updates the documentation page.