### PR TITLE
:bug: fix: compile code not work when page reload

### DIFF
--- a/js/repl/Repl.tsx
+++ b/js/repl/Repl.tsx
@@ -364,7 +364,7 @@ class Repl extends React.Component<Props, State> {
     }
     // If no plugins are enabled, immediately invoke a new compilation
     if (this._numLoadingPlugins === 0) {
-      this._compile(this.state.code, this._persistState);
+      this._compileToState(this.state.code);
     }
 
     // Babel (runtime) polyfill is large;
@@ -554,7 +554,7 @@ class Repl extends React.Component<Props, State> {
   // Debounce compilation since it's expensive.
   // This also avoids prematurely warning the user about invalid syntax,
   // eg when in the middle of typing a variable name.
-  _compileToState = debounce(
+  _compileToState: (code: string) => void = debounce(
     (code: string) => this._compile(code, this._persistState),
     DEBOUNCE_DELAY
   );


### PR DESCRIPTION
You can try it, and change something in the left panel, then it will be compiled correctly.

[babel repl demo](https://babeljs.io/repl#?browsers=chrome%20%3E%3D%2049&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=NoQwNABARguhC8FgwNxA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2&prettier=false&targets=&version=8.0.0-alpha.2&externalPlugins=&assumptions=%7B%7D)
