### PR TITLE
learn.md: Remove enumerate from Proxy handler

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -560,8 +560,6 @@ var handler =
   getPrototypeOf: ...,
   // Object.setPrototypeOf(target), Reflect.setPrototypeOf(target)
   setPrototypeOf: ...,
-  // for (let i in target) {}
-  enumerate: ...,
   // Object.keys(target)
   ownKeys: ...,
   // Object.preventExtensions(target)


### PR DESCRIPTION
This is not mentioned in the standard:

https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#table-proxy-handler-methods