### PR TITLE
Use builtin plugins when available and provide default options for some external plugins

### DIFF
--- a/js/repl/Repl.tsx
+++ b/js/repl/Repl.tsx
@@ -102,6 +102,31 @@ function hasOwnProperty(obj, string) {
   return Object.prototype.hasOwnProperty.call(obj, string);
 }
 
+function provideDefaultOptionsForExternalPlugins(pluginName, babelVersion) {
+  switch (pluginName) {
+    case "@babel/plugin-proposal-decorators": {
+      if (compareVersions(babelVersion, "7.21.0") >= 0) {
+        return { version: "2023-01" };
+      } else if (compareVersions(babelVersion, "7.19.0") >= 0) {
+        return { version: "2022-03" };
+      } else if (compareVersions(babelVersion, "7.17.0") >= 0) {
+        return { version: "2021-12" };
+      } else if (compareVersions(babelVersion, "7.0.0") >= 0) {
+        return { version: "2018-09", decoratorsBeforeExport: true };
+      }
+    }
+    case "@babel/plugin-proposal-pipeline-operator": {
+      if (compareVersions(babelVersion, "7.15.0") >= 0) {
+        return { proposal: "hack", topicToken: "%" };
+      } else {
+        return { proposal: "minimal" };
+      }
+    }
+    default:
+      return {};
+  }
+}
+
 class Repl extends React.Component<Props, State> {
   _numLoadingPlugins = 0;
   _workerApi = new WorkerApi();
@@ -499,7 +524,13 @@ class Repl extends React.Component<Props, State> {
 
     this._workerApi
       .compile(code, {
-        plugins: state.externalPlugins.map((plugin) => plugin.name),
+        plugins: state.externalPlugins.map((plugin) => [
+          plugin.name,
+          provideDefaultOptionsForExternalPlugins(
+            plugin.name,
+            state.babel.version
+          ),
+        ]),
         debugEnvPreset: state.debugEnvPreset,
         envConfig: state.envConfig,
         presetsOptions: state.presetsOptions,

--- a/js/repl/Repl.tsx
+++ b/js/repl/Repl.tsx
@@ -381,8 +381,7 @@ class Repl extends React.Component<Props, State> {
 
     if (result.didError) return result;
 
-    const availablePlugins = await this._workerApi.getAvailablePlugins();
-    const availablePluginsNames = availablePlugins.map(({ label }) => label);
+    const availablePluginsNames = await this._workerApi.getAvailablePlugins();
     const notRegisteredPackages =
       this.state.shippedProposalsState.config.packages
         .filter(

--- a/js/repl/Repl.tsx
+++ b/js/repl/Repl.tsx
@@ -423,7 +423,15 @@ class Repl extends React.Component<Props, State> {
     );
   };
 
-  _loadExternalPlugin = (plugin: BabelPlugin) => {
+  _loadExternalPlugin = async (plugin: BabelPlugin) => {
+    // use available plugins from @babel/standalone for official external plugins
+    if (plugin.name.startsWith("@babel/plugin-")) {
+      const availablePlugins = await this._workerApi.getAvailablePlugins();
+      const shorthandName = plugin.name.replace("@babel/plugin-", "");
+      if (availablePlugins.includes(shorthandName)) {
+        return this._workerApi.registerPluginAlias(plugin.name, shorthandName);
+      }
+    }
     const bundledUrl = [
       "https://bundle.run",
       "https://packd.liuxingbaoyu.xyz",

--- a/js/repl/Repl.tsx
+++ b/js/repl/Repl.tsx
@@ -105,7 +105,9 @@ function hasOwnProperty(obj, string) {
 function provideDefaultOptionsForExternalPlugins(pluginName, babelVersion) {
   switch (pluginName) {
     case "@babel/plugin-proposal-decorators": {
-      if (compareVersions(babelVersion, "7.21.0") >= 0) {
+      if (compareVersions(babelVersion, "7.22.0") >= 0) {
+        return { version: "2023-05" };
+      } else if (compareVersions(babelVersion, "7.21.0") >= 0) {
         return { version: "2023-01" };
       } else if (compareVersions(babelVersion, "7.19.0") >= 0) {
         return { version: "2022-03" };

--- a/js/repl/Repl.tsx
+++ b/js/repl/Repl.tsx
@@ -296,8 +296,6 @@ class Repl extends React.Component<Props, State> {
         babelState.didError = true;
         babelState.errorMessage =
           babelState.errorMessage || envState.errorMessage;
-      } else {
-        await this._workerApi.registerEnvPreset();
       }
     }
 

--- a/js/repl/Worker.ts
+++ b/js/repl/Worker.ts
@@ -78,5 +78,18 @@ registerPromiseWorker((message) => {
       } catch (error) {
         return false;
       }
+
+    case "registerPluginAlias":
+      try {
+        const { aliasTo, pluginName } = message;
+        if (aliasTo in Babel.availablePlugins) {
+          Babel.registerPlugin(pluginName, Babel.availablePlugins[aliasTo]);
+          return true;
+        } else {
+          return false;
+        }
+      } catch {
+        return false;
+      }
   }
 });

--- a/js/repl/Worker.ts
+++ b/js/repl/Worker.ts
@@ -40,10 +40,7 @@ registerPromiseWorker((message) => {
     case "getAvailablePlugins":
       if (!Babel) return [];
 
-      return Object.keys(Babel.availablePlugins).map((p) => ({
-        label: p,
-        isPreLoaded: true,
-      }));
+      return Object.keys(Babel.availablePlugins);
 
     case "loadScript":
       if (!Array.isArray(message.url)) {

--- a/js/repl/Worker.ts
+++ b/js/repl/Worker.ts
@@ -2,7 +2,6 @@ import compile from "./compile";
 import { registerPromiseWorker } from "./WorkerUtils";
 
 declare var Babel: any;
-declare var babelPresetEnv: any;
 declare function importScripts(url: string): void;
 
 // This script should be executed within a web-worker.
@@ -59,16 +58,6 @@ registerPromiseWorker((message) => {
         }
       }
       return false;
-
-    case "registerEnvPreset":
-      try {
-        // Was registered when loaded;
-        // Babel.registerPreset("env", babelPresetEnv.default);
-
-        return true;
-      } catch (error) {
-        return false;
-      }
 
     case "registerPlugins":
       try {

--- a/js/repl/WorkerApi.ts
+++ b/js/repl/WorkerApi.ts
@@ -136,12 +136,6 @@ export default class WorkerApi {
     });
   }
 
-  registerEnvPreset(): Promise<boolean> {
-    return this._worker.postMessage({
-      method: "registerEnvPreset",
-    });
-  }
-
   registerPlugins(plugins: Array<PluginShape>): Promise<boolean> {
     return this._worker.postMessage({
       method: "registerPlugins",

--- a/js/repl/WorkerApi.ts
+++ b/js/repl/WorkerApi.ts
@@ -137,4 +137,12 @@ export default class WorkerApi {
       plugins,
     });
   }
+
+  registerPluginAlias(pluginName: string, aliasTo: string): Promise<boolean> {
+    return this._worker.postMessage({
+      method: "registerPluginAlias",
+      pluginName,
+      aliasTo,
+    });
+  }
 }

--- a/js/repl/WorkerApi.ts
+++ b/js/repl/WorkerApi.ts
@@ -87,12 +87,7 @@ export default class WorkerApi {
     return this._worker.postMessage({ method: "getAvailablePresets" });
   }
 
-  getAvailablePlugins(): Promise<
-    Array<{
-      label: string;
-      isPreloaded: boolean;
-    }>
-  > {
+  getAvailablePlugins(): Promise<Array<string>> {
     return this._worker.postMessage({ method: "getAvailablePlugins" });
   }
 

--- a/js/repl/types.ts
+++ b/js/repl/types.ts
@@ -1,5 +1,5 @@
 export type BabelPresets = Array<string | Array<string | any>>;
-export type BabelPlugins = Array<string>;
+export type BabelPlugins = Array<string | [string, any]>;
 export type BabelPlugin = {
   name: string;
   version: string;


### PR DESCRIPTION
In this PR we provide builtin plugins available in `@babel/standalone` when the external plugins is an official Babel plugin. In this way we can reduce dependency on the rollup service and improve external plugin loading time.

Then we provide default options for decorators and pipeline plugins. Ideally we should provide an UI to modify such options, but for now at least we can provide a working plugin demo.

[Preview link (decorator transform only)](https://deploy-preview-2783--babel.netlify.app/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=AIMw9mBQDGA2CGBnRACAwig3pFKDEADgNw4qIAu85AltCgLYAUAlFgL6RtA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=react&prettier=false&targets=&version=7.21.8&externalPlugins=%40babel%2Fplugin-proposal-decorators%407.21.0&assumptions=%7B%7D)