### PR TITLE
docs(assumptions): Remove references to `noObjectSuper` & `noUndeclaredVariablesCheck`

### DIFF
--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -434,7 +434,6 @@ class Child extends Parent {
     "mutableTemplateObject": true,
     "noClassCalls": true,
     "noDocumentAll": true,
-    "noObjectSuper": true,
     "noUndeclaredVariablesCheck": true,
     "objectRestNoSymbols": true,
     "privateFieldsAsProperties": true,

--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -434,7 +434,6 @@ class Child extends Parent {
     "mutableTemplateObject": true,
     "noClassCalls": true,
     "noDocumentAll": true,
-    "noUndeclaredVariablesCheck": true,
     "objectRestNoSymbols": true,
     "privateFieldsAsProperties": true,
     "pureGetters": true,


### PR DESCRIPTION
Assuming I'm not being daft, `noObjectSuper` & `noUndeclaredVariablesCheck` do not seem to be a supported assumptions.