### PR TITLE
docs: v8-migration-api: parenthesized instead of parens

### DIFF
--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -67,7 +67,7 @@ Check out the [v8-migration guide](v8-migration.md) for other user-level changes
   ```json title="babel.config.json"
   { "parserOpts": { "createParenthesizedExpression": true } }
   ```
-  When `createParenthesizedExpression` is `false`, you can also use `node.extra.parens` to detect whether `node` is wrapped in parentheses.
+  When `createParenthesizedExpression` is `false`, you can also use `node.extra.parenthesized` to detect whether `node` is wrapped in parentheses.
 
 
 ## API Changes


### PR DESCRIPTION
As I see `extra` contains `parenthesized`:

<img width="438" alt="image" src="https://github.com/babel/website/assets/1573141/d6b40af4-a8e9-46d0-8c58-91aed1341434">
