### PR TITLE
docs: `import attributes` enabled by default

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -228,7 +228,7 @@ require("@babel/parser").parse("code", {
 | `exportDefaultFrom` ([proposal](https://github.com/tc39/ecmascript-export-default-from))                 | `export v from "mod"`                                            |
 | `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind))                              | `a::b`, `::console.log`                                          |
 | `functionSent` ([proposal](https://github.com/tc39/proposal-function.sent))                              | `function.sent`                                                  |
-| `importAttributes` ([proposal](https://github.com/tc39/proposal-import-attributes))                      | `import json from "./foo.json" with { type: "json" };`           |
+| `deprecatedImportAssert` (legacy syntax of [import attributes](https://github.com/tc39/proposal-import-attributes)) | `import json from "./foo.json" assert { type: "json" };`           |
 | `moduleBlocks` ([proposal](https://github.com/tc39/proposal-js-module-blocks))                           | `let m = module { export let y = 1; };`                          |
 | `optionalChainingAssign` ([proposal](https://github.com/tc39/proposal-optional-chaining-assignment))     | `x?.prop = 2`                                                    |
 | `partialApplication` ([proposal](https://github.com/babel/proposals/issues/32))                          | `f(?, a)`                                                        |
@@ -277,6 +277,7 @@ require("@babel/parser").parse("code", {
 | `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind))                                                  | `a::b`, `::console.log`                                          |
 | `functionSent` ([proposal](https://github.com/tc39/proposal-function.sent))                                                  | `function.sent`                                                  |
 | `importAttributes` ([proposal](https://github.com/tc39/proposal-import-attributes)) <br/> `importAssertions` (⚠️ deprecated)  | `import json from "./foo.json" with { type: "json" };`           |
+| `deprecatedImportAssert` (legacy syntax of [import attributes](https://github.com/tc39/proposal-import-attributes)) <br/> `importAssertions` (⚠️ deprecated)  | `import json from "./foo.json" assert { type: "json" };`           |
 | `importReflection` ([proposal](https://github.com/tc39/proposal-import-reflection))                                          | `import module foo from "./foo.wasm";`                           |
 | `moduleBlocks` ([proposal](https://github.com/tc39/proposal-js-module-blocks))                                               | `let m = module { export let y = 1; };`                          |
 | `optionalChainingAssign` ([proposal](https://github.com/tc39/proposal-optional-chaining-assignment))                         | `x?.prop = 2`                                                    |
@@ -413,6 +414,10 @@ When a plugin is specified multiple times, only the first options are considered
     This option will enable parsing within a TypeScript ambient context, where certain syntax have different rules (like `.d.ts` files and inside `declare module` blocks). Please see https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html and https://basarat.gitbook.io/typescript/type-system/intro for more information about ambient contexts.
   - `disallowAmbiguousJSXLike` (`boolean`, default `false`)
     Even when the `jsx` plugin is not enabled, this option disallows using syntax that would be ambiguous with JSX (`<X> y` type assertions and `<X>() => {}` type arguments). It matches the `tsc` behavior when parsing `.mts` and `.mjs` files.
+
+:::babel7
+`@babel/parser` also supports a no-op `importAttributes` plugin, which takes a `deprecatedAssertSyntax: boolean` option. When this option is enabled, it's equivalent to the `deprecatedImportAssert` plugin.
+:::
 
 ### Error codes
 

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -311,6 +311,7 @@ You should enable these features only if you are using an older version.
 | `privateIn` ([proposal](https://github.com/tc39/proposal-private-fields-in-in))           | `#p in obj`                                         |
 | `regexpUnicodeSets` ([proposal](https://github.com/tc39/proposal-regexp-set-notation))    | `/[\p{Decimal_Number}--[0-9]]/v;`                   |
 | `topLevelAwait` ([proposal](https://github.com/tc39/proposal-top-level-await/))           | `await promise` in modules                          |
+| `importAttributes` ([proposal](https://github.com/tc39/proposal-import-attributes))       | `import json from "./foo.json" with { type: "json" };`           |
 
 :::
 
@@ -334,16 +335,6 @@ You should enable these features only if you are using an older version.
 :::note
 When a plugin is specified multiple times, only the first options are considered.
 :::
-
-- `importAttributes`:
-
-  - `deprecatedAssertSyntax` (`boolean`, defaults to `false`)
-
-    When `true`, allow parsing an old version of the import attributes, which used the `assert` keyword instead of `with`.
-
-    :::babel7
-    This matches the syntax originally supported by the `importAssertions` parser plugin.
-    :::
 
 - `decorators`:
 
@@ -415,7 +406,18 @@ When a plugin is specified multiple times, only the first options are considered
     Even when the `jsx` plugin is not enabled, this option disallows using syntax that would be ambiguous with JSX (`<X> y` type assertions and `<X>() => {}` type arguments). It matches the `tsc` behavior when parsing `.mts` and `.mjs` files.
 
 :::babel7
-`@babel/parser` also supports a no-op `importAttributes` plugin, which takes a `deprecatedAssertSyntax: boolean` option. When this option is enabled, it's equivalent to the `deprecatedImportAssert` plugin.
+
+
+- `importAttributes`:
+
+  - `deprecatedAssertSyntax` (`boolean`, defaults to `false`)
+
+    When `true`, allow parsing an old version of the import attributes, which used the `assert` keyword instead of `with`.
+
+    :::babel7
+    This matches the syntax originally supported by the `importAssertions` parser plugin.
+    :::
+
 :::
 
 ### Error codes

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -222,13 +222,13 @@ require("@babel/parser").parse("code", {
 | `decorators` ([proposal](https://github.com/tc39/proposal-decorators)) <br/> `decorators-legacy`         | `@a class A {}`                                                  |
 | `decoratorAutoAccessors` ([proposal](https://github.com/tc39/proposal-decorators))                       | `class Example { @reactive accessor myBool = false; }`           |
 | `deferredImportEvaluation` ([proposal](https://github.com/tc39/proposal-defer-import-eval))              | `import defer * as ns from "dep";`                               |
+| `deprecatedImportAssert` (legacy syntax of [import attributes](https://github.com/tc39/proposal-import-attributes)) | `import json from "./foo.json" assert { type: "json" };`           |
 | `destructuringPrivate` ([proposal](https://github.com/tc39/proposal-destructuring-private))              | `class Example { #x = 1; method() { const { #x: x } = this; } }` |
 | `doExpressions` ([proposal](https://github.com/tc39/proposal-do-expressions))                            | `var a = do { if (true) { 'hi'; } };`                            |
 | `explicitResourceManagement` ([proposal](https://github.com/tc39/proposal-explicit-resource-management)) | `using reader = getReader()`                                     |
 | `exportDefaultFrom` ([proposal](https://github.com/tc39/ecmascript-export-default-from))                 | `export v from "mod"`                                            |
 | `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind))                              | `a::b`, `::console.log`                                          |
 | `functionSent` ([proposal](https://github.com/tc39/proposal-function.sent))                              | `function.sent`                                                  |
-| `deprecatedImportAssert` (legacy syntax of [import attributes](https://github.com/tc39/proposal-import-attributes)) | `import json from "./foo.json" assert { type: "json" };`           |
 | `moduleBlocks` ([proposal](https://github.com/tc39/proposal-js-module-blocks))                           | `let m = module { export let y = 1; };`                          |
 | `optionalChainingAssign` ([proposal](https://github.com/tc39/proposal-optional-chaining-assignment))     | `x?.prop = 2`                                                    |
 | `partialApplication` ([proposal](https://github.com/babel/proposals/issues/32))                          | `f(?, a)`                                                        |
@@ -270,6 +270,7 @@ require("@babel/parser").parse("code", {
 | `decorators` ([proposal](https://github.com/tc39/proposal-decorators)) <br/> `decorators-legacy`                             | `@a class A {}`                                                  |
 | `decoratorAutoAccessors` ([proposal](https://github.com/tc39/proposal-decorators))                                           | `class Example { @reactive accessor myBool = false; }`           |
 | `deferredImportEvaluation` ([proposal](https://github.com/tc39/proposal-defer-import-eval))                                  | `import defer * as ns from "dep";`                               |
+| `deprecatedImportAssert` (legacy syntax of [import attributes](https://github.com/tc39/proposal-import-attributes)) <br/> `importAssertions` (⚠️ deprecated)  | `import json from "./foo.json" assert { type: "json" };`           |
 | `destructuringPrivate` ([proposal](https://github.com/tc39/proposal-destructuring-private))                                  | `class Example { #x = 1; method() { const { #x: x } = this; } }` |
 | `doExpressions` ([proposal](https://github.com/tc39/proposal-do-expressions))                                                | `var a = do { if (true) { 'hi'; } };`                            |
 | `explicitResourceManagement` ([proposal](https://github.com/tc39/proposal-explicit-resource-management))                     | `using reader = getReader()`                                     |
@@ -277,7 +278,6 @@ require("@babel/parser").parse("code", {
 | `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind))                                                  | `a::b`, `::console.log`                                          |
 | `functionSent` ([proposal](https://github.com/tc39/proposal-function.sent))                                                  | `function.sent`                                                  |
 | `importAttributes` ([proposal](https://github.com/tc39/proposal-import-attributes)) <br/> `importAssertions` (⚠️ deprecated)  | `import json from "./foo.json" with { type: "json" };`           |
-| `deprecatedImportAssert` (legacy syntax of [import attributes](https://github.com/tc39/proposal-import-attributes)) <br/> `importAssertions` (⚠️ deprecated)  | `import json from "./foo.json" assert { type: "json" };`           |
 | `importReflection` ([proposal](https://github.com/tc39/proposal-import-reflection))                                          | `import module foo from "./foo.wasm";`                           |
 | `moduleBlocks` ([proposal](https://github.com/tc39/proposal-js-module-blocks))                                               | `let m = module { export let y = 1; };`                          |
 | `optionalChainingAssign` ([proposal](https://github.com/tc39/proposal-optional-chaining-assignment))                         | `x?.prop = 2`                                                    |

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -277,7 +277,6 @@ require("@babel/parser").parse("code", {
 | `exportDefaultFrom` ([proposal](https://github.com/tc39/ecmascript-export-default-from))                                     | `export v from "mod"`                                            |
 | `functionBind` ([proposal](https://github.com/zenparsing/es-function-bind))                                                  | `a::b`, `::console.log`                                          |
 | `functionSent` ([proposal](https://github.com/tc39/proposal-function.sent))                                                  | `function.sent`                                                  |
-| `importAttributes` ([proposal](https://github.com/tc39/proposal-import-attributes)) <br/> `importAssertions` (⚠️ deprecated)  | `import json from "./foo.json" with { type: "json" };`           |
 | `importReflection` ([proposal](https://github.com/tc39/proposal-import-reflection))                                          | `import module foo from "./foo.wasm";`                           |
 | `moduleBlocks` ([proposal](https://github.com/tc39/proposal-js-module-blocks))                                               | `let m = module { export let y = 1; };`                          |
 | `optionalChainingAssign` ([proposal](https://github.com/tc39/proposal-optional-chaining-assignment))                         | `x?.prop = 2`                                                    |

--- a/docs/plugin-syntax-import-attributes.md
+++ b/docs/plugin-syntax-import-attributes.md
@@ -4,10 +4,28 @@ title: "@babel/plugin-syntax-import-attributes"
 sidebar_label: syntax-import-attributes
 ---
 
+:::info
+This plugin is included in `@babel/preset-env`, in [ES2025](https://github.com/tc39/proposals/blob/master/finished-proposals.md)
+:::
+
 :::note
 #### Syntax only
 
-This plugin only enables Babel to parse this syntax. Babel does not support transforming this syntax
+This plugin only enables Babel to parse and generate this syntax. Babel does not support transforming this syntax.
+
+::::babel7
+
+While Babel supports parsing import attributes by default since v7.25.0, this plugin is still needed to let Babel choose the correct syntax when emitting code. As an alternative to this plugin, you can use `@babel/generator`'s [`importAttributesKeyword`](https://babeljs.io/docs/babel-generator#options) option:
+```json
+{
+  "generatorOpts": {
+    "importAttributesKeyword": "with"
+  },
+}
+```
+
+::::
+
 :::
 
 This plugin enables Babel to parse import attributes:

--- a/docs/v8-migration.md
+++ b/docs/v8-migration.md
@@ -72,7 +72,8 @@ you install the new runtime, please set the [`corejs` version](https://babel.dev
 ```
 
 ### `@babel/plugin-syntax-import-assertions`
-Please migrate to `@babel/plugin-syntax-import-attributes` ([#15536](https://github.com/babel/babel/pull/15536)). After you replace the plugin, you should search and replace the following patterns in your codebase:
+
+The proposal evolved into [import attributes](https://github.com/tc39/proposal-import-attributes), which now Babel supports parsing by default. You can remove `@babel/plugin-syntax-import-assertions` from your config, and  replace the following patterns in your codebase:
 
 ```diff title="input.js"
 - import value from "module" assert { type: "json" };


### PR DESCRIPTION
Docs for https://github.com/babel/babel/pull/16850