### PR TITLE
Make ReplOptions wider

### DIFF
--- a/js/repl/ReplOptions.tsx
+++ b/js/repl/ReplOptions.tsx
@@ -979,7 +979,7 @@ const styles = {
 
     [media.large]: {
       height: "calc(100% - 38px)", // 38px is babel-version tab's height
-      width: "18rem",
+      minWidth: "18rem",
       [`& .${nestedCloseButton}`]: {
         right: "-2rem",
       },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/02b94a60-d10f-4e78-a93b-140976226a45)
![image](https://github.com/user-attachments/assets/4c59aeeb-9093-4d98-a13c-fb4817ffd9e3)

I can make `usebuiltins` option use less space, but feel use `minWidth` more flexible.