### PR TITLE
Add migration docs for compat-data JSON

### DIFF
--- a/docs/compat-data.md
+++ b/docs/compat-data.md
@@ -14,10 +14,21 @@ npm install --save-dev @babel/compat-data
 ## Usage
 
 ### plugins
+
+:::babel7
+
 ```javascript title="my-babel-plugin.js"
 import _plugins from "@babel/compat-data/plugins";
 const pluginsCompatData = _plugins.default;
 ```
+
+:::
+:::babel8
+
+```javascript title="my-babel-plugin.js"
+import pluginsCompatData from "@babel/compat-data/plugins" with { type: "json" };
+```
+:::
 
 The `pluginsCompatData` is an object with the Babel plugin short name as the key and a compat data entry as its value. Each entry is an object with a browser name as the key and the minimum supported version as its value.
 

--- a/docs/v8-migration-api.md
+++ b/docs/v8-migration-api.md
@@ -1372,8 +1372,6 @@ Other than the changes listed below, `@babel/parser` is affected by all the [AST
 
 ### `@babel/compat-data`
 
-![medium](https://img.shields.io/badge/risk%20of%20breakage%3F-medium-yellow.svg)
-
 - Rename stage 4 plugin entries from `proposal-*` to `transform-*` in `plugins.json` ([#14976](https://github.com/babel/babel/pull/14976))
 
   This change also affects the `isRequired` function of `@babel/helper-compilation-targets`, which receives plugin names as its first parameter.
@@ -1392,6 +1390,12 @@ Other than the changes listed below, `@babel/parser` is affected by all the [AST
     );
   };
   ```
+
+- Directly export data as JSON files ([#17267](https://github.com/babel/babel/pull/17267))
+
+  The entrypoints of the package are now JSON files, rather than JS files.
+
+  __Migration__: If you are importing this package from ESM, you will need to change your imports adding [`with { type: "json" }`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with#importing_json_modules_with_the_type_attribute) to them.
 
 ![low](https://img.shields.io/badge/risk%20of%20breakage%3F-low-yellowgreen.svg)
 


### PR DESCRIPTION
Marking as "medium" because it will make your program crash at startup, but you are only affected if you are already using native ESM with this package. It's also trivial to fix.

Docs for https://github.com/babel/babel/pull/17267