### PR TITLE
fix transform-dynamic-import 404

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -70,6 +70,7 @@ https://babel.netlify.com/* https://babeljs.io/:splat 301!
 /docs/babel-plugin-proposal-class-properties                    /docs/babel-plugin-transform-class-properties
 /docs/babel-plugin-proposal-private-methods                     /docs/babel-plugin-transform-private-methods
 /docs/babel-plugin-proposal-numeric-separator                   /docs/babel-plugin-transform-numeric-separator
+/docs/babel-plugin-proposal-dynamic-import                      /docs/babel-plugin-transform-dynamic-import
 /docs/babel-plugin-proposal-logical-assignment-operators        /docs/babel-plugin-transform-logical-assignment-operators
 /docs/babel-plugin-proposal-nullish-coalescing-operator         /docs/babel-plugin-transform-nullish-coalescing-operator
 /docs/babel-plugin-proposal-optional-chaining                   /docs/babel-plugin-transform-optional-chaining
@@ -93,7 +94,7 @@ https://babel.netlify.com/* https://babeljs.io/:splat 301!
 
 # Blog rewrites
 /7.24.0 /blog/2024/02/28/7.24.0
-/7.23.0 /blog/2023/09/25/7.22.0
+/7.23.0 /blog/2023/09/25/7.23.0
 /7.22.0 /blog/2023/05/26/7.22.0
 /7.21.0 /blog/2023/02/20/7.21.0
 /7.20.0 /blog/2022/10/27/7.20.0

--- a/docs/plugin-transform-dynamic-import.md
+++ b/docs/plugin-transform-dynamic-import.md
@@ -1,6 +1,6 @@
 ---
-id: babel-plugin-proposal-dynamic-import
-title: "@babel/plugin-proposal-dynamic-import"
+id: babel-plugin-transform-dynamic-import
+title: "@babel/plugin-transform-dynamic-import"
 sidebar_label: dynamic-import
 ---
 
@@ -74,7 +74,7 @@ will be transformed to
 ## Installation
 
 ```shell npm2yarn
-npm install --save-dev @babel/plugin-proposal-dynamic-import
+npm install --save-dev @babel/plugin-transform-dynamic-import
 ```
 
 ## Usage
@@ -84,7 +84,7 @@ npm install --save-dev @babel/plugin-proposal-dynamic-import
 ```json title="babel.config.json"
 {
   "plugins": [
-    "@babel/plugin-proposal-dynamic-import",
+    "@babel/plugin-transform-dynamic-import",
     "@babel/plugin-transform-modules-commonjs"
   ]
 }
@@ -93,7 +93,7 @@ npm install --save-dev @babel/plugin-proposal-dynamic-import
 ### Via CLI
 
 ```sh title="Shell"
-babel --plugins=@babel/plugin-proposal-dynamic-import,@babel/plugin-transform-modules-amd script.js
+babel --plugins=@babel/plugin-transform-dynamic-import,@babel/plugin-transform-modules-amd script.js
 ```
 
 ### Via Node API
@@ -101,7 +101,7 @@ babel --plugins=@babel/plugin-proposal-dynamic-import,@babel/plugin-transform-mo
 ```js title="JavaScript"
 require("@babel/core").transformSync("code", {
   plugins: [
-    "@babel/plugin-proposal-dynamic-import",
+    "@babel/plugin-transform-dynamic-import",
     "@babel/plugin-transform-modules-systemjs"
   ],
 });
@@ -109,4 +109,4 @@ require("@babel/core").transformSync("code", {
 
 ## References
 
-- [Proposal: import()](https://github.com/tc39/proposal-dynamic-import)
+- [Proposal: import()](https://github.com/tc39/transform-dynamic-import)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -70,7 +70,7 @@ module.exports = {
               type: "category",
               label: "ES2020",
               items: [
-                "babel-plugin-proposal-dynamic-import",
+                "babel-plugin-transform-dynamic-import",
                 "babel-plugin-transform-export-namespace-from",
                 "babel-plugin-transform-nullish-coalescing-operator",
                 "babel-plugin-transform-optional-chaining",


### PR DESCRIPTION
Fixed issue: The docs link provided in https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-dynamic-import/README.md is returns 404.