### PR TITLE
Light / Dark theme applied by default based on OS / Browser preference

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -208,6 +208,11 @@ const siteConfig = {
         hideable: true,
       },
     },
+    colorMode: {
+      defaultMode: "light",
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
     prism: {
       additionalLanguages: ["flow", "powershell"],
       theme: require("./src/theme/prism/light"),


### PR DESCRIPTION
Right now, Light theme is applied even users OS / Browser preference is dark.

Pullrequest is to apply Light / Dark theme by default based on OS / Browser preference

docusaurus documentation:
https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode

[Screencast from 04-10-23 05_47_57 PM IST.webm](https://github.com/babel/website/assets/9389944/ca8bbe3b-ea3b-4a06-9237-8fb0cdeab51f)
