### PR TITLE
docs(options.md): clarify `--source-maps` CLI option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -612,7 +612,8 @@ Default: `false`<br />
 - `"inline"` to generate a sourcemap and append it as a data URL to the end of the code, but not include it in the result object.
 - `"both"` is the same as inline, but will include the map in the result object.
 
-`@babel/cli` overloads some of these to also affect how maps are written to disk:
+Options in configuration files have no effect on whether `@babel/cli` writes files separate `.map` files to disk.
+When the `--source-maps` CLI options is passed to `@babel/cli` it will also control whether `.map` files are written:
 
 - `true` will write the map to a `.map` file on disk
 - `"inline"` will write the file directly, so it will have a `data:` containing the map


### PR DESCRIPTION
it's confusing.  Honestly it would be less confusing and IMO better if having `sourceMaps: true` in config files would make `@babel/cli` write `.map` files to disk.