### PR TITLE
update decorators docs

### DIFF
--- a/docs/plugin-proposal-decorators.md
+++ b/docs/plugin-proposal-decorators.md
@@ -6,8 +6,6 @@ sidebar_label: decorators
 
 ## Example
 
-(examples are from proposal)
-
 ### Simple class decorator
 
 ```js title="JavaScript"
@@ -32,19 +30,22 @@ function isTestable(value) {
 }
 ```
 
-### Class function decorator
+### Class method decorator {#class-function-decorator}
 
 ```js title="JavaScript"
 class C {
-  @enumerable(false)
-  method() {}
+  message = "hello!";
+
+  @bound
+  m() {
+    console.log(this.message);
+  }
 }
 
-function enumerable(value) {
-  return function(target, key, descriptor) {
-    descriptor.enumerable = value;
-    return descriptor;
-  };
+function bound(value, { name, addInitializer }) {
+  addInitializer(function () {
+    this[name] = this[name].bind(this);
+  });
 }
 ```
 
@@ -60,21 +61,19 @@ npm install --save-dev @babel/plugin-proposal-decorators
 
 ```json title="babel.config.json"
 {
-  "plugins": ["@babel/plugin-proposal-decorators"]
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "version": "2023-01" }]
+  ]
 }
-```
-
-### Via CLI
-
-```sh title="Shell"
-babel --plugins @babel/plugin-proposal-decorators script.js
 ```
 
 ### Via Node API
 
 ```js title="JavaScript"
 require("@babel/core").transformSync("code", {
-  plugins: ["@babel/plugin-proposal-decorators"],
+  plugins: [
+    ["@babel/plugin-proposal-decorators", { version: "2023-01" }],
+  ]
 });
 ```
 
@@ -99,9 +98,11 @@ Selects the decorators proposal to use:
 - `"2022-03"` is the proposal version that reached consensus for Stage 3 in the March 2022 TC39 meeting. You can read more about it at [`tc39/proposal-decorators@8ca65c046d`](https://github.com/tc39/proposal-decorators/tree/8ca65c046dd5e9aa3846a1fe5df343a6f7efd9f8).
 - `"2021-12"` is the proposal version as it was presented to TC39 in Dec 2021. You can read more about it at [`tc39/proposal-decorators@d6c056fa06`](https://github.com/tc39/proposal-decorators/tree/d6c056fa061646178c34f361bad33d583316dc85).
 - `"2018-09"` is the proposal version that was initially promoted to Stage 2 presented to TC39 in Sept 2018.  You can read more about it at [`tc39/proposal-decorators@7fa580b40f`](https://github.com/tc39/proposal-decorators/tree/7fa580b40f2c19c561511ea2c978e307ae689a1b).
-- `legacy` is the original Stage 1 proposal, defined at [`wycats/javascript-decorators@e1bf8d41bf`](https://github.com/wycats/javascript-decorators/blob/e1bf8d41bfa2591d949dd3bbf013514c8904b913/README.md).
+- `legacy` is the legacy Stage 1 proposal, defined at [`wycats/javascript-decorators@e1bf8d41bf`](https://github.com/wycats/javascript-decorators/blob/e1bf8d41bfa2591d949dd3bbf013514c8904b913/README.md).
 
-> ⚠️ If you specify the `decoratorsBeforeExport` option, `version` defaults to `"2018-09"`.
+The spec repo provides a brief [summary of the differences between these versions](https://github.com/tc39/proposal-decorators#how-does-this-proposal-compare-to-other-versions-of-decorators).
+
+If you specify the `decoratorsBeforeExport` option, `version` defaults to `"2018-09"`, otherwise it is a required option.
 
 ### `decoratorsBeforeExport`
 
@@ -125,7 +126,9 @@ This option was originally added to help tc39 collect feedback from the communit
 
 ### `legacy`
 
-> **⚠️ DEPRECATED**: Use `version: "legacy"` instead. This option is a legacy alias.
+:::danger Deprecated
+Use `version: "legacy"` instead. This option is a legacy alias.
+:::
 
 `boolean`, defaults to `false`.
 
@@ -133,26 +136,26 @@ Use the legacy (stage 1) decorators syntax and behavior.
 
 #### NOTE: Compatibility with `@babel/plugin-proposal-class-properties`
 
-If you are including your plugins manually and using `@babel/plugin-proposal-class-properties` and legacy decorators, make sure that `@babel/plugin-proposal-decorators` comes _before_ `@babel/plugin-proposal-class-properties`.
+If you are including your plugins manually and using `@babel/plugin-proposal-class-properties` or `@babel/plugin-private-methods` and legacy decorators, make sure that `@babel/plugin-proposal-decorators` comes _before_ `@babel/plugin-proposal-class-properties`.
 
-Wrong:
-
-```json title="babel.config.json"
+```diff title="babel.config.json"
 {
   "plugins": [
-    "@babel/plugin-proposal-class-properties",
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }]
+-   "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-proposal-decorators", { "version": "2023-01" }]
++   "@babel/plugin-proposal-class-properties"
   ]
 }
 ```
 
-Right:
+If you are already using `@babel/preset-env`, you can safely remove `@babel/plugin-proposal-class-properties` and `@babel/plugin-private-methods`:
 
-```json title="babel.config.json"
+```diff title="babel.config.json"
 {
+  "presets": ["@babel/preset-env"],
   "plugins": [
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+-   "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-proposal-decorators", { "version": "2023-01" }]
   ]
 }
 ```


### PR DESCRIPTION
Resolves https://github.com/babel/website/issues/2768

In this PR we

- updated the examples of decorators to the "2023-01" version 
- marked the version option as required
- removed the CLI usage because this plugin requires at least one plugin option, which can not be passed from command line
- linked the spec repo for a brief summary of different decorator versions
- recommend to use `preset-env` when using with class properties / private methods transform, c.f. https://github.com/babel/babel/discussions/15582

Preview link: https://deploy-preview-2770--babel.netlify.app/docs/babel-plugin-proposal-decorators