### PR TITLE
Update plugin-proposal-optional-chaining-assign.md docs to work

### DIFF
--- a/docs/plugin-proposal-optional-chaining-assign.md
+++ b/docs/plugin-proposal-optional-chaining-assign.md
@@ -33,9 +33,16 @@ npm install --save-dev @babel/plugin-proposal-optional-chaining-assign
 
 ```json title="babel.config.json"
 {
-  "plugins": ["@babel/plugin-proposal-optional-chaining-assign"]
+  "plugins": [
+    "@babel/plugin-proposal-optional-chaining-assign",
+    {
+      "version": "2023-07"
+    }
+  ]
 }
 ```
+
+Currently '.version' option required, representing the last proposal update. Currently, the only supported value is '2023-07'. 
 
 ### Via CLI
 

--- a/docs/plugin-proposal-optional-chaining-assign.md
+++ b/docs/plugin-proposal-optional-chaining-assign.md
@@ -1,7 +1,7 @@
 ---
 id: babel-plugin-proposal-optional-chaining-assign
 title: "@babel/plugin-proposal-optional-chaining-assign"
-sidebar_label: optional-chaining
+sidebar_label: optional-chaining-assign
 ---
 
 Transform optional chaining on the left-hand side of assignment expressions.

--- a/docs/plugin-proposal-optional-chaining-assign.md
+++ b/docs/plugin-proposal-optional-chaining-assign.md
@@ -66,7 +66,7 @@ Required.
 
 Selects the proposal to use:
 
-- `"2023-07"`: The stage 1 proposal defined at [`tc39/proposal-optional-chaining-assignment@49d055c44b`](https://github.com/tc39/proposal-optional-chaining-assignment/commit/e7b48795b66a8196b1abcab2e52e2049d055c44b), demonstrated in the July 2023 TC39 meeting.
+- `"2023-07"`: The stage 1 proposal as defined at [`tc39/proposal-optional-chaining-assignment@49d055c44b`](https://github.com/tc39/proposal-optional-chaining-assignment/commit/e7b48795b66a8196b1abcab2e52e2049d055c44b), presented in the July 2023 TC39 meeting.
 
 ## References
 

--- a/docs/plugin-proposal-optional-chaining-assign.md
+++ b/docs/plugin-proposal-optional-chaining-assign.md
@@ -42,19 +42,13 @@ npm install --save-dev @babel/plugin-proposal-optional-chaining-assign
 }
 ```
 
-Currently '.version' option required, representing the last proposal update. Currently, the only supported value is '2023-07'. 
-
-### Via CLI
-
-```sh title="Shell"
-babel --plugins @babel/plugin-proposal-optional-chaining-assign script.js
-```
-
 ### Via Node API
 
 ```js title="JavaScript"
 require("@babel/core").transformSync("code", {
-  plugins: ["@babel/plugin-proposal-optional-chaining-assign"],
+  plugins: [["@babel/plugin-proposal-optional-chaining-assign", {
+      "version": "2023-07"
+    }]],
 });
 ```
 
@@ -63,6 +57,16 @@ require("@babel/core").transformSync("code", {
 ### Assumptions
 
 This plugin is affected by the [`noDocumentAll`](https://babeljs.io/docs/assumptions#nodocumentall) assumption.
+
+### `version`
+
+Required.
+
+`"2023-07"`
+
+Selects the proposal to use:
+
+- `"2023-07"`: The stage 1 proposal defined at [`tc39/proposal-optional-chaining-assignment@49d055c44b`](https://github.com/tc39/proposal-optional-chaining-assignment/commit/e7b48795b66a8196b1abcab2e52e2049d055c44b), demonstrated in the July 2023 TC39 meeting.
 
 ## References
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -256,6 +256,7 @@ module.exports = {
         "babel-plugin-proposal-function-bind",
         "babel-plugin-proposal-function-sent",
         "babel-plugin-proposal-import-defer",
+        "babel-plugin-proposal-optional-chaining-assign",
         "babel-plugin-proposal-partial-application",
         "babel-plugin-proposal-pipeline-operator",
         "babel-plugin-proposal-record-and-tuple",


### PR DESCRIPTION
When installing this plugin I received this error and needed to fix it as such

Error: [BABEL] /Users/blackmad/Code/gen2-blackmadeco/src/index.tsx: @babel/plugin-syntax-optional-chaining-assign: '.version' option required, representing the last proposal update. Currently, the only supported value is '2023-07'. (While processing: "/Users/blackmad/Code/gen2-blackmadeco/node_modules/@babel/plugin-proposal-optional-chaining-assign/lib/index.js$inherits")