### PR TITLE
Fix unused markdown directives warning

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -348,18 +348,18 @@ When a plugin is specified multiple times, only the first options are considered
 
   - `decoratorsBeforeExport` (`boolean`)
 
-        By default decorators on exported classes can be placed either before or after the `export` keyword. When this option is set, decorators will only be allowed in the specified position.
+    By default decorators on exported classes can be placed either before or after the `export` keyword. When this option is set, decorators will only be allowed in the specified position.
 
-        ```js title="JavaScript"
-        // decoratorsBeforeExport: true
-        @dec
-        export class C {}
+    ```js title="JavaScript"
+    // decoratorsBeforeExport: true
+    @dec
+    export class C {}
 
-        // decoratorsBeforeExport: false
-        export @dec class C {}
-        ```
+    // decoratorsBeforeExport: false
+    export @dec class C {}
+    ```
 
-        :::caution
+    :::caution
 
     This option is deprecated and will be removed in a future version. Code that is valid when this option is explicitly set to `true` or `false` is also valid when this option is not set.
     :::
@@ -421,16 +421,13 @@ When a plugin is specified multiple times, only the first options are considered
 
 :::babel7
 
-
 - `importAttributes`:
 
   - `deprecatedAssertSyntax` (`boolean`, defaults to `false`)
 
     When `true`, allow parsing an old version of the import attributes, which used the `assert` keyword instead of `with`.
 
-    :::babel7
     This matches the syntax originally supported by the `importAssertions` parser plugin.
-    :::
 
 :::
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -111,8 +111,10 @@ function remarkDirectiveBabel8Plugin({ renderBabel8 }) {
             children.splice(index, 1, ...node.children);
           }
         } else {
-          transformer(node); // for support inside ::tip, etc
+          transformer(node); // inside :::tip, etc
         }
+      } else if (Array.isArray(node.children)) {
+        transformer(node); // inside list items
       }
     }
   };


### PR DESCRIPTION
Current main:

https://babel.dev/docs/babel-parser

<img width="983" alt="image" src="https://github.com/user-attachments/assets/f5e614d3-ffd9-4cca-99a8-4c9cc69169c5">

This PR:

<img width="952" alt="image" src="https://github.com/user-attachments/assets/4244b529-d0b3-4c11-8efd-e628fe4fbf13">

This error is caught by https://github.com/facebook/docusaurus/pull/9394. 

@slorber Can docusaurus throw on unused MDX directives? I can't find such an option so if I missed anything please let me know, thank you.