### PR TITLE
Update polyfill.md

### DIFF
--- a/docs/polyfill.md
+++ b/docs/polyfill.md
@@ -9,7 +9,7 @@ title: "@babel/polyfill"
 > import "core-js/stable";
 > ```
 >
-> If you are compiling generators or async function to ES5, and you are using a version of `@babel/core` or `@babel/plugin-transform-regenerator` older than `7.18.0`, you must also load the [`regenerator runtime`](https://github.com/facebook/regenerator/tree/main/packages/runtime) package. It is automatically loaded when using `@babel/preset-env`'s `useBuiltIns: "usage"` option or `@babel/plugin-transform-runtime`.
+> If you are compiling generators or async function to ES5, and you are using a version of `@babel/plugin-transform-regenerator` older than `7.18.0`, you must also load the [`regenerator runtime`](https://github.com/facebook/regenerator/tree/main/packages/runtime) package. It is automatically loaded when using `@babel/preset-env`'s `useBuiltIns: "usage"` option or `@babel/plugin-transform-runtime`.
 
 Babel includes a [polyfill](<https://en.wikipedia.org/wiki/Polyfill_(programming)>) that includes a custom [regenerator runtime](https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js) and [core-js](https://github.com/zloirock/core-js).
 


### PR DESCRIPTION
After my testing, it depends on the version of the `@babel/plugin-transform-regenerator` plugin whether the auxiliary function for the generator will be produced. It is not related to the version of `@babel/core`.

If the `transforme-regenerator` plugin version is lower than 7.18.0, the compiled file will not inline the generator auxiliary function. If the version of the `transform-regenerator` plug-in is higher than or equal to 7.18.0, auxiliary inline function will be generated.

Here is a warehouse address for my testing: https://github.com/keer-tea/babel-regenerator-test

There is one type of warehouse, with versions of both packages less than 7.18.0. In Warehouse 2, the `@babel/core` version is less than 7.18.0, and the `@babel/plugin-transform-regenerator` version is greater than 7.18.0. In Warehouse 3, the `@babel/core` version is greater than 7.18.0, and the `@babel/plugin-transform-reenerator` version is less than 7.18.0.

I hope to correct this mistake.