### PR TITLE
Fix repl CI build

### DIFF
--- a/js/repl/index.html
+++ b/js/repl/index.html
@@ -399,6 +399,7 @@
          rel="stylesheet"
          /> -->
     <script src="/js/codetabs.js"></script>
+    <script defer src="/repl/repl.js"></script>
   </head>
 
   <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,6 @@ const config = {
   },
   entry: {
     repl: "./js/repl/index.tsx",
-    minirepl: "./js/minirepl.js",
   },
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".json"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ const config = {
   plugins: [
     new HtmlWebpackPlugin({
       template: "./js/repl/index.html",
+      inject: false,
     }),
     new webpack.ProvidePlugin({
       Buffer: ["buffer"],


### PR DESCRIPTION
The REPL CI build is broken because the script `./repl.js` can not be found from `/repl/build/12345`. In this PR we manually inject `/repl/repl.js` so that it can be imported under `/repl/build/12345`

We also remove another unused js import `minirepl` as it has been handled by docusaurus.

Preview URL:

https://deploy-preview-2781--babel.netlify.app/repl/build/54393
https://deploy-preview-2781--babel-next.netlify.app/repl/build/54393
