### PR TITLE
fix(options): drop visual noise

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -365,7 +365,7 @@ If a minor version is not specified, Babel will interpret it as `MAJOR.0`. For e
 
 #### No targets
 
-:::babel7
+::::babel7
 
 When no targets are specified: Babel will assume you are targeting the oldest browsers possible. For example, `@babel/preset-env` will transform all ES2015-ES2020 code to be ES5 compatible.
 
@@ -389,11 +389,13 @@ Because of this, Babel's behavior is different than [browserslist](https://githu
 
 We recognize this isn’t ideal and will be revisiting this in Babel v8.
 
-:::
+::::
 
 :::babel8
 
 When no targets are specified: Babel will assume you are using the [browserslist](https://github.com/browserslist/browserslist#queries) [`defaults`](https://browsersl.ist/#q=defaults) query, which covers most modern browsers. If you want to support legacy browsers, specify the `targets` option.
+
+:::
 
 #### `targets.esmodules`
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -395,8 +395,6 @@ We recognize this isn’t ideal and will be revisiting this in Babel v8.
 
 When no targets are specified: Babel will assume you are using the [browserslist](https://github.com/browserslist/browserslist#queries) [`defaults`](https://browsersl.ist/#q=defaults) query, which covers most modern browsers. If you want to support legacy browsers, specify the `targets` option.
 
-:::
-
 #### `targets.esmodules`
 
 Type: `boolean`

--- a/docs/plugin-transform-runtime.md
+++ b/docs/plugin-transform-runtime.md
@@ -462,13 +462,13 @@ var Person = function Person() {
 
 :::babel8
 
-The following options where removed in Babel 8.0.0:
+The following options were removed in Babel 8.0.0:
 - `corejs`
 - `helpers`
 - `regenerator`
 
 :::
 
-The following options where removed in Babel 7.0.0:
+The following options were removed in Babel 7.0.0:
 - `useBuiltIns`
 - `polyfill`

--- a/docs/preset-react.md
+++ b/docs/preset-react.md
@@ -176,7 +176,7 @@ Replace the function used when compiling JSX expressions. It should be a qualifi
 
 Replace the component used when compiling JSX fragments. It should be a valid JSX tag name.
 
-:::babel7
+::::babel7
 
 #### `useBuiltIns`
 
@@ -200,7 +200,7 @@ This option will be removed in Babel 8. Set `useSpread` to `true` if you are tar
 
 When spreading props, use inline object with spread elements directly instead of Babel's extend helper or `Object.assign`.
 
-:::
+::::
 
 ### babel.config.js
 


### PR DESCRIPTION
Hi!
I notice rubbish on [options](https://babeljs.io/docs/options#no-targets) page. My PR drop unused text.

<img width="698" alt="Снимок экрана 2024-07-09 в 16 53 19" src="https://github.com/babel/website/assets/3195714/64973d71-f548-4af3-8adc-aa8cb8b205b3">
