### PR TITLE
remove useBuiltIns and useSpread for Babel 8

### DIFF
--- a/docs/plugin-transform-react-jsx.md
+++ b/docs/plugin-transform-react-jsx.md
@@ -361,6 +361,8 @@ Note that the `@jsx React.DOM` pragma has been deprecated as of React v0.12
 
 Replace the component used when compiling JSX fragments. It should be a valid JSX tag name.
 
+:::babel7
+
 ### `useBuiltIns`
 
 `boolean`, defaults to `false`.
@@ -372,3 +374,5 @@ When spreading props, use `Object.assign` directly instead of Babel's extend hel
 `boolean`, defaults to `false`.
 
 When spreading props, use inline object with spread elements directly instead of Babel's extend helper or `Object.assign`.
+
+:::

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -135,9 +135,15 @@ Replace the function used when compiling JSX expressions. It should be a qualifi
 
 Replace the component used when compiling JSX fragments. It should be a valid JSX tag name.
 
+:::babel7
+
 #### `useBuiltIns`
 
 `boolean`, defaults to `false`.
+
+:::warning
+This option will be removed in Babel 8. Set `useBuiltIns` to `true` if you are targeting to modern browsers.
+:::
 
 Will use the native built-in instead of trying to polyfill behavior for any plugins that require one.
 
@@ -147,7 +153,13 @@ Will use the native built-in instead of trying to polyfill behavior for any plug
 
 Added in: `v7.7.0`
 
+:::warning
+This option will be removed in Babel 8. Set `useSpread` to `true` if you are targeting to modern browsers.
+:::
+
 When spreading props, use inline object with spread elements directly instead of Babel's extend helper or `Object.assign`.
+
+:::
 
 ### babel.config.js
 


### PR DESCRIPTION
Companion of https://github.com/babel/babel/pull/12593.