### PR TITLE
Add Igalia as a base support sponsor

### DIFF
--- a/website/data/sponsors.yml
+++ b/website/data/sponsors.yml
@@ -1,3 +1,9 @@
+- name: Igalia
+  url: https://www.igalia.com/
+  image: https://images.opencollective.com/igalia/1c2e7cb/logo/256.png
+  type: opencollective
+  tier: base-support-sponsor
+  yearly: 30000 # There is not actual amount, but we need a large enough amount to fit in the tier
 - name: Coinbase
   url: https://github.com/coinbase
   image: https://avatars.githubusercontent.com/u/1885080?s=200&v=4


### PR DESCRIPTION
Igalia is now paying for me to work on Babel, so that I don't rely on OpenCollective anymore.