### PR TITLE
fix(docsearch): better text contrast for active hit in dark mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -109,6 +109,10 @@ article[itemprop="blogPost"] h4 {
   --docsearch-muted-color: #7f8497;
 }
 
+.DocSearch-Hit-Container {
+  --docsearch-hit-active-color: var(--ifm-color-content-inverse);
+}
+
 .wrapper {
   margin: 0 auto;
   max-width: 1100px;


### PR DESCRIPTION
before:
![image](https://github.com/babel/website/assets/1770529/af1a6d22-13bd-40a2-9bcc-35d322abfa09)

after:
![image](https://github.com/babel/website/assets/1770529/4b2bbaa8-45f3-4e25-bda8-e5f59d7f336c)

for light mode it stays without changes:
![image](https://github.com/babel/website/assets/1770529/7d93eebf-2d92-4ef8-a9df-77dd1d3e6b62)
