### PR TITLE
Fix page not found error

### DIFF
--- a/website/data/tools/babel_cli/usage.md
+++ b/website/data/tools/babel_cli/usage.md
@@ -34,6 +34,6 @@ Alternatively, you can reference the `babel` cli inside of `node_modules`.
 
 <blockquote class="alert alert--info">
   <p>
-    For full documentation on the Babel CLI see the <a href="/docs/usage/cli/">usage docs</a>.
+    For full documentation on the Babel CLI see the <a href="/docs/usage#basic-usage-with-cli">usage docs</a>.
   </p>
 </blockquote>


### PR DESCRIPTION
Hey there. If I'm right, the link is broken. This change aims to fix it.
> For full documentation on the Babel CLI see the [usage docs](https://babel.dev/docs/usage/cli/).