### PR TITLE
Add Route4Me sponsor logo

### DIFF
--- a/website/data/sponsors.yml
+++ b/website/data/sponsors.yml
@@ -16,3 +16,9 @@
   type: opencollective
   tier: gold-sponsors
   monthly: 1000
+- name: Route Planner
+  url: https://route4me.com/
+  image: https://github.com/user-attachments/assets/002949fe-aa5e-4311-b77f-7f2c905e91f5
+  type: opencollective
+  tier: silver-sponsors
+  monthly: 500


### PR DESCRIPTION
I got an email from this sponsor asking why it was not there. I re-triggered website builds a few times, but then I realized that it's because it's from GH sponsors.

<details>
<img width="195" alt="Route4MeIconLogo-3" src="https://github.com/user-attachments/assets/002949fe-aa5e-4311-b77f-7f2c905e91f5">
</details>
