### PR TITLE
Docs: add Babel 8 default targets

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -365,6 +365,8 @@ If a minor version is not specified, Babel will interpret it as `MAJOR.0`. For e
 
 #### No targets
 
+:::babel7
+
 When no targets are specified: Babel will assume you are targeting the oldest browsers possible. For example, `@babel/preset-env` will transform all ES2015-ES2020 code to be ES5 compatible.
 
 > We recommend setting `targets` to reduce the output code size.
@@ -384,6 +386,14 @@ Because of this, Babel's behavior is different than [browserslist](https://githu
 ```
 
 We recognize this isn’t ideal and will be revisiting this in Babel v8.
+
+:::
+
+:::babel8
+
+When no targets are specified: Babel will assume you are using the [browserslist](https://github.com/browserslist/browserslist#queries) [`defaults`](https://browsersl.ist/#q=defaults) query, which covers most modern browsers. If you want to support legacy browsers, specify the `targets` option.
+
+:::
 
 #### `targets.esmodules`
 


### PR DESCRIPTION
Companion of https://github.com/babel/babel/pull/15551