### PR TITLE
[babel 8] Remove `loose`/`spec` from `preset-env`, and `useESModules`

### DIFF
--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -148,6 +148,16 @@ This option was removed in v7.
 
 ### `useESModules`
 
+::::babel8
+
+:::danger
+This option was removed in v8.
+:::
+
+::::
+
+::::babel7
+
 :::caution
 This option has been deprecated: starting from version `7.13.0`, `@babel/runtime`'s `package.json` uses `"exports"` option to automatically choose between CJS and ESM helpers.
 :::
@@ -187,6 +197,8 @@ export default function(instance, Constructor) {
   }
 }
 ```
+
+::::
 
 ### `absoluteRuntime`
 

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -159,7 +159,7 @@ This option was removed in v8.
 ::::babel7
 
 :::caution
-This option has been deprecated: starting from version `7.13.0`, `@babel/runtime`'s `package.json` uses `"exports"` option to automatically choose between CJS and ESM helpers.
+This option has been deprecated and will be removed in Babel 8: starting from version `7.13.0`, `@babel/runtime`'s `package.json` uses `"exports"` option to automatically choose between CJS and ESM helpers.
 :::
 
 `boolean`, defaults to `false`.

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -127,7 +127,7 @@ These options have been removed in Babel 8. Consider migrating to the top level 
 Enable more spec compliant, but potentially slower, transformations for any plugins in this preset that support them.
 
 :::caution
-Consider migrating to the top level [`assumptions`](assumptions.md) available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
+This option has been deprecated and will be removed in Babel 8. Consider migrating to the top level [`assumptions`](assumptions.md) available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
 :::
 
 ### `loose`
@@ -137,7 +137,7 @@ Consider migrating to the top level [`assumptions`](assumptions.md) available si
 Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.html) for any plugins in this preset that allow them.
 
 :::caution
-Consider migrating to the top level [`assumptions`](assumptions.md) available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
+This option has been deprecated and will be removed in Babel 8. Consider migrating to the top level [`assumptions`](assumptions.md) available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
 :::
 
 ::::

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -113,7 +113,7 @@ When this option is enabled, `@babel/preset-env` tries to compile the broken syn
 ### `loose`, `spec`
 
 :::danger
-These option have been removed in Babel 8. Consider migrating to the top level [`assumptions`](assumptions.md), available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
+These options have been removed in Babel 8. Consider migrating to the top level [`assumptions`](assumptions.md), available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
 :::
 
 ::::

--- a/docs/preset-env.md
+++ b/docs/preset-env.md
@@ -108,6 +108,18 @@ By default, `@babel/preset-env` (and Babel plugins in general) grouped ECMAScrip
 
 When this option is enabled, `@babel/preset-env` tries to compile the broken syntax to the closest _non-broken modern syntax_ supported by your target browsers. Depending on your `targets` and on how many modern syntax you are using, this can lead to a significant size reduction in the compiled app. This option merges the features of [`@babel/preset-modules`](https://github.com/babel/preset-modules) without having to use another preset.
 
+::::babel8
+
+### `loose`, `spec`
+
+:::danger
+These option have been removed in Babel 8. Consider migrating to the top level [`assumptions`](assumptions.md), available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
+:::
+
+::::
+
+::::babel7
+
 ### `spec`
 
 `boolean`, defaults to `false`.
@@ -127,6 +139,8 @@ Enable ["loose" transformations](http://2ality.com/2015/12/babel6-loose-mode.htm
 :::caution
 Consider migrating to the top level [`assumptions`](assumptions.md) available since Babel 7.13. See ["Migrating from `@babel/preset-env`'s `"loose"` and `"spec"` modes"](assumptions.md#migrating-from-babelpreset-envs-loose-and-spec-modes) for the equivalent assumptions-based configuration, ready to be copied and pasted as a starting point.
 :::
+
+::::
 
 ### `modules`
 

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -136,6 +136,12 @@ The following syntax plugins are no longer needed, you can safely remove them fr
 
 ### `@babel/preset-env` {#configuration-change-preset-env}
 
+![high](https://img.shields.io/badge/risk%20of%20breakage%3F-high-red.svg)
+
+- The `loose` and `spec` options have been removed ([#16043](https://github.com/babel/babel/pull/16043))
+
+  **Migration**: You can use the [`assumptions`](https://babeljs.io/docs/assumptions) top-level option instead. See ["Migrating from @babel/preset-env's "loose" and "spec" modes"](https://babeljs.io/docs/assumptions#migrating-from-babelpreset-envs-loose-and-spec-modes) for the ready-to-copy equivalent configuration.
+
 ![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
 
 - `includes` and `excludes` respect renamed package names ([#15576](https://github.com/babel/babel/pull/15576))
@@ -394,6 +400,14 @@ The following syntax plugins are no longer needed, you can safely remove them fr
   The syntax is the same, but you will need to rewrite your decorator functions. The spec repo provides [comparison between the latest version and the `2018-09` version](https://github.com/tc39/proposal-decorators#comparison-with-the-previous-stage-2-decorators-proposal). You can already migrate since Babel 7.22.0, using the `"version": "2023-05"` option of `@babel/plugin-proposal-decorators`.
 
   Although Babel 8 still supports the `legacy` version, it is advisable to migrate to the `2023-05` version regardless: both Babel 8 and TypeScript 5.0 support the `2023-05` version, while there are [a few behaviour differences](https://github.com/babel/babel/issues/8864#issuecomment-688535867) in the `legacy` version between Babel and `tsc`'s implementation.
+
+### `@babel/plugin-transform-runtime`
+
+![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
+
+- The `useESModules` option has been removed ([#16141](https://github.com/babel/babel/pull/16141))
+
+  **Migration**: Delete it from your configuration. `@babel/runtime` will now automatically expose ES modules when needed, using `package.json#exports`.
 
 ### `@babel/node`
 


### PR DESCRIPTION
Docs for https://github.com/babel/babel/pull/16141 and https://github.com/babel/babel/pull/16043