### PR TITLE
add default jsx runtime in Babel 8

### DIFF
--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -280,6 +280,27 @@ Without options:
 
 With options:
 
+:::babel8
+
+```json title="babel.config.json"
+{
+  "plugins": [
+    [
+      "@babel/plugin-transform-react-jsx",
+      {
+        "throwIfNamespace": false, // defaults to true
+        "runtime": "automatic", // defaults to autoamtic
+        "importSource": "custom-jsx-library" // defaults to react
+      }
+    ]
+  ]
+}
+```
+
+:::
+
+:::babel7
+
 ```json title="babel.config.json"
 {
   "plugins": [
@@ -294,6 +315,8 @@ With options:
   ]
 }
 ```
+
+:::
 
 ### Via CLI
 
@@ -327,7 +350,17 @@ Though the JSX spec allows this, it is disabled by default since React's JSX doe
 
 #### `runtime`
 
+:::babel8
+
+`classic | automatic`, defaults to `automatic`
+
+:::
+
+:::babel7
+
 `classic | automatic`, defaults to `classic`
+
+:::
 
 Added in: `v7.9.0`
 

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -79,9 +79,25 @@ require("@babel/core").transformSync("code", {
 
 #### `runtime`
 
+:::babel8
+
+`classic | automatic`, defaults to `automatic`
+
+:::
+
+:::babel7
+
 `classic | automatic`, defaults to `classic`
 
+:::
+
 Added in: `v7.9.0`
+
+:::babel7
+
+> Note: The default runtime will be switched to `automatic` in Babel 8.
+
+:::
 
 Decides which runtime to use.
 

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -42,6 +42,29 @@ Without options:
 
 With options:
 
+:::babel8
+
+```json title="babel.config.json"
+{
+  "presets": [
+    [
+      "@babel/preset-react",
+      {
+        "runtime": "automatic", // defaults to automatic
+        "importSource": "custom-jsx-library", // defaults to react(only in automatic runtime)
+        "throwIfNamespace": false // defaults to true
+        // "pragma": "dom", // default pragma is React.createElement (only in classic runtime)
+        // "pragmaFrag": "DomFrag", // default is React.Fragment (only in classic runtime)
+      }
+    ]
+  ]
+}
+```
+
+:::
+
+:::babel7
+
 ```json title="babel.config.json"
 {
   "presets": [
@@ -58,6 +81,8 @@ With options:
   ]
 }
 ```
+
+:::
 
 ### Via CLI
 


### PR DESCRIPTION
Companion of https://github.com/babel/babel/pull/12630

Babel 8 Preview: https://deploy-preview-2778--babel-next.netlify.app/docs/babel-preset-react