### PR TITLE
Add `ignoreExtensions` docs

### DIFF
--- a/docs/preset-flow.md
+++ b/docs/preset-flow.md
@@ -93,4 +93,17 @@ class A {
 }
 ```
 
+:::babel8
+
+### `ignoreExtensions`
+
+`boolean`, defaults to `false`
+
+Added in : `v8.0.0`
+
+When it is set to `true`, Babel will apply the flow transform to all extensions. When it is set to `false`, Babel
+will avoid the flow transform for `*.tsx` files.
+
+:::
+
 > You can read more about configuring preset options [here](https://babeljs.io/docs/en/presets#preset-options)

--- a/docs/preset-flow.md
+++ b/docs/preset-flow.md
@@ -93,17 +93,13 @@ class A {
 }
 ```
 
-:::babel8
-
 ### `ignoreExtensions`
 
 `boolean`, defaults to `false`
 
-Added in : `v8.0.0`
+Added in: `v7.21.4`
 
 When it is set to `true`, Babel will apply the flow transform to all extensions. When it is set to `false`, Babel
 will avoid the flow transform for `*.tsx` files.
-
-:::
 
 > You can read more about configuring preset options [here](https://babeljs.io/docs/en/presets#preset-options)

--- a/docs/preset-typescript.md
+++ b/docs/preset-typescript.md
@@ -56,11 +56,15 @@ require("@babel/core").transformSync("code", {
 
 ## Options
 
+:::babel7
+
 ### `isTSX`
 
 `boolean`, defaults to `false`
 
 Forcibly enables `jsx` parsing. Otherwise angle brackets will be treated as typescript's legacy type assertion `var foo = <string>bar;`. Also, `isTSX: true` requires `allExtensions: true`.
+
+:::
 
 ### `jsxPragma`
 
@@ -74,11 +78,15 @@ Replace the function used when compiling JSX expressions. This is so that we kno
 
 Replace the function used when compiling JSX fragment expressions. This is so that we know that the import is not a type import, and should not be removed.
 
+:::babel7
+
 ### `allExtensions`
 
 `boolean`, defaults to `false`
 
 Indicates that every file should be parsed as TS, TSX, or as TS without JSX ambiguities (depending on the `isTSX` and `disallowAmbiguousJSXLike` options).
+
+:::
 
 ### `allowNamespaces`
 
@@ -114,6 +122,32 @@ class A {
 Added in: `v7.16.0`
 
 Even when JSX parsing is not enabled, this option disallows using syntax that would be ambiguous with JSX (`<X> y` type assertions and `<X>() => {}` type arguments). It matches the `tsc` behavior when parsing `.mts` and `.mjs` files.
+
+:::babel8
+
+### `ignoreExtensions`
+
+`boolean`, defaults to `false`
+
+Added in: `v8.0.0`
+
+When it is set to `false`, Babel will automatically provide required plugins for `*.ts`, `*.tsx`, `*.mts` and `*.cts` files.
+
+When it is set to `true`, Babel will provide a general TS plugin. If you want to transpile source as if it were `*.tsx`, enable the `@babel/preset-react` preset and this plugin should work with the JSX transform seamlessly. For example,
+
+```json title="babel.config.json"
+{
+  "presets": ["@babel/preset-react"],
+  "overrides": [{
+    "test": "*.vue",
+    "presets": [
+      ["@babel/preset-typescript"], { "ignoreExtensions": true }
+    ]
+  }]
+}
+```
+
+:::
 
 ### `onlyRemoveTypeImports`
 

--- a/docs/preset-typescript.md
+++ b/docs/preset-typescript.md
@@ -123,13 +123,11 @@ Added in: `v7.16.0`
 
 Even when JSX parsing is not enabled, this option disallows using syntax that would be ambiguous with JSX (`<X> y` type assertions and `<X>() => {}` type arguments). It matches the `tsc` behavior when parsing `.mts` and `.mjs` files.
 
-:::babel8
-
 ### `ignoreExtensions`
 
 `boolean`, defaults to `false`
 
-Added in: `v8.0.0`
+Added in: `v7.21.4`
 
 When it is set to `false`, Babel will automatically provide required plugins for `*.ts`, `*.tsx`, `*.mts` and `*.cts` files.
 
@@ -146,8 +144,6 @@ When it is set to `true`, Babel will provide a general TS plugin. If you want to
   }]
 }
 ```
-
-:::
 
 ### `onlyRemoveTypeImports`
 


### PR DESCRIPTION
Add `ignoreExtensions` docs introduced in Babel 7.21.4.

Companion PR of https://github.com/babel/babel/pull/14955

<s>This PR depends on #2772, I will rebase after it is merged.</s>