### PR TITLE
add bugfix plugins docs

### DIFF
--- a/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
+++ b/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
@@ -4,7 +4,7 @@ title: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expre
 sidebar_label: safari-id-destructuring-collision-in-function-expression
 ---
 
-This bugfix plugin renames destructuring parameters to workaround a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=220517) affecting versions from 10 to 15.6.
+This bugfix plugin renames destructuring parameters to workaround a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=220517) affecting versions from 10 to 16.2.
 
 :::tip
 This plugin is included in `@babel/preset-env`. Set the [`bugfixes` option](./preset-env.md#bugfixes) to `true` so Babel will automatically enable this plugin for you when your `targets` are affected by the browser bug.

--- a/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
+++ b/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
@@ -1,7 +1,7 @@
 ---
 id: babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression
 title: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression"
-sidebar_label: bugfix-safari-id-destructuring-collision-in-function-expression
+sidebar_label: safari-id-destructuring-collision-in-function-expression
 ---
 
 This bugfix plugin renames destructuring parameters to workaround a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=220517) affecting versions from 10 to 15.6.

--- a/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
+++ b/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
@@ -1,0 +1,41 @@
+---
+id: babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression
+title: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression"
+sidebar_label: bugfix-safari-id-destructuring-collision-in-function-expression
+---
+
+This bugfix plugin renames destructuring parameters to workaround a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=220517) affecting versions from 10 to 15.6.
+
+:::tip
+This plugin is included in `@babel/preset-env`. Set the [`bugfixes` option](./preset-env.md#bugfixes) to `true` so Babel will automatically enable this plugin for you when your `targets` are affected by the browser bug.
+:::
+
+## Installation
+
+```shell npm2yarn
+npm install --save-dev @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression
+```
+
+## Usage
+
+### With a configuration file (Recommended)
+
+```json title="babel.config.json"
+{
+  "plugins": ["@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression"]
+}
+```
+
+### Via CLI
+
+```sh title="Shell"
+babel --plugins @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression script.js
+```
+
+### Via Node API
+
+```js title="JavaScript"
+require("@babel/core").transformSync("code", {
+  plugins: ["@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression"],
+});
+```

--- a/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
+++ b/docs/plugin-bugfix-safari-id-destructuring-collision-in-function-expression.md
@@ -4,7 +4,7 @@ title: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expre
 sidebar_label: safari-id-destructuring-collision-in-function-expression
 ---
 
-This bugfix plugin renames destructuring parameters to workaround a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=220517) affecting versions from 10 to 16.2.
+This bugfix plugin renames destructuring parameters to workaround a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=220517) affecting versions 10 to 16.2.
 
 :::tip
 This plugin is included in `@babel/preset-env`. Set the [`bugfixes` option](./preset-env.md#bugfixes) to `true` so Babel will automatically enable this plugin for you when your `targets` are affected by the browser bug.

--- a/docs/plugin-bugfix-v8-spread-parameters-in-optional-chaining.md
+++ b/docs/plugin-bugfix-v8-spread-parameters-in-optional-chaining.md
@@ -1,0 +1,41 @@
+---
+id: babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining
+title: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining"
+sidebar_label: bugfix-v8-spread-parameters-in-optional-chaining
+---
+
+This bugfix plugin transforms optional chaining operators to workaround a [V8 bug](https://crbug.com/v8/11558) affecting versions from 8.0 to 9.0.
+
+:::tip
+This plugin is included in `@babel/preset-env`. Set the [`bugfixes` option](./preset-env.md#bugfixes) to `true` so Babel will automatically enable this plugin for you when your `targets` are affected by the browser bug.
+:::
+
+## Installation
+
+```shell npm2yarn
+npm install --save-dev @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining
+```
+
+## Usage
+
+### With a configuration file (Recommended)
+
+```json title="babel.config.json"
+{
+  "plugins": ["@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining"]
+}
+```
+
+### Via CLI
+
+```sh title="Shell"
+babel --plugins @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining script.js
+```
+
+### Via Node API
+
+```js title="JavaScript"
+require("@babel/core").transformSync("code", {
+  plugins: ["@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining"],
+});
+```

--- a/docs/plugin-bugfix-v8-spread-parameters-in-optional-chaining.md
+++ b/docs/plugin-bugfix-v8-spread-parameters-in-optional-chaining.md
@@ -4,7 +4,7 @@ title: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining"
 sidebar_label: v8-spread-parameters-in-optional-chaining
 ---
 
-This bugfix plugin transforms optional chaining operators to workaround a [V8 bug](https://crbug.com/v8/11558) affecting versions from 8.0 to 9.0.
+This bugfix plugin transforms optional chaining operators to workaround a [V8 bug](https://crbug.com/v8/11558) affecting versions 8.0 to 9.0.
 
 :::tip
 This plugin is included in `@babel/preset-env`. Set the [`bugfixes` option](./preset-env.md#bugfixes) to `true` so Babel will automatically enable this plugin for you when your `targets` are affected by the browser bug.

--- a/docs/plugin-bugfix-v8-spread-parameters-in-optional-chaining.md
+++ b/docs/plugin-bugfix-v8-spread-parameters-in-optional-chaining.md
@@ -1,7 +1,7 @@
 ---
 id: babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining
 title: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining"
-sidebar_label: bugfix-v8-spread-parameters-in-optional-chaining
+sidebar_label: v8-spread-parameters-in-optional-chaining
 ---
 
 This bugfix plugin transforms optional chaining operators to workaround a [V8 bug](https://crbug.com/v8/11558) affecting versions from 8.0 to 9.0.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -138,6 +138,14 @@ module.exports = {
                 "babel-plugin-transform-reserved-words",
               ],
             },
+            {
+              type: "category",
+              label: "Bugfix",
+              items: [
+                "babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression",
+                "babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining",
+              ],
+            },
           ],
         },
         {


### PR DESCRIPTION
Added missing docs for bugfix plugins.

Preview Link:

https://deploy-preview-2800--babel.netlify.app/docs/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression