### PR TITLE
add diff to additionalLanguages

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -189,7 +189,7 @@ const siteConfig = {
       respectPrefersColorScheme: true,
     },
     prism: {
-      additionalLanguages: ["flow", "powershell"],
+      additionalLanguages: ["diff", "flow", "powershell"],
       theme: require("./src/theme/prism/light"),
       darkTheme: require("./src/theme/prism/dark"),
       magicComments: [


### PR DESCRIPTION
The diff highlight regression was introduced in #2848, where `docusaurus` bumped `prism-react-renderer` from v1 to v2, which drops quite a lot of languages in the default bundle. So we have to add the `diff` to the `additionalLanguages` config.