### PR TITLE
Add module options docs

### DIFF
--- a/docs/plugin-transform-modules-amd.md
+++ b/docs/plugin-transform-modules-amd.md
@@ -68,6 +68,39 @@ require("@babel/core").transformSync("code", {
 });
 ```
 
-### Options
+## Options
 
-See options for [`@babel/plugin-transform-modules-commonjs`](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs#options).
+### `moduleIds`
+
+`boolean` defaults to `!!moduleId`
+
+Added in: `v7.9.0`
+
+Enables module ID generation.
+
+### `moduleId`
+
+`string`
+
+Added in: `v7.9.0`
+
+A hard-coded ID to use for the module. Cannot be used alongside `getModuleId`.
+
+### `getModuleId`
+
+`(name: string) => string`
+
+Added in: `v7.9.0`
+
+Given the babel-generated module name, return the name to use. Returning
+a falsy value will use the original `name`.
+
+### `moduleRoot`
+
+`string`
+
+Added in: `v7.9.0`
+
+A root path to include on generated module names.
+
+For options not listed here, see options for [`@babel/plugin-transform-modules-commonjs`](plugin-transform-modules-commonjs.md#options).

--- a/docs/plugin-transform-modules-systemjs.md
+++ b/docs/plugin-transform-modules-systemjs.md
@@ -78,3 +78,38 @@ require("@babel/core").transformSync("code", {
   plugins: ["@babel/plugin-transform-modules-systemjs"],
 });
 ```
+
+## Options
+
+### `moduleIds`
+
+`boolean` defaults to `!!moduleId`
+
+Added in: `v7.9.0`
+
+Enables module ID generation.
+
+### `moduleId`
+
+`string`
+
+Added in: `v7.9.0`
+
+A hard-coded ID to use for the module. Cannot be used alongside `getModuleId`.
+
+### `getModuleId`
+
+`(name: string) => string`
+
+Added in: `v7.9.0`
+
+Given the babel-generated module name, return the name to use. Returning
+a falsy value will use the original `name`.
+
+### `moduleRoot`
+
+`string`
+
+Added in: `v7.9.0`
+
+A root path to include on generated module names.

--- a/docs/plugin-transform-modules-umd.md
+++ b/docs/plugin-transform-modules-umd.md
@@ -233,6 +233,39 @@ require("@babel/core").transformSync("code", {
 });
 ```
 
-### Options
+## Options
 
-See options for [`@babel/plugin-transform-modules-commonjs`](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs#options).
+### `moduleIds`
+
+`boolean` defaults to `!!moduleId`
+
+Added in: `v7.9.0`
+
+Enables module ID generation.
+
+### `moduleId`
+
+`string`
+
+Added in: `v7.9.0`
+
+A hard-coded ID to use for the module. Cannot be used alongside `getModuleId`.
+
+### `getModuleId`
+
+`(name: string) => string`
+
+Added in: `v7.9.0`
+
+Given the babel-generated module name, return the name to use. Returning
+a falsy value will use the original `name`.
+
+### `moduleRoot`
+
+`string`
+
+Added in: `v7.9.0`
+
+A root path to include on generated module names.
+
+For options not listed here, see options for [`@babel/plugin-transform-modules-commonjs`](plugin-transform-modules-commonjs.md#options).


### PR DESCRIPTION
Add docs for module options supported in v7.9.0. The current docs are copied from `options.md`.

This is a docs PR for https://github.com/babel/babel/pull/11194