### PR TITLE
support OC_API_TOKEN

### DIFF
--- a/scripts/download-sponsors.js
+++ b/scripts/download-sponsors.js
@@ -83,12 +83,17 @@ const getAllNodes = async (graphqlQuery, getNodes, time = "year") => {
   // Handling pagination if necessary
   // eslint-disable-next-line
   while (true) {
+    const headers = {
+      "Content-Type": "application/json",
+    };
+    if (process.env.OC_API_TOKEN) {
+      headers["Personal-Token"] = process.env.OC_API_TOKEN;
+    }
+
     const result = await fetch(graphqlEndpoint, {
       method: "POST",
       body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers,
     }).then(response => response.json());
     if (result.errors) {
       const {


### PR DESCRIPTION
Recently our netlify builds are failing because we introduced the babel-next build, which eventually hit the OC free API rate limit: 10 / min. ([ref](https://graphql-docs-v2.opencollective.com/access))

In this PR we will add a personal token when the environment variable `OC_API_TOKEN` is available. When a token is provided, the rate limit is 100 / min, it should be enough for the netlify jobs.